### PR TITLE
docs: track CLAUDE.md, as a pointer rather than a second copy of the docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,11 @@ secrets/
 *.key
 
 # === Claude Code local config ===
-CLAUDE.md
+# CLAUDE.md is TRACKED: it is a short pointer to CONTRIBUTING.md / ARCHITECTURE.md
+# and carries only the handful of facts that live nowhere else. Untracking it was
+# what let it drift — it duplicated public docs and no reviewer saw it change.
+# Personal, machine-specific or client-specific notes belong in the user-level
+# ~/.claude/CLAUDE.md, never here.
 .claude/
 # Note: .claude-plugin/plugin.json AND .claude-plugin/marketplace.json
 # ARE Claude Code plugin/marketplace manifests for memesh itself — both

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,76 @@
+# MeMesh — instructions for AI coding assistants
+
+This file is a **pointer**, on purpose. It used to carry its own copy of the
+module tree, the dependency list and the development standards, and a copy is a
+thing that drifts. It was the last file in the repository still quoting a
+benchmark figure (95.40% R@5) that release 4.2.11 was spent proving wrong, and
+its test count was 44 behind. It was also untracked, so no reviewer ever saw it
+change. Both problems had one cause: it duplicated documents that already
+exist, are already public, and are already checked by CI.
+
+So — **read the real documents.** Do not restate them here.
+
+| Question | Read |
+|---|---|
+| How do I contribute, what must a PR include, which docs move with a code change | [CONTRIBUTING.md](CONTRIBUTING.md) |
+| What are the modules, how does data flow, why is it built this way | [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) |
+| What is the MCP / HTTP / CLI surface, exactly | [docs/api/API_REFERENCE.md](docs/api/API_REFERENCE.md) |
+| What does the product do, how is it installed | [README.md](README.md) |
+| Colour, type, spacing, interaction — before ANY dashboard change | [DESIGN.md](DESIGN.md) |
+| How do I report a vulnerability | [SECURITY.md](SECURITY.md) |
+
+---
+
+## The few things that live only here
+
+Everything below is either non-obvious from the code or specific to working
+with an assistant. If anything here starts duplicating a document above, delete
+it here and link instead.
+
+### Running the tests
+
+```bash
+node scripts/run-tests-isolated.mjs        # whole suite, against a throwaway HOME
+npm test -- --run                          # vitest directly — uses YOUR ~/.memesh
+```
+
+Prefer the first. The suite writes to `~/.memesh`, so running vitest directly
+mutates your real knowledge graph.
+
+**Do not set `MEMESH_DB_PATH` when running the suite.** Pointing it at an
+existing file makes `tests/hooks/session-start-telemetry.test.ts` fail: its
+"short-circuits on a missing DB" case then has nothing to short-circuit on. An
+isolated `HOME` is the right isolation; a fixed DB path is not.
+
+Pool mode is `forks`, single fork, no file parallelism. That is not a
+preference — several test files share one HOME and therefore one SQLite
+database, and running them concurrently deadlocks on the write lock.
+
+### Verifying a change before claiming it works
+
+Do not report a test result, a CI status or a benchmark number you did not
+produce in this session. Paste the runner's actual output. `npm run
+verify:release` is the same gate the publish path runs; `bash
+scripts/verify-docs-sync.sh` checks the doc contracts.
+
+When you fix a bug, **revert the fix and confirm the test goes red.** A green
+suite is not evidence that a fix is protected: three tests in this repository
+have passed while the thing they guarded was removed.
+
+### Git
+
+- `main` (production) ← `develop` (development). Never commit directly to `main`.
+- Commit format: `<type>(<scope>): <subject>`
+- **No AI attribution.** Commit messages and PR descriptions must not contain
+  `Co-Authored-By: Claude`, `🤖 Generated with [Claude Code]`, or any text
+  crediting an AI as author or generator. Strip it from any default template.
+- Never `git add -A` or `git add .` — stage the files you meant to change.
+
+### Two storage facts worth knowing before you touch persistence
+
+- `entities_fts` is a **contentless** FTS5 table. A delete must be issued with
+  the exact text that was indexed, or the index silently keeps the old tokens
+  and search answers for content that is gone.
+- `entities_vec` is one sqlite-vec table for the **whole database**, not one per
+  namespace. Dropping it drops every namespace's embeddings, and only a full
+  re-embed brings them back — on a paid provider, at cost.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,10 +27,10 @@ Documentation is part of the change, not follow-up work. The CI's `Version coher
 - Update `docs/api/API_REFERENCE.md` when the MCP / HTTP / CLI surface changes (and bump its `**Version**: ` line on a release).
 - Update `docs/ARCHITECTURE.md` when module structure, storage behavior, or packaging flow changes (and bump its `**Version**: ` line on a release).
 - Read `DESIGN.md` before any dashboard change that touches colour, type, spacing or an interaction, and update it when a token or rule changes. It is derived from `dashboard/src/styles/global.css`; when the two disagree the CSS is what ships, so fix whichever is wrong rather than leaving them apart.
