### PR TITLE
test(hooks): permanent CI gates for the fake-working write-path class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to MeMesh are documented here.
 
 ## [Unreleased]
 
+### Tests
+- **Permanent CI gates for the fake-working write-path class** (`tests/hooks/write-hook-invariants.test.ts`) — turns the session-capture-FTS fix into invariants that can't silently regress: (1) `captureEntity()` really keeps `entities_fts` in sync (write → `MATCH` returns the row), and (2) every write hook (session-summary / post-commit / pre-compact) routes through `captureEntity()` and hand-rolls no `INSERT INTO observations` / `entities_fts` of its own — so a future hook can't drop the FTS step again. Mirrors the i18n key-coverage guard shipped for the AuthPrompt fix.
+
 ### Performance
 - **Dashboard graph + browse + type-list no longer fire a query storm** (`src/knowledge-graph.ts`, `src/core/graph.ts`, `src/transports/http/server.ts`) — `computeGraph` (the `/v1/graph` endpoint), `listRecent` / `listRecentByTag` (empty-query recall + Browse tab), and the `/v1/entities?type=` branch each mapped `getEntity()` over their result rows, and `getEntity()` fires 4 queries per row. A 700-entity graph meant ~2800 queries per request. All now route their id list through the existing order-preserving `getEntitiesByIds()` batch hydrator (4 queries total). The transport's hand-rolled `SELECT ... WHERE type = ?` moved into a new `KnowledgeGraph.listByType()` so status/ordering semantics live in the storage layer, not the HTTP handler. Same fields, same active/archived filtering, same ordering — verified by the existing listRecent tests plus a new listByType test.
 

--- a/tests/hooks/write-hook-invariants.test.ts
+++ b/tests/hooks/write-hook-invariants.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Permanent CI gates for the "fake-working" write-path classes this audit
+ * found — so they can't silently come back.
+ *
+ * The seed bug: session-summary.js wrote an entity but skipped the FTS reindex,
+ * so the memory was stored yet unrecallable. The fix centralised the write dance
+ * in _shared.js `captureEntity()`. These invariants lock BOTH halves of that
+ * fix: (1) the shared helper really does keep FTS in sync, and (2) no write
+ * hook hand-rolls its own entity write that could skip the FTS step again.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createRequire } from 'module';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const require = createRequire(import.meta.url);
+// _shared.js is plain JS with no type declarations.
+const shared = require('../../scripts/hooks/_shared.js');
+
+describe('write-hook invariants (fake-working gates)', () => {
+  let tmpDir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memesh-invariants-'));
+    dbPath = path.join(tmpDir, 'test.db');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('captureEntity keeps entities_fts in sync, so hook-written memories are FTS-recallable', () => {
+    const handle = shared.openHookDb({ ...process.env, MEMESH_DB_PATH: dbPath }, { fts: true });
+    expect(handle).not.toBeNull();
+    const { db } = handle;
+    try {
+      const res = shared.captureEntity(db, {
+        name: 'invariant-entity-1',
+        type: 'note',
+        observations: ['the quick brown zebra jumped the fence'],
+        tags: ['project:test'],
+      });
+      expect(res).not.toBeNull();
+
+      // The distinctive observation token must be reachable through the FTS5
+      // index — not just present in the observations table.
+      const ftsRowids = (db.prepare(
+        "SELECT rowid FROM entities_fts WHERE entities_fts MATCH 'zebra'",
+      ).all() as Array<{ rowid: number }>).map((r) => r.rowid);
+      expect(ftsRowids).toContain(res.id);
+    } finally {
+      db.close();
+    }
+  });
+
+  it('every write hook routes through captureEntity and hand-rolls no entity writes', () => {
+    // These three hooks persist entities. If any of them writes rows directly
+    // instead of via captureEntity, it can drop the FTS/observation steps the
+    // helper guarantees — exactly the drift that made session memories
+    // unrecallable. A new write hook must be added here too.
+    const writeHooks = ['session-summary.js', 'post-commit.js', 'pre-compact.js'];
+    for (const hook of writeHooks) {
+      const src = fs.readFileSync(path.join('scripts/hooks', hook), 'utf8');
+      expect(src, `${hook} must use the shared captureEntity() write helper`).toMatch(/captureEntity\(/);
+      expect(
+        src,
+        `${hook} must not hand-roll "INSERT INTO observations" (bypasses captureEntity's FTS reindex)`,
+      ).not.toMatch(/INSERT INTO observations/);
+      expect(
+        src,
+        `${hook} must not hand-roll "INSERT INTO entities_fts" (that belongs in captureEntity)`,
+      ).not.toMatch(/INSERT INTO entities_fts/);
+    }
+  });
+});


### PR DESCRIPTION
## Why

The audit found and fixed several "fake-working" bugs (code that reports success while doing nothing). Fixing the instance isn't enough — the COO/CTO ask was to turn each class into a permanent CI gate so it can't come back. This is the write-path analogue of the i18n key-coverage guard shipped with the AuthPrompt fix.

## What it locks

Two invariants around the session-capture-FTS fix:
1. **`captureEntity()` really keeps `entities_fts` in sync** — write an entity via the shared helper, assert an FTS `MATCH` on its observation returns the row. (The seed bug: a hook wrote the row but skipped this step, so the memory was stored yet unrecallable.)
2. **Every write hook routes through `captureEntity()`** and hand-rolls no `INSERT INTO observations` / `entities_fts` of its own — so no hook can drift back to a raw write that drops the FTS step. A new write hook must be added to the list, which is the point.

## Verification
- `npx vitest run tests/hooks/write-hook-invariants.test.ts` → **2 passed**.
- Test-only; no src / dist / manifest change.

## Docs synced
- [x] CHANGELOG.md `[Unreleased] › Tests`