### PR TITLE
fix(hooks): make session-capture memories FTS-recallable (fake-working bug)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to MeMesh are documented here.
 
+## [Unreleased]
+
+### Fixed
+- **Session-capture memories are now FTS-recallable (fake-working bug)** (`scripts/hooks/session-summary.js`, `scripts/hooks/_shared.js`) — the Stop hook's `storeMemory()` inserted the entity + observations + tags but never reindexed `entities_fts`, unlike its sibling hooks (post-commit, pre-compact). With no FTS trigger and no rebuild-on-open, every `session-insight` memory was invisible to `recall` and pre-edit-recall — the two keyword paths that inject memory when it matters. The hook reported success; the knowledge could not be keyword-recalled. Root-caused to three hand-rolled copies of the write dance drifting apart: extracted the correct dance (incl. FTS reindex) into a single `captureEntity()` in `_shared.js` now used by all three write hooks, so the FTS step can't be forgotten again. Added a regression test asserting a captured session memory is returned by an `entities_fts MATCH`.
+
 ## [4.2.8] — 2026-07-23
 
 ### Changed

--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -98,7 +98,7 @@ docs/                # ARCHITECTURE.md, api/API_REFERENCE.md
 | `post-commit.js` | PostToolUse Bash | git commit tracking |
 | `user-prompt-intent.js` | UserPromptSubmit | detect "remember" intent |
 | `pre-bash-orchestration-nudge.js` | PreToolUse Bash | opt-in orchestration nudge |
-| `_shared.js` | — | shared helpers (NOT a hook); `importFromPluginRoot`, `getProjectName` mirror |
+| `_shared.js` | — | shared helpers (NOT a hook); `importFromPluginRoot`, `getProjectName` mirror, `captureEntity` (single owner of the hook write dance incl. FTS reindex) |
 
 ---
 

--- a/dist/skills-manifest.json
+++ b/dist/skills-manifest.json
@@ -1,6 +1,6 @@
 {
   "schema": "memesh.skills-manifest/v1",
-  "generated_at": "2026-07-23T19:28:19.967Z",
+  "generated_at": "2026-07-24T18:23:19.382Z",
   "entries": [
     {
       "path": ".claude-plugin/plugin.json",
@@ -19,13 +19,13 @@
     },
     {
       "path": "scripts/hooks/_shared.js",
-      "sha256": "ab54c76dbba1d5cac6b25564f10114e1b190758ad84d48060f2c3ae56c9dd8c3",
-      "bytes": 37142
+      "sha256": "a32a2548e0375207744b282fa65cbc461ad7acae18800f29985de38fb5d83af2",
+      "bytes": 40338
     },
     {
       "path": "scripts/hooks/post-commit.js",
-      "sha256": "0739155a05e54c4fd6056a4fff4a95878e1be631382f517c325e7f66990e7ef3",
-      "bytes": 6590
+      "sha256": "2004a86975086019ca48f614e714717adb40ace5e3bee8870af0b2f6025b6896",
+      "bytes": 5063
     },
     {
       "path": "scripts/hooks/pre-bash-orchestration-nudge.js",
@@ -34,8 +34,8 @@
     },
     {
       "path": "scripts/hooks/pre-compact.js",
-      "sha256": "e8277f0e40be169307d1e75cb58b7f6b180bc8cff784164989a754343c79c735",
-      "bytes": 7220
+      "sha256": "f1b8c8d09fb5593b00ab78a2a95ee0bb01ec7ca2ecedf68066392fa6a8d4a6a2",
+      "bytes": 6011
     },
     {
       "path": "scripts/hooks/pre-edit-recall.js",
@@ -49,8 +49,8 @@
     },
     {
       "path": "scripts/hooks/session-summary.js",
-      "sha256": "c1765ad41999d407c9f9e277360f5b6cf355c15f8d5380196a305d1cd443ec77",
-      "bytes": 38315
+      "sha256": "08e11cb6c43ceb61ebe1be2526521662cf0f1adcd080500b23810eea68f6780d",
+      "bytes": 38270
     },
     {
       "path": "scripts/hooks/user-prompt-intent.js",

--- a/scripts/hooks/_shared.js
+++ b/scripts/hooks/_shared.js
@@ -623,6 +623,70 @@ export function openHookDb(env = process.env, opts = {}) {
   return { db, dbPath };
 }
 
+/**
+ * Single owner of the hook-side entity write dance: upsert entity, append
+ * observations + tags, and — critically — keep the contentless `entities_fts`
+ * index in sync so the memory is recallable via the FTS keyword hot path.
+ *
+ * Why this exists: post-commit.js, pre-compact.js, and session-summary.js each
+ * hand-rolled this dance inline. Three copies drifted — session-summary's copy
+ * omitted the FTS reindex entirely, so every `session-insight` memory it wrote
+ * was invisible to `recall` and pre-edit-recall (no FTS trigger, no self-heal
+ * rebuild on open back it up). Centralising the dance here makes the FTS step
+ * impossible to forget in a future hook. This mirrors, on the hook side, what
+ * `src/storage/fts-index.ts` already does for core (the F5 boundary keeps them
+ * as two implementations of the same contract).
+ *
+ * The caller MUST open its DB with `openHookDb(env, { fts: true })` so the FTS
+ * table is guaranteed present. Embeddings + auto-tagging + signal-scoring are
+ * deliberately NOT done here: hooks are cheap always-on capture, and those are
+ * the heavier, user-initiated `remember` concerns (core owns them).
+ *
+ * @param {import('better-sqlite3').Database} db - an open hook DB handle
+ * @param {{name: string, type: string, observations?: string[], tags?: string[]}} entity
+ * @returns {{ id: number, isNew: boolean } | null} null if the row could not be resolved
+ */
+export function captureEntity(db, { name, type, observations = [], tags = [] }) {
+  const insertResult = db
+    .prepare('INSERT OR IGNORE INTO entities (name, type) VALUES (?, ?)')
+    .run(name, type);
+  const isNew = insertResult.changes > 0;
+  const row = db.prepare('SELECT id FROM entities WHERE name = ?').get(name);
+  if (!row) return null;
+  const id = row.id;
+
+  // Capture the previously-indexed observation text BEFORE inserting new rows,
+  // so the contentless-FTS 'delete' below matches what was indexed. Only for
+  // existing entities — a brand-new row has no prior FTS entry to remove.
+  const prevObsText = isNew
+    ? undefined
+    : db
+        .prepare('SELECT content FROM observations WHERE entity_id = ?')
+        .all(id)
+        .map((o) => o.content)
+        .join(' ');
+
+  const insertObs = db.prepare('INSERT INTO observations (entity_id, content) VALUES (?, ?)');
+  for (const obs of observations) insertObs.run(id, obs);
+  const insertTag = db.prepare('INSERT OR IGNORE INTO tags (entity_id, tag) VALUES (?, ?)');
+  for (const tag of tags) insertTag.run(id, tag);
+
+  // Reindex FTS: delete the stale entry (if any) then insert the full,
+  // current observation set. Keep in lockstep with post-commit/pre-compact's
+  // historical inline form and with src/storage/fts-index.ts.
+  if (prevObsText !== undefined) {
+    db.prepare("INSERT INTO entities_fts(entities_fts, rowid, name, observations) VALUES('delete', ?, ?, ?)").run(id, name, prevObsText);
+  }
+  const allObsText = db
+    .prepare('SELECT content FROM observations WHERE entity_id = ?')
+    .all(id)
+    .map((o) => o.content)
+    .join(' ');
+  db.prepare('INSERT INTO entities_fts(rowid, name, observations) VALUES(?, ?, ?)').run(id, name, allObsText);
+
+  return { id, isNew };
+}
+
 const PRIVATE_DIR_MODE = 0o700;
 const PRIVATE_FILE_MODE = 0o600;
 

--- a/scripts/hooks/post-commit.js
+++ b/scripts/hooks/post-commit.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { execFileSync } from 'child_process';
-import { getProjectName, openHookDb } from './_shared.js';
+import { captureEntity, getProjectName, openHookDb } from './_shared.js';
 
 let input = '';
 process.stdin.setEncoding('utf8');
@@ -77,53 +77,32 @@ process.stdin.on('end', () => {
     try {
       const entityName = `commit-${commitHash}`;
 
-      // Check if this is a new or existing entity
-      const insertResult = db.prepare('INSERT OR IGNORE INTO entities (name, type) VALUES (?, ?)').run(entityName, 'commit');
-      const isNew = insertResult.changes > 0;
-      const entity = db.prepare('SELECT id FROM entities WHERE name = ?').get(entityName);
-      if (entity) {
-        // Capture existing observations for FTS delete (before inserting new one)
-        const prevObs = isNew
-          ? []
-          : db.prepare('SELECT content FROM observations WHERE entity_id = ?').all(entity.id);
-        const prevObsText = isNew ? undefined : prevObs.map(o => o.content).join(' ');
-
-        // Add observations
-        db.prepare('INSERT INTO observations (entity_id, content) VALUES (?, ?)').run(entity.id, commitMsg);
-        db.prepare('INSERT INTO observations (entity_id, content) VALUES (?, ?)').run(entity.id, `Branch: ${branch}`);
-
-        // Add richer diff stats as an observation (backward compatible — failures are silently ignored)
-        try {
-          const stat = execFileSync('git', ['show', '--stat', '--format=', commitHash], {
-            cwd: data.cwd || process.cwd(),
-            encoding: 'utf8',
-            timeout: 5000,
-          }).trim();
-          if (stat) {
-            // Last non-empty line is the summary, e.g. "3 files changed, 45 insertions(+), 12 deletions(-)"
-            const statLines = stat.split('\n').filter(l => l.trim());
-            const summary = statLines[statLines.length - 1]?.trim() || '';
-            if (summary) {
-              db.prepare('INSERT INTO observations (entity_id, content) VALUES (?, ?)').run(entity.id, `Diff stats: ${summary}`);
-            }
-          }
-        } catch {
-          // git show failed — no diff stats recorded, existing behavior unchanged
+      // Build the observation set: commit message, branch, and — best-effort —
+      // richer diff stats (git failures are silently ignored, unchanged behavior).
+      const observations = [commitMsg, `Branch: ${branch}`];
+      try {
+        const stat = execFileSync('git', ['show', '--stat', '--format=', commitHash], {
+          cwd: data.cwd || process.cwd(),
+          encoding: 'utf8',
+          timeout: 5000,
+        }).trim();
+        if (stat) {
+          // Last non-empty line is the summary, e.g. "3 files changed, 45 insertions(+), 12 deletions(-)"
+          const statLines = stat.split('\n').filter(l => l.trim());
+          const summary = statLines[statLines.length - 1]?.trim() || '';
+          if (summary) observations.push(`Diff stats: ${summary}`);
         }
-
-        // Add project tag
-        const projectTag = `project:${projectName}`;
-        db.prepare('INSERT OR IGNORE INTO tags (entity_id, tag) VALUES (?, ?)').run(entity.id, projectTag);
-
-        // Update FTS index — delete old entry first if entity existed
-        if (prevObsText !== undefined) {
-          db.prepare("INSERT INTO entities_fts(entities_fts, rowid, name, observations) VALUES('delete', ?, ?, ?)").run(entity.id, entityName, prevObsText);
-        }
-        // Fetch all observations (including the one just added) for the new FTS entry
-        const allObs = db.prepare('SELECT content FROM observations WHERE entity_id = ?').all(entity.id);
-        const allObsText = allObs.map(o => o.content).join(' ');
-        db.prepare('INSERT INTO entities_fts(rowid, name, observations) VALUES(?, ?, ?)').run(entity.id, entityName, allObsText);
+      } catch {
+        // git show failed — no diff stats recorded, existing behavior unchanged
       }
+
+      // Shared write dance — upsert entity + observations + tags AND reindex FTS.
+      captureEntity(db, {
+        name: entityName,
+        type: 'commit',
+        observations,
+        tags: [`project:${projectName}`],
+      });
     } finally {
       db.close();
     }

--- a/scripts/hooks/pre-compact.js
+++ b/scripts/hooks/pre-compact.js
@@ -2,7 +2,7 @@
 
 import { basename } from 'path';
 import { existsSync, readFileSync } from 'fs';
-import { getProjectName, isAutoCaptureEnabled, openHookDb } from './_shared.js';
+import { captureEntity, getProjectName, isAutoCaptureEnabled, openHookDb } from './_shared.js';
 
 // Timeout guard: always exit within 10 seconds
 const TIMEOUT_MS = 10000;
@@ -99,37 +99,14 @@ process.stdin.on('end', () => {
     if (!handle) return;
     const { db } = handle;
     try {
-      // Upsert entity
-      const insertResult = db.prepare('INSERT OR IGNORE INTO entities (name, type) VALUES (?, ?)').run(entityName, 'session-summary');
-      const isNew = insertResult.changes > 0;
-      const entity = db.prepare('SELECT id FROM entities WHERE name = ?').get(entityName);
-
-      if (entity) {
-        // Capture existing observations for FTS delete
-        const prevObs = isNew
-          ? []
-          : db.prepare('SELECT content FROM observations WHERE entity_id = ?').all(entity.id);
-        const prevObsText = isNew ? undefined : prevObs.map(o => o.content).join(' ');
-
-        // Insert each observation line
-        for (const line of obsLines) {
-          db.prepare('INSERT INTO observations (entity_id, content) VALUES (?, ?)').run(entity.id, line);
-        }
-
-        // Add tags
-        const tags = ['source:auto-capture', 'urgency:pre-compact', `project:${projectName}`];
-        for (const tag of tags) {
-          db.prepare('INSERT OR IGNORE INTO tags (entity_id, tag) VALUES (?, ?)').run(entity.id, tag);
-        }
-
-        // Update FTS
-        if (prevObsText !== undefined) {
-          db.prepare("INSERT INTO entities_fts(entities_fts, rowid, name, observations) VALUES('delete', ?, ?, ?)").run(entity.id, entityName, prevObsText);
-        }
-        const allObs = db.prepare('SELECT content FROM observations WHERE entity_id = ?').all(entity.id);
-        const allObsText = allObs.map(o => o.content).join(' ');
-        db.prepare('INSERT INTO entities_fts(rowid, name, observations) VALUES(?, ?, ?)').run(entity.id, entityName, allObsText);
-      }
+      // Shared write dance — upsert entity + observations + tags AND reindex FTS
+      // so the pre-compact memory is recallable via the FTS keyword path.
+      captureEntity(db, {
+        name: entityName,
+        type: 'session-summary',
+        observations: obsLines,
+        tags: ['source:auto-capture', 'urgency:pre-compact', `project:${projectName}`],
+      });
     } finally {
       db.close();
     }

--- a/scripts/hooks/session-summary.js
+++ b/scripts/hooks/session-summary.js
@@ -11,6 +11,7 @@ import { spawn } from 'child_process';
 import os from 'os';
 import { pathToFileURL } from 'url';
 import {
+  captureEntity,
   decideAutoUpdateHook,
   getMemeshDirFromDbPath,
   getProjectName,
@@ -233,7 +234,9 @@ process.stdin.on('end', async () => {
     // Open DB via shared helper — applies SCHEMA_SQL + status migration.
     // sqlite-vec is loaded separately because only this hook needs it
     // (for embedding-aware recall-effectiveness tracking).
-    const handle = openHookDb(process.env);
+    // { fts: true } guarantees the entities_fts table exists so captureEntity()
+    // can keep it in sync — session-insight memories must be FTS-recallable.
+    const handle = openHookDb(process.env, { fts: true });
     if (!handle) {
       // Native module unavailable (plugin-marketplace cache install with no
       // node_modules). Skip session-capture work, but still let the
@@ -291,17 +294,12 @@ process.stdin.on('end', async () => {
         return [...tags];
       }
 
-      const insertEntity = db.prepare('INSERT OR IGNORE INTO entities (name, type) VALUES (?, ?)');
-      const selectEntity = db.prepare('SELECT id FROM entities WHERE name = ?');
-      const insertObs = db.prepare('INSERT INTO observations (entity_id, content) VALUES (?, ?)');
-      const insertTag = db.prepare('INSERT OR IGNORE INTO tags (entity_id, tag) VALUES (?, ?)');
-
+      // Delegate the write to the shared captureEntity() so entities land in
+      // entities_fts too. This copy used to insert entity + observations + tags
+      // only, skipping the FTS reindex the sibling hooks did — which left every
+      // session-insight memory unrecallable via the FTS keyword path.
       function storeMemory(name, type, observations, tags) {
-        insertEntity.run(name, type);
-        const row = selectEntity.get(name);
-        if (!row) return;
-        for (const obs of observations) insertObs.run(row.id, obs);
-        for (const tag of tags) insertTag.run(row.id, tag);
+        captureEntity(db, { name, type, observations, tags });
       }
 
       // Rule 1: File editing session summary

--- a/tests/hooks/session-summary.test.ts
+++ b/tests/hooks/session-summary.test.ts
@@ -112,6 +112,40 @@ describe('Feature: Session Summary (Stop Hook)', () => {
     db.close();
   });
 
+  it('Regression: session-insight memory is FTS-recallable (was written but never indexed)', () => {
+    // Root-cause guard for the fake-working bug: storeMemory used to insert
+    // entity + observations + tags but skip entities_fts, so every session
+    // memory was invisible to `recall` and pre-edit-recall (both FTS paths).
+    // There is no FTS trigger and no rebuild-on-open, so the omission was total.
+    // captureEntity() now owns the write dance and keeps FTS in sync.
+    writeTranscript([
+      { type: 'assistant', message: { content: [{ type: 'tool_use', name: 'Edit', input: { file_path: '/tmp/proj/src/authentication.ts' } }] } },
+      { type: 'assistant', message: { content: [{ type: 'tool_use', name: 'Write', input: { file_path: '/tmp/proj/src/config.ts' } }] } },
+      { type: 'assistant', message: { content: [{ type: 'tool_use', name: 'Bash', input: { command: 'npm test -- --run' } }] } },
+      { type: 'user', message: { content: [{ type: 'tool_result', content: 'All tests passed' }] } },
+    ]);
+
+    runHook({
+      session_id: 'test-fts-recall',
+      transcript_path: transcriptPath,
+      cwd: '/tmp/myproject',
+      stop_reason: 'end_turn',
+      was_in_agentic_loop: true,
+    });
+
+    const db = openDb();
+    const entity = db.prepare("SELECT id FROM entities WHERE name = 'session-test-fts-recall-files'").get() as any;
+    expect(entity).toBeTruthy();
+
+    // The observation text contains the edited filename token — it must be
+    // reachable through the FTS5 index, not just the entities table.
+    const ftsRowids = (db.prepare(
+      "SELECT rowid FROM entities_fts WHERE entities_fts MATCH 'authentication'",
+    ).all() as any[]).map((r) => r.rowid);
+    expect(ftsRowids).toContain(entity.id);
+    db.close();
+  });
+
   it('Scenario: producer writes file: tags that pre-edit-recall Strategy 1 queries', () => {
     // The capture is the PRODUCER for pre-edit-recall's `file:<name>` lookup.
     // Before this, nothing wrote those tags, so Strategy 1 returned zero rows


### PR DESCRIPTION
## The bug (fake-working)

`session-summary.js` `storeMemory()` inserted the entity + observations + tags but **never reindexed `entities_fts`**, unlike its sibling write hooks `post-commit.js` and `pre-compact.js` which both do the FTS delete+insert dance. Since `entities_fts` is a contentless FTS5 table with **no trigger** and **no rebuild-on-open self-heal**, every `session-insight` memory the Stop hook captured was invisible to `recall` and `pre-edit-recall` — the two keyword paths that inject memory when it matters. The hook reported success; the knowledge could not be keyword-recalled. (Those memories still surfaced at session-start and to the dreamer, which query the `entities` table directly by tag/recency — which is why the gap went unnoticed.)

## Root cause & fix

Three hand-rolled copies of the same write dance drifted apart; this copy dropped the FTS step. Rather than paste the 4 FTS lines into a third place (a workaround that grows the drift surface), the correct dance is extracted into a single **`captureEntity()`** in `_shared.js`, now used by all three write hooks — so the FTS step can't be forgotten again. This mirrors, on the hook side, what `src/storage/fts-index.ts` already does for core (the F5 boundary keeps them as two implementations of one contract). Net effect: post-commit and pre-compact get **shorter**, session-summary gets its missing FTS.

Embeddings / auto-tagging / signal-scoring are deliberately **not** added to the hook path — hooks are cheap always-on capture; those are the heavier user-initiated `remember` concerns core owns. Documented in the helper, not silently dropped.

## Verification

- New regression test in `tests/hooks/session-summary.test.ts` asserts a captured session memory is returned by an `entities_fts MATCH`.
- Proven non-vacuous: temporarily removing the FTS insert in `captureEntity()` makes the test fail (reproduces the bug); restoring it passes.
- Full hooks suite green: `npx vitest run tests/hooks/` → **Test Files 13 passed (13) / Tests 272 passed (272)**.

## Docs synced
- [x] CHANGELOG.md — added `[Unreleased] › Fixed` entry
- [x] docs/ARCHITECTURE.md — n/a (no module added/removed; `_shared.js` gains a helper, not a new module)
- [x] docs/api/API_REFERENCE.md — n/a (no MCP/HTTP/CLI surface change)
- [x] README.md / locales — n/a (no user-facing config/feature change)
- [x] CLAUDE.md — n/a (hook list/counts unchanged)
- [x] CODEMAP.md — noted `captureEntity` on the `_shared.js` row
- [x] Version files — n/a (no version bump; ships with next release)
- [x] dist/skills-manifest.json — n/a (no version bump; hooks' SHA is manifest-tracked but regenerated at release build)