### PR TITLE
chore(release): v4.2.9 — security + 2 fake-working fixes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "memesh",
       "source": "./",
       "description": "MeMesh — Local memory for Claude Code and MCP coding agents. One SQLite file, zero cloud required.",
-      "version": "4.2.8",
+      "version": "4.2.9",
       "author": {
         "name": "PCIRCLE AI"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -4,7 +4,7 @@
   "author": {
     "name": "PCIRCLE AI"
   },
-  "version": "4.2.8",
+  "version": "4.2.9",
   "homepage": "https://pcircle.ai/memesh-llm-memory",
   "repository": "https://github.com/PCIRCLE-AI/memesh-llm-memory",
   "license": "MIT",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to MeMesh are documented here.
 
-## [Unreleased]
+## [4.2.9] — 2026-07-24
 
 ### Security
 - **`POST /v1/config` no longer echoes fallback-provider API keys in plaintext** (`src/transports/http/server.ts`) — the POST response masked only `llm.apiKey`, so saving an `llmFallbacks: [{provider, apiKey}]` chain returned each fallback key in cleartext to the dashboard SPA (the GET handler already masked the whole chain). Consolidated both surfaces onto one `maskLlmSecrets()` helper that redacts the primary key and every fallback entry, so they can't drift again. Persistence was unaffected; only the response surface leaked.

--- a/dist/skills-manifest.json
+++ b/dist/skills-manifest.json
@@ -1,10 +1,10 @@
 {
   "schema": "memesh.skills-manifest/v1",
-  "generated_at": "2026-07-24T18:23:19.382Z",
+  "generated_at": "2026-07-24T19:32:25.516Z",
   "entries": [
     {
       "path": ".claude-plugin/plugin.json",
-      "sha256": "4ab25f81646267d3c6a77c2178819cd54300099ffa4644bb3c622e68a58b80fe",
+      "sha256": "07cfae6f05964eb00bea7a78a23676ce4fadc024379ac2cdf8d30837bfb851d0",
       "bytes": 441
     },
     {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # MeMesh Plugin Architecture
 
-**Version**: 4.2.8
+**Version**: 4.2.9
 
 > Looking for "which file do I change for X?" — see [CODEMAP.md](../CODEMAP.md).
 

--- a/docs/api/API_REFERENCE.md
+++ b/docs/api/API_REFERENCE.md
@@ -1,7 +1,7 @@
 # MeMesh Plugin -- API Reference
 
 **Protocol**: Model Context Protocol (MCP) over stdio
-**Version**: 4.2.8
+**Version**: 4.2.9
 **Compatibility**: Works with Claude Code plugins, Claude Managed Agents (via MCP connector), and any MCP-compatible client.
 
 ---
@@ -552,8 +552,8 @@ Use `?cached=1` to read the cached state only. Without it, MeMesh prefers a fres
 {
   "success": true,
   "data": {
-    "currentVersion": "4.2.7",
-    "latestVersion": "4.2.8",
+    "currentVersion": "4.2.8",
+    "latestVersion": "4.2.9",
     "checkedAt": "2026-04-24T10:15:00.000Z",
     "lastAttemptAt": "2026-04-24T10:15:00.000Z",
     "lastSuccessfulCheckAt": "2026-04-24T10:00:00.000Z",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcircle/memesh",
-  "version": "4.2.8",
+  "version": "4.2.9",
   "description": "MeMesh — Local memory for Claude Code and MCP coding agents. One SQLite file, zero cloud required.",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## v4.2.9 patch release

Bundles three fixes already merged to `main` under `[Unreleased]` and ships them to npm + plugin marketplace. The config-response security fix is why we release now — the affected version (4.2.8) is what npm currently serves.

### What ships (all merged, reviewed, tested)
- **Security (#63)** — the config read/write responses now share one redaction helper so the whole provider chain is masked, not just the primary entry.
- **Fix (#62)** — session-capture memories are keyword-recallable again; the hook write path is centralised so the search-index step can't be dropped.
- **Fix (#64)** — the dashboard auth screen renders real text instead of raw i18n key names; a CI guard now fails on any component key missing from English.

### Version bump (all anchors 4.2.8 → 4.2.9)
- [x] package.json + .claude-plugin/plugin.json + .claude-plugin/marketplace.json
- [x] CHANGELOG.md `## [4.2.9] — 2026-07-24`
- [x] docs/ARCHITECTURE.md + docs/api/API_REFERENCE.md version headers
- [x] dist/skills-manifest.json regenerated (`memesh doctor` manifest PASS, 14 files SHA-256 verified)

### Acceptance
- `npm test -- --run` → **Test Files 69 passed (69) / Tests 1139 passed (1139)**
- `memesh doctor` → Overall PASS_WITH_CONCERNS (activity + update-status only; no FAIL)

After merge: create the GitHub release `v4.2.9` → triggers `publish-npm.yml` (`on: release: published`). Do NOT publish manually (double-publish → E409).