### PR TITLE
docs(claude): state the branching rule that is actually enforced

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,20 @@ have passed while the thing they guarded was removed.
 
 ### Git
 
-- `main` (production) ← `develop` (development). Never commit directly to `main`.
+- **Short-lived branch → PR → `main`. Never push directly to `main`.** That is
+  the whole flow; branch protection enforces it. `develop` is a passive mirror
+  of `main`, kept for anyone whose tooling expects it — it is not a stage work
+  passes through, and nothing is ever merged *into* it. This used to read
+  "`main` ← `develop`", which described git-flow: a model for software with
+  several release lines under support at once, and one whose own author now
+  warns against using it for continuously delivered projects. Nothing here has
+  release lines, and the branch proved it — `develop` sat 58 commits behind
+  `main` and 0 ahead, through four releases, while every PR went straight to
+  `main`. A rule nobody follows and nothing enforces is worse than no rule: it
+  makes this file lie to whoever reads it next.
+- Releases are tags on `main`. "Merged but not yet published" is answered by
+  `CHANGELOG.md`'s `[Unreleased]` section, which is why a branch does not need
+  to answer it.
 - Commit format: `<type>(<scope>): <subject>`
 - **No AI attribution.** Commit messages and PR descriptions must not contain
   `Co-Authored-By: Claude`, `🤖 Generated with [Claude Code]`, or any text


### PR DESCRIPTION
## The line

```diff
-- `main` (production) ← `develop` (development). Never commit directly to `main`.
+- **Short-lived branch → PR → `main`. Never push directly to `main`.** …
+- Releases are tags on `main`. "Merged but not yet published" is answered by
+  `CHANGELOG.md`'s `[Unreleased]` section …
```

Half the old line was true and enforced by branch protection. The other half described git-flow, which nothing in this repository has followed for months.

## Why

**The branch is the evidence.** `develop` sat **58 commits behind `main` and 0 ahead**, across four releases, while every PR went straight to `main`.

git-flow was designed for software with several release lines under support at once — its own author added a note in 2020 warning against it for continuously delivered projects. This package has one release line and publishes from tags on `main`. `develop` bought no isolation a PR branch does not already give; it only added a second branch someone has to remember to sync.

A rule nobody follows and nothing enforces is worse than no rule. This file is read by assistants that act on it, and it was telling them to route work through a dead branch.

## What `develop` is now

A passive mirror of `main`, kept for tooling that expects the name. Nothing merges *into* it; it is fast-forwarded from `main` after a merge.

## Scope

No code. No public document described the develop flow, so nothing else needed correcting — `CONTRIBUTING.md`, `README.md` and `docs/` never mentioned it.

One thing deliberately **not** changed: `.github/workflows/ci.yml` still has `push: branches: [main, develop]`, so every mirror sync re-runs the full matrix on commits that already passed it on `main` (measured: 10 jobs, `run 30777564073`). Free on a public repo, but it is duplicate wall-clock. Removing `develop` from that trigger is a separate call, since it also means a hand-made direct push to `develop` would go untested.

## Verification

```
node scripts/check-version-coherence.mjs -> exit 0
bash scripts/verify-docs-sync.sh         -> exit 0
```