-- Keep version metadata coherent: `package.json` + `.claude-plugin/plugin.json` + `.claude-plugin/marketplace.json` `plugins[].version` + `CHANGELOG.md` `## [X.Y.Z]` header + the two `**Version**:` lines above must all match. The `node scripts/check-version-coherence.mjs` check (run as a CI step) catches partial bumps.
+- Keep version metadata coherent: `package.json` + **`package-lock.json` (both the root `version` and `packages[""].version`)** + `.claude-plugin/plugin.json` + `.claude-plugin/marketplace.json` `plugins[].version` + `CHANGELOG.md` `## [X.Y.Z]` header + the two `**Version**:` lines above must all match. The `node scripts/check-version-coherence.mjs` check (run as a CI step) catches partial bumps. `package-lock.json` is called out because it is the one that drifted silently across four releases (4.2.6 through 4.2.10) while every other anchor stayed correct — `npm version` updates it, hand-editing `package.json` does not.
 - After ANY change to `.claude-plugin/`, `scripts/hooks/`, `skills/`, or version files, run `npm run build` so `dist/skills-manifest.json` regenerates. Otherwise `memesh doctor` reports `Skills + hooks integrity FAIL` and users see "memesh setup is incomplete" in their dashboard. CI's `Doctor` step catches this before merge.
 
-The repository-level engineering rules in `CLAUDE.md` apply to contributor changes as well.
+`CLAUDE.md` carries the same rules in the form an AI coding assistant reads. It is a pointer file — this document is the source of truth for anything that applies to a human contributor.
 
 ## Pull Requests
 

--- a/scripts/check-version-coherence.mjs
+++ b/scripts/check-version-coherence.mjs
@@ -57,7 +57,7 @@ if (pluginVersion !== pkgVersion) {
 
 // package-lock.json carries the version TWICE and both must agree.
 //
-// `CLAUDE.md` names these as required anchors and records that they "silently
+// `CONTRIBUTING.md` names these as required anchors and records that they "silently
 // drifted from 4.2.6 through 4.2.10" — five releases — which is exactly what a
 // coherence gate exists to stop, and this gate did not read the file. `npm ci`
 // does not compensate: measured with package.json at 2.0.0 against a lockfile


### PR DESCRIPTION
`CLAUDE.md` was untracked. That was the wrong half of the problem to solve.

## What it actually was

236 lines duplicating `docs/ARCHITECTURE.md`, `CONTRIBUTING.md` and `README.md`. A duplicate drifts, and this one had:

| | CLAUDE.md said | Reality |
|---|---|---|
| LongMemEval R@5 | **95.40%** (twice) | 95.60% |
| Test count | 1362 / 95 files | 1406 / 96 files |
| `signal-scorer.ts` | listed | **absent** from ARCHITECTURE.md's list |

The first row is the sharpest: **95.40% is the figure release 4.2.11 was spent proving wrong** (it measured the benchmark's own reimplementation, not the product). README.md and ARCHITECTURE.md both say 95.60% and explain the correction. CLAUDE.md was the last file in the repository still repeating the retracted number.

Why it drifted is not a mystery: it was the only entry in **its own "documentation contracts" table** with no gate. `verify-docs-sync.sh` doesn't read it, CI can't see it, no reviewer sees it change.

## And a public doc pointed at it

`CONTRIBUTING.md` — public, always was — ended its documentation section with:

> The repository-level engineering rules in `CLAUDE.md` apply to contributor changes as well.

A public document sending contributors to a file that is not in the repository.

## What it is now

A pointer. A table routing each question to the real document, then only what lives nowhere else:

- how to run the suite without mutating your own `~/.memesh`
- why `MEMESH_DB_PATH` must **not** be set for it (`session-start-telemetry.test.ts`'s "short-circuits on a missing DB" case has nothing to short-circuit on)
- why the pool is single-fork (shared HOME → shared SQLite → write-lock deadlock)
- revert-the-fix-and-confirm-red, because three tests in this repo have passed while the thing they guarded was removed
- git conventions, including no AI attribution
- two storage facts that are expensive to learn the hard way: `entities_fts` is contentless, `entities_vec` is one table for the whole database

**236 lines → 76.** Anything that starts duplicating a linked document gets deleted here, not synced.

## Two things move with it

- `CONTRIBUTING.md`'s version-coherence list was missing **`package-lock.json`** — the one anchor that silently drifted across four releases (4.2.6→4.2.10) while every other stayed correct. Now named explicitly, both fields, with the reason (`npm version` updates it; hand-editing `package.json` does not).
- `scripts/check-version-coherence.mjs` cited CLAUDE.md as the place recording that drift. It now cites CONTRIBUTING.md, where the record actually lives.

## Safety review before tracking

Scanned for credentials, tokens, absolute paths, addresses, client material — **none**. Personal and machine-specific instructions stay in the user-level `~/.claude/CLAUDE.md`, which is where they already were; that separation was correct from the start and is unchanged. The `.gitignore` entry is replaced by a comment recording the decision, so the next person finds the reason instead of re-deciding it.

## Verification

```
version coherence  node scripts/check-version-coherence.mjs — exit 0, "All version sources agree."
docs sync          bash scripts/verify-docs-sync.sh — exit 0, ALL CHECKS PASSED
lint               exit 0
gitignore          git check-ignore -v CLAUDE.md — no match
content scan       only hit is the word "tokens" in the FTS5 note
```

- [x] CHANGELOG.md — not updated: docs-only, no user-facing or API change
- [x] docs/ARCHITECTURE.md — unchanged (it is the source this stops duplicating)
- [x] docs/api/API_REFERENCE.md — unchanged
- [x] README.md / locales — unchanged
- [x] CONTRIBUTING.md updated (package-lock.json anchor + CLAUDE.md description)
- [x] Version files unchanged
- [x] `npm run build` not required — no source, hook, skill or version file touched