### PR TITLE
chore(release): v4.2.10

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "memesh",
       "source": "./",
       "description": "MeMesh — Local memory for Claude Code and MCP coding agents. One SQLite file, zero cloud required.",
-      "version": "4.2.9",
+      "version": "4.2.10",
       "author": {
         "name": "PCIRCLE AI"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -4,7 +4,7 @@
   "author": {
     "name": "PCIRCLE AI"
   },
-  "version": "4.2.9",
+  "version": "4.2.10",
   "homepage": "https://pcircle.ai/memesh-llm-memory",
   "repository": "https://github.com/PCIRCLE-AI/memesh-llm-memory",
   "license": "MIT",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to MeMesh are documented here.
 
 ## [Unreleased]
 
+## [4.2.10] — 2026-07-25
+
 ### Fixed
 - **LLM JSON-block extraction is now nesting- and prose-safe (latent bug)** (`src/core/json-utils.ts` + auto-tagger / consolidator / digest-validator / dreamer) — five sites pulled a JSON object/array out of a chatty LLM reply with a regex, and they had drifted between a greedy `/\{[\s\S]*\}/` and a lazy `/\{[\s\S]*?\}/`. Both are fragile: greedy over-matches a `]`/`}` that appears later in prose and breaks `JSON.parse`; lazy stops at the first closer and truncates a nested block. Replaced all five with one `extractJsonBlock(text, kind)` that scans for the first balanced block, tracking depth and skipping brackets inside string literals — robust to nesting, trailing prose, and quoted brackets. Covered by a new unit test hitting each case the old regexes broke on.
 

--- a/dist/skills-manifest.json
+++ b/dist/skills-manifest.json
@@ -1,11 +1,11 @@
 {
   "schema": "memesh.skills-manifest/v1",
-  "generated_at": "2026-07-25T16:54:03.967Z",
+  "generated_at": "2026-07-25T19:27:34.396Z",
   "entries": [
     {
       "path": ".claude-plugin/plugin.json",
-      "sha256": "07cfae6f05964eb00bea7a78a23676ce4fadc024379ac2cdf8d30837bfb851d0",
-      "bytes": 441
+      "sha256": "56f861dcfe4cb6d35f4750b44450401fe05826c9ef578ecfd6451791a91cd249",
+      "bytes": 442
     },
     {
       "path": ".mcp.json",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # MeMesh Plugin Architecture
 
-**Version**: 4.2.9
+**Version**: 4.2.10
 
 > Looking for "which file do I change for X?" — see [CODEMAP.md](../CODEMAP.md).
 

--- a/docs/api/API_REFERENCE.md
+++ b/docs/api/API_REFERENCE.md
@@ -1,7 +1,7 @@
 # MeMesh Plugin -- API Reference
 
 **Protocol**: Model Context Protocol (MCP) over stdio
-**Version**: 4.2.9
+**Version**: 4.2.10
 **Compatibility**: Works with Claude Code plugins, Claude Managed Agents (via MCP connector), and any MCP-compatible client.
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcircle/memesh",
-  "version": "4.2.9",
+  "version": "4.2.10",
   "description": "MeMesh — Local memory for Claude Code and MCP coding agents. One SQLite file, zero cloud required.",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
Patch release bundling the fixes/refactors merged to main since v4.2.9.

**User-facing:** `config list` shows all settable keys (#69); Settings toggles now surface a failed save (#70); dashboard graph/browse got much faster (N+1 → batch, #67).
**Under the hood:** nesting/prose-safe LLM JSON extraction (#72); recall ranking no longer polluted by synthetic names (#66); recall+conflict owned by core (#71); the F5 hook-core mirror is now generated from source instead of hand-copied, with drift caught three ways (#75/#76).

7 version anchors bumped to 4.2.10; manifest regenerated.

## Docs synced
- [x] CHANGELOG.md — `[4.2.10] — 2026-07-25` section stamped; fresh empty `[Unreleased]`
- [x] docs/ARCHITECTURE.md — Version 4.2.10 (F5 section already updated in #75)
- [x] docs/api/API_REFERENCE.md — Version 4.2.10
- [x] README / locales — N/A (no user-facing feature/flag change beyond what shipped in the bundled PRs)
- [x] Version files — package.json + plugin.json + marketplace.json all 4.2.10
- [x] dist/skills-manifest.json — regenerated (plugin.json rehashed; 16 files)
- [x] memesh doctor — Overall PASS (Skills+hooks integrity PASS, 16 files SHA-256 verified)
- [x] Tests — 1167 passed (74 files); version-coherence agrees