### PR TITLE
docs(api): refresh /v1/update-status example to coherent real versions

### DIFF
--- a/docs/api/API_REFERENCE.md
+++ b/docs/api/API_REFERENCE.md
@@ -552,8 +552,8 @@ Use `?cached=1` to read the cached state only. Without it, MeMesh prefers a fres
 {
   "success": true,
   "data": {
-    "currentVersion": "4.1.0",
-    "latestVersion": "4.1.0",
+    "currentVersion": "4.2.7",
+    "latestVersion": "4.2.8",
     "checkedAt": "2026-04-24T10:15:00.000Z",
     "lastAttemptAt": "2026-04-24T10:15:00.000Z",
     "lastSuccessfulCheckAt": "2026-04-24T10:00:00.000Z",


### PR DESCRIPTION
## What

The `/v1/update-status` response example in `docs/api/API_REFERENCE.md` showed `currentVersion` and `latestVersion` both `4.1.0` while `updateAvailable: true` — internally inconsistent, and two minor versions stale against the released 4.2.8.

Refreshed to a real "one version behind" scenario: `4.2.7` installed, `4.2.8` latest. Uses only released versions (no invented future version), and the `updateAvailable: true` branch is now illustrated coherently.

## Scope

- Docs-only. No code, no API surface change, no version anchor touched (the doc's `**Version**: 4.2.8` header is unchanged and correct).

Docs synced:
- [x] CHANGELOG.md — n/a (doc example refresh, no behavior change)
- [x] docs/ARCHITECTURE.md — n/a (no module change)
- [x] docs/api/API_REFERENCE.md — this IS the change (version header already 4.2.8)
- [x] README.md — n/a (no user-facing feature change)
- [x] README locales — n/a
- [x] CLAUDE.md — n/a (no structure change)
- [x] Version files — n/a (no version bump)
- [x] dist/skills-manifest.json — n/a (no version bump; docs not in manifest)