### PR TITLE
chore(release): v4.2.8

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "memesh",
       "source": "./",
       "description": "MeMesh — Local memory for Claude Code and MCP coding agents. One SQLite file, zero cloud required.",
-      "version": "4.2.7",
+      "version": "4.2.8",
       "author": {
         "name": "PCIRCLE AI"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -4,7 +4,7 @@
   "author": {
     "name": "PCIRCLE AI"
   },
-  "version": "4.2.7",
+  "version": "4.2.8",
   "homepage": "https://pcircle.ai/memesh-llm-memory",
   "repository": "https://github.com/PCIRCLE-AI/memesh-llm-memory",
   "license": "MIT",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to MeMesh are documented here.
 
-## [Unreleased]
+## [4.2.8] — 2026-07-23
 
 ### Changed
 - **Simplify pass over the audit's changes (quality-only; a 4-agent reuse/simplification/efficiency/altitude review)** — no behaviour change:

--- a/dist/skills-manifest.json
+++ b/dist/skills-manifest.json
@@ -1,10 +1,10 @@
 {
   "schema": "memesh.skills-manifest/v1",
-  "generated_at": "2026-07-23T16:11:06.691Z",
+  "generated_at": "2026-07-23T19:28:19.967Z",
   "entries": [
     {
       "path": ".claude-plugin/plugin.json",
-      "sha256": "22a438f9154be0174699ca1204a5ff3908c92bfef872538ab5a640a7bc665278",
+      "sha256": "4ab25f81646267d3c6a77c2178819cd54300099ffa4644bb3c622e68a58b80fe",
       "bytes": 441
     },
     {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # MeMesh Plugin Architecture
 
-**Version**: 4.2.7
+**Version**: 4.2.8
 
 ---
 

--- a/docs/api/API_REFERENCE.md
+++ b/docs/api/API_REFERENCE.md
@@ -1,7 +1,7 @@
 # MeMesh Plugin -- API Reference
 
 **Protocol**: Model Context Protocol (MCP) over stdio
-**Version**: 4.2.7
+**Version**: 4.2.8
 **Compatibility**: Works with Claude Code plugins, Claude Managed Agents (via MCP connector), and any MCP-compatible client.
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcircle/memesh",
-  "version": "4.2.7",
+  "version": "4.2.8",
   "description": "MeMesh — Local memory for Claude Code and MCP coding agents. One SQLite file, zero cloud required.",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
Version bump 4.2.7 → 4.2.8. All anchors updated (package.json, plugin.json, marketplace.json, ARCHITECTURE.md, API_REFERENCE.md); CHANGELOG `[Unreleased]` finalized under the 4.2.8 header; `dist/skills-manifest.json` regenerated.

4.2.8 ships everything merged under `[Unreleased]` this cycle:
- The fake-working audit (stop reporting success for work that never happened) + follow-ups.
- Dead-code removal, git-based project identity + `memesh kg rename-project`, telemetry `by_model`/`by_project` views, `memesh pin`/`unpin`, BYOK-embedder docs.
- `memesh doctor --probe` no longer hangs ~15s after printing.

Verified: tsc 0, eslint 0, 1136/1136 vitest, `memesh doctor` PASS_WITH_CONCERNS (activity + update-status only, no FAIL), manifest SHA-256 verified.

Docs synced: version anchors all match; CHANGELOG dated; no README change needed (no hardcoded version).