### PR TITLE
fix(test): stop Windows temp-dir teardown from failing unrelated builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to MeMesh are documented here.
 
 ## [Unreleased]
 
+### Tests
+
+- **A docs-only pull request went red on Windows because a temp directory was slow to delete** (`vitest.config.ts`, `tests/**`) — `hookTimeout` was 10 seconds, which fits POSIX and does not fit Windows: every DB test's `afterEach` closes SQLite and recursively removes a temp directory, SQLite leaves `-wal`/`-shm` beside the database, and the OS (plus whatever scans files on a CI runner) can hold a handle open for a moment after close. Measured — `tests/core/export-import.test.ts` hit `Hook timed out in 10000ms` on `windows-latest` / Node 24, in a pull request that changed only `CHANGELOG.md`.
+
+  Two halves, because there are two causes. The budget is now 30 seconds, for removals that succeed but are slow. And every recursive `rmSync` in `tests/` (74 of them; exactly one already had it) now passes `maxRetries: 5, retryDelay: 100` — the documented Windows mitigation for the `EBUSY`/`EPERM` a still-open handle produces. The shared DB fixture additionally treats a failed removal as non-fatal: a directory under `os.tmpdir()` that will not delete is the operating system's problem and gets swept by the platform, and failing a test over it turns a machine-local file lock into a red build on an unrelated change.
+
+
 ### Removed
 
 - **`consolidate` is retired — MCP tool, HTTP endpoint and CLI command** (`src/core/consolidator.ts` deleted; `handlers.ts`, `server.ts`, `cli.ts`, `schema-export.ts`, `types.ts`, `schemas.ts`) — **this is a breaking change.** MeMesh now exposes **8** MCP tools.

--- a/tests/cjk-recall.test.ts
+++ b/tests/cjk-recall.test.ts
@@ -295,7 +295,7 @@ describe('Feature: CJK recall', () => {
         } catch {
           /* already closed */
         }
-        fs.rmSync(dir, { recursive: true, force: true });
+        fs.rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
       }
     });
 
@@ -337,7 +337,7 @@ describe('Feature: CJK recall', () => {
         } catch {
           /* already closed */
         }
-        fs.rmSync(dir, { recursive: true, force: true });
+        fs.rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
       }
     });
   });

--- a/tests/cli-reindex-vectors-guard.test.ts
+++ b/tests/cli-reindex-vectors-guard.test.ts
@@ -36,7 +36,7 @@ describe('memesh reindex --vectors refuses to destroy more than asked', () => {
   });
 
   afterEach(() => {
-    fs.rmSync(home, { recursive: true, force: true });
+    fs.rmSync(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   });
 
   function run(args: string[]): { status: number; stderr: string; stdout: string } {

--- a/tests/cli/remember-quick.test.ts
+++ b/tests/cli/remember-quick.test.ts
@@ -38,7 +38,7 @@ describe('memesh remember CLI: quick-capture form', () => {
   });
 
   afterEach(() => {
-    if (fs.existsSync(tmpHome)) fs.rmSync(tmpHome, { recursive: true, force: true });
+    if (fs.existsSync(tmpHome)) fs.rmSync(tmpHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   });
 
   it('accepts a single positional text argument and stores it as a note', () => {

--- a/tests/cli/view.test.ts
+++ b/tests/cli/view.test.ts
@@ -53,7 +53,7 @@ describe('Feature: MeMesh View Dashboard', () => {
   });
 
   afterEach(() => {
-    fs.rmSync(testDir, { recursive: true, force: true });
+    fs.rmSync(testDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   });
 
   describe('Scenario: Generate dashboard with empty database', () => {

--- a/tests/confidence-bump.test.ts
+++ b/tests/confidence-bump.test.ts
@@ -37,7 +37,7 @@ describe('G1 — confidence bump paths', () => {
     const { closeDatabase } = await import('../src/db.js');
     try { closeDatabase(); } catch { /* already closed */ }
     delete process.env.MEMESH_DB_PATH;
-    rmSync(tmpHome, { recursive: true, force: true });
+    rmSync(tmpHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   });
 
   function getConfidence(name: string): number {

--- a/tests/consumer-audit-gate.test.ts
+++ b/tests/consumer-audit-gate.test.ts
@@ -81,7 +81,7 @@ describe('Feature: the consumer audit cannot pass on an empty tree', () => {
   });
 
   afterEach(() => {
-    fs.rmSync(binDir, { recursive: true, force: true });
+    fs.rmSync(binDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
     fs.rmSync(path.join(repoRoot, 'fake-package-0.0.0.tgz'), { force: true });
   });
 

--- a/tests/core/config.test.ts
+++ b/tests/core/config.test.ts
@@ -286,7 +286,7 @@ describe('Config: a corrupt config file is traced, not silently ignored', () => 
     stderrSpy.mockRestore();
     if (savedMemeshDir === undefined) delete process.env.MEMESH_DIR;
     else process.env.MEMESH_DIR = savedMemeshDir;
-    fs.rmSync(dir, { recursive: true, force: true });
+    fs.rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   });
 
   it('returns {} AND writes a stderr trace naming the file when JSON is corrupt', () => {

--- a/tests/core/demo.test.ts
+++ b/tests/core/demo.test.ts
@@ -23,7 +23,7 @@ describe('seedDemo', () => {
     const { closeDatabase } = await import('../../src/db.js');
     try { closeDatabase(); } catch { /* already closed */ }
     delete process.env.MEMESH_DB_PATH;
-    rmSync(tmpHome, { recursive: true, force: true });
+    rmSync(tmpHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   });
 
   it('seeds 30 entities all flagged metadata.demo = true', async () => {

--- a/tests/core/doctor.test.ts
+++ b/tests/core/doctor.test.ts
@@ -166,7 +166,7 @@ const tempRoots: string[] = [];
 
 afterEach(() => {
   for (const root of tempRoots.splice(0)) {
-    fs.rmSync(root, { recursive: true, force: true });
+    fs.rmSync(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   }
 });
 

--- a/tests/core/dreamer.test.ts
+++ b/tests/core/dreamer.test.ts
@@ -27,7 +27,7 @@ describe('dreamer', () => {
     try { closeDatabase(); } catch { /* already closed */ }
     delete process.env.MEMESH_DB_PATH;
     delete process.env.MEMESH_DIR;
-    rmSync(tmpHome, { recursive: true, force: true });
+    rmSync(tmpHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   });
 
   function seedCommits(count: number, project = 'memesh'): number[] {

--- a/tests/core/embedder.test.ts
+++ b/tests/core/embedder.test.ts
@@ -22,7 +22,7 @@ describe('Embedder', () => {
   afterEach(() => {
     try { closeDatabase(); } catch {}
     if (testDir) {
-      fs.rmSync(testDir, { recursive: true, force: true });
+      fs.rmSync(testDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
       testDir = undefined;
     }
   });

--- a/tests/core/extractor.test.ts
+++ b/tests/core/extractor.test.ts
@@ -69,7 +69,7 @@ describe('RuleBasedExtractor: memory extraction', () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   });
 
   function writeTranscript(entries: object[]): void {
@@ -258,7 +258,7 @@ describe('parseTranscript', () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   });
 
   function writeLine(filePath: string, entries: object[]): void {

--- a/tests/core/install-id.test.ts
+++ b/tests/core/install-id.test.ts
@@ -28,7 +28,7 @@ describe('install-id', () => {
   afterEach(() => {
     if (originalEnv === undefined) delete process.env.MEMESH_DIR;
     else process.env.MEMESH_DIR = originalEnv;
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   });
 
   async function freshModule() {

--- a/tests/core/integration.test.ts
+++ b/tests/core/integration.test.ts
@@ -23,7 +23,7 @@ beforeEach(() => {
 afterEach(() => {
   closeDatabase();
   delete process.env.MEMESH_DB_PATH;
-  fs.rmSync(tmpDir, { recursive: true, force: true });
+  fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
 });
 
 // ── remember → recall → verify observations ────────────────────────────────
@@ -192,7 +192,7 @@ describe('Integration: export → import round-trip', () => {
 
     // Clean up import dir
     closeDatabase();
-    fs.rmSync(importDir, { recursive: true, force: true });
+    fs.rmSync(importDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
 
     // Re-open original DB for afterEach cleanup
     process.env.MEMESH_DB_PATH = path.join(tmpDir, 'test.db');

--- a/tests/core/kg-backfill-integration.test.ts
+++ b/tests/core/kg-backfill-integration.test.ts
@@ -34,7 +34,7 @@ describe('KG backfill — integration: orphan rate reduction', () => {
     try { closeDatabase(); } catch { /* already closed */ }
     if (prevDbPath === undefined) delete process.env.MEMESH_DB_PATH;
     else process.env.MEMESH_DB_PATH = prevDbPath;
-    fs.rmSync(testDir, { recursive: true, force: true });
+    fs.rmSync(testDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   });
 
   it('reduces orphan rate below 50% on a mixed 50-entity seed', () => {

--- a/tests/core/kg-backfill.test.ts
+++ b/tests/core/kg-backfill.test.ts
@@ -111,7 +111,7 @@ describe('kg-backfill integration', () => {
     try { closeDatabase(); } catch { /* already closed */ }
     if (prevDbPath === undefined) delete process.env.MEMESH_DB_PATH;
     else process.env.MEMESH_DB_PATH = prevDbPath;
-    fs.rmSync(testDir, { recursive: true, force: true });
+    fs.rmSync(testDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   });
 
   // ---------------------------------------------------------------------------

--- a/tests/core/llm-telemetry.test.ts
+++ b/tests/core/llm-telemetry.test.ts
@@ -36,7 +36,7 @@ describe('llm-telemetry persistence + summarise', () => {
     try { closeDatabase(); } catch { /* already closed */ }
     if (prevDbPath === undefined) delete process.env.MEMESH_DB_PATH;
     else process.env.MEMESH_DB_PATH = prevDbPath;
-    fs.rmSync(testDir, { recursive: true, force: true });
+    fs.rmSync(testDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   });
 
   it('records a single successful primary attempt — fallback_used = 0', () => {

--- a/tests/core/memory-tool.test.ts
+++ b/tests/core/memory-tool.test.ts
@@ -47,7 +47,7 @@ describe('Feature: memory_20250818 over the knowledge graph', () => {
     try { closeDatabase(); } catch { /* already closed */ }
     if (savedMemeshDir === undefined) delete process.env.MEMESH_DIR;
     else process.env.MEMESH_DIR = savedMemeshDir;
-    fs.rmSync(dir, { recursive: true, force: true });
+    fs.rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   });
 
   function seed(name: string, observations: string[], namespace = 'personal'): void {

--- a/tests/core/node-runtime-check.test.ts
+++ b/tests/core/node-runtime-check.test.ts
@@ -81,7 +81,7 @@ describe('doctor: Node runtime row', () => {
   });
 
   afterEach(() => {
-    fs.rmSync(dir, { recursive: true, force: true });
+    fs.rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   });
 
   /** A real package.json on disk — the row reads a file, so give it one. */
@@ -197,7 +197,7 @@ describe('the row reaches the report a user actually sees', () => {
       expect(out).toContain(`Node ${process.version}`);
       expect(out).toContain('node:sqlite');
     } finally {
-      fs.rmSync(home, { recursive: true, force: true });
+      fs.rmSync(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
     }
   });
 });

--- a/tests/core/pm-analytics.test.ts
+++ b/tests/core/pm-analytics.test.ts
@@ -32,7 +32,7 @@ describe('computePmAnalytics', () => {
     try { closeDatabase(); } catch { /* already closed */ }
     if (prevDbPath === undefined) delete process.env.MEMESH_DB_PATH;
     else process.env.MEMESH_DB_PATH = prevDbPath;
-    fs.rmSync(testDir, { recursive: true, force: true });
+    fs.rmSync(testDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   });
 
   const insertEntity = (name: string, type: string, daysAgo = 0, lastAccessedDaysAgo?: number): number => {

--- a/tests/core/project-identity.test.ts
+++ b/tests/core/project-identity.test.ts
@@ -64,7 +64,7 @@ describe('getProjectName — layered git identity', () => {
   const created: string[] = [];
   beforeEach(() => _clearProjectNameCache());
   afterEach(() => {
-    for (const d of created.splice(0)) fs.rmSync(d, { recursive: true, force: true });
+    for (const d of created.splice(0)) fs.rmSync(d, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   });
 
   it('uses the git remote slug, not the directory name (location-independent)', () => {

--- a/tests/core/skill-usage-log.test.ts
+++ b/tests/core/skill-usage-log.test.ts
@@ -13,7 +13,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  fs.rmSync(tmpDir, { recursive: true, force: true });
+  fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
 });
 
 describe('skill-usage-log: logSkillEvent', () => {

--- a/tests/core/verifier.test.ts
+++ b/tests/core/verifier.test.ts
@@ -41,8 +41,8 @@ beforeEach(() => {
 
 afterEach(() => {
   closeDatabase();
-  fs.rmSync(tmpDbDir, { recursive: true, force: true });
-  fs.rmSync(tmpRepo, { recursive: true, force: true });
+  fs.rmSync(tmpDbDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+  fs.rmSync(tmpRepo, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
 });
 
 describe('verifyAgentWork — reality check', () => {
@@ -280,7 +280,7 @@ describe('verifyAgentWork — error paths', () => {
         workdir: nonGit,
       })).toThrow(/not a git working tree/);
     } finally {
-      fs.rmSync(nonGit, { recursive: true, force: true });
+      fs.rmSync(nonGit, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
     }
   });
 
@@ -309,7 +309,7 @@ describe('verifyAgentWork — error paths', () => {
         workdir: filePath,
       })).toThrow(/not a directory/);
     } finally {
-      fs.rmSync(tmp, { recursive: true, force: true });
+      fs.rmSync(tmp, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
     }
   });
 
@@ -380,7 +380,7 @@ describe('verifyAgentWork — workdir handling (subdir + symlink, codex 2026-05-
       expect(result.entity_name).toMatch(/^verification:symlink:/);
     } finally {
       try { fs.unlinkSync(linkPath); } catch { /* ignore */ }
-      fs.rmSync(linkParent, { recursive: true, force: true });
+      fs.rmSync(linkParent, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
     }
   });
 });
@@ -427,7 +427,7 @@ describe('a claim that could not be evaluated is not a pass', () => {
       // So the answer is "I could not check that", not "it passed".
       expect(result.verdict).toBe('unverified');
     } finally {
-      fs.rmSync(repo, { recursive: true, force: true });
+      fs.rmSync(repo, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
     }
   });
 
@@ -444,7 +444,7 @@ describe('a claim that could not be evaluated is not a pass', () => {
       });
       expect(result.verdict).toBe('pass');
     } finally {
-      fs.rmSync(repo, { recursive: true, force: true });
+      fs.rmSync(repo, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
     }
   });
 });

--- a/tests/db-open-and-archived-search.test.ts
+++ b/tests/db-open-and-archived-search.test.ts
@@ -35,7 +35,7 @@ describe('Feature: a failed open does not poison the process', () => {
 
   afterEach(() => {
     try { closeDatabase(); } catch { /* already closed */ }
-    fs.rmSync(dir, { recursive: true, force: true });
+    fs.rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   });
 
   it('a failed open leaves nothing behind, and the retry is fully initialised', () => {
@@ -111,7 +111,7 @@ describe('Feature: archived search answers the same question as active search', 
 
   afterEach(() => {
     try { closeDatabase(); } catch { /* already closed */ }
-    fs.rmSync(dir, { recursive: true, force: true });
+    fs.rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   });
 
   it('finds a decomposed memory after it is archived', () => {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -17,7 +17,7 @@ describe('Feature: Database Management', () => {
 
   afterEach(() => {
     try { closeDatabase(); } catch {}
-    fs.rmSync(testDir, { recursive: true, force: true });
+    fs.rmSync(testDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   });
 
   describe('Scenario: Open database for first time', () => {

--- a/tests/fts-segmentation-doctor.test.ts
+++ b/tests/fts-segmentation-doctor.test.ts
@@ -60,7 +60,7 @@ describe('Feature: doctor detects a stale (unsegmented) keyword index', () => {
 
   afterEach(() => {
     try { closeDatabase(); } catch { /* already closed */ }
-    fs.rmSync(dir, { recursive: true, force: true });
+    fs.rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   });
 
   /** How many unsegmented runs doctor would report. 0 means "healthy". */

--- a/tests/helpers/db-fixture.ts
+++ b/tests/helpers/db-fixture.ts
@@ -9,7 +9,7 @@
 //   });
 //   afterEach(() => {
 //     closeDatabase();
-//     fs.rmSync(tmpDir, { recursive: true, force: true });
+//     fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
 //   });
 //
 // This helper folds that into one call per file. The closure also
@@ -55,7 +55,18 @@ export function useTestDatabase(prefix = 'memesh-test-'): TestDbHandle {
   afterEach(() => {
     try { closeDatabase(); } catch { /* already closed */ }
     if (_tmpDir) {
-      fs.rmSync(_tmpDir, { recursive: true, force: true });
+      try {
+        // `maxRetries` is the documented Windows mitigation: SQLite leaves
+        // -wal/-shm beside the database and a handle can still be open for a
+        // moment after close, which surfaces as EBUSY/EPERM.
+        fs.rmSync(_tmpDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+      } catch {
+        // A temp directory that will not delete is the operating system's
+        // problem, not the test's. It sits under os.tmpdir() and gets swept by
+        // the platform; failing the test over it turns a machine-local file
+        // lock into a red build on an unrelated change, which is exactly what
+        // happened on windows-latest in a docs-only pull request.
+      }
       _tmpDir = null;
     }
   });

--- a/tests/hooks/config-precedence.test.ts
+++ b/tests/hooks/config-precedence.test.ts
@@ -52,7 +52,7 @@ afterEach(() => {
   else process.env.HOME = savedHome;
   if (savedUserProfile === undefined) delete process.env.USERPROFILE;
   else process.env.USERPROFILE = savedUserProfile;
-  fs.rmSync(tmpDir, { recursive: true, force: true });
+  fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
 });
 
 describe('isAgenticOrchestrationEnabled — env > config > default(false)', () => {

--- a/tests/hooks/dream-auto-trigger.test.ts
+++ b/tests/hooks/dream-auto-trigger.test.ts
@@ -30,7 +30,7 @@ describe("Feature: Stop-hook dream auto-trigger", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(testDir, { recursive: true, force: true });
+    fs.rmSync(testDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   });
 
   function writeConfig(cfg: object): void {

--- a/tests/hooks/hook-fts-migration.test.ts
+++ b/tests/hooks/hook-fts-migration.test.ts
@@ -40,7 +40,7 @@ describe('Feature: hooks migrate the keyword index too', () => {
   });
 
   afterEach(() => {
-    fs.rmSync(dir, { recursive: true, force: true });
+    fs.rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   });
 
   /** Open the way a hook does. */

--- a/tests/hooks/hook-output-contract.test.ts
+++ b/tests/hooks/hook-output-contract.test.ts
@@ -156,7 +156,7 @@ describe('Feature: Claude Code hook-output contract', () => {
   });
 
   afterEach(() => {
-    fs.rmSync(testDir, { recursive: true, force: true });
+    fs.rmSync(testDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   });
 
   // Seed memories into the test DB via the real CLI so the schema matches

--- a/tests/hooks/mirror-parity.test.ts
+++ b/tests/hooks/mirror-parity.test.ts
@@ -74,7 +74,7 @@ describe('F5 mirror parity: scripts/hooks/_shared.js vs src/core', () => {
         process.env.HOME = tmpHome;
         expect(shared.memeshDir()).toBe(coreMemeshDir());
       } finally {
-        fs.rmSync(tmpHome, { recursive: true, force: true });
+        fs.rmSync(tmpHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
       }
     });
 
@@ -91,7 +91,7 @@ describe('F5 mirror parity: scripts/hooks/_shared.js vs src/core', () => {
         process.env.MEMESH_DB_PATH = override;
         expect(shared.getDbPath()).toBe(coreGetDbPath());
       } finally {
-        fs.rmSync(tmpHome, { recursive: true, force: true });
+        fs.rmSync(tmpHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
       }
     });
 
@@ -106,7 +106,7 @@ describe('F5 mirror parity: scripts/hooks/_shared.js vs src/core', () => {
         delete process.env.MEMESH_DB_PATH;
         expect(shared.getMemeshDirFromDbPath()).toBe(coreGetMemeshDirFromDbPath());
       } finally {
-        fs.rmSync(tmpHome, { recursive: true, force: true });
+        fs.rmSync(tmpHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
       }
     });
 
@@ -125,7 +125,7 @@ describe('F5 mirror parity: scripts/hooks/_shared.js vs src/core', () => {
       tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memesh-parity-fts-'));
     });
     afterEach(() => {
-      fs.rmSync(tmpDir, { recursive: true, force: true });
+      fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
     });
 
     /** Open a fresh hook DB (creates entities/observations/tags/entities_fts). */

--- a/tests/hooks/plugin-root-and-drift.test.ts
+++ b/tests/hooks/plugin-root-and-drift.test.ts
@@ -127,8 +127,8 @@ describe('readHookConfig — homedir is canonical, MEMESH_DB_PATH does not redir
     else process.env.HOME = savedHome;
     if (savedUserProfile === undefined) delete process.env.USERPROFILE;
     else process.env.USERPROFILE = savedUserProfile;
-    fs.rmSync(homeDir, { recursive: true, force: true });
-    fs.rmSync(dbDir, { recursive: true, force: true });
+    fs.rmSync(homeDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+    fs.rmSync(dbDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   });
 
   function writeHomeConfig(obj: Record<string, unknown>) {

--- a/tests/hooks/post-commit.test.ts
+++ b/tests/hooks/post-commit.test.ts
@@ -17,7 +17,7 @@ describe('Feature: Post-Commit Hook', () => {
   });
 
   afterEach(() => {
-    fs.rmSync(testDir, { recursive: true, force: true });
+    fs.rmSync(testDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   });
 
   function runHook(input: object): void {

--- a/tests/hooks/pre-bash-orchestration-nudge.test.ts
+++ b/tests/hooks/pre-bash-orchestration-nudge.test.ts
@@ -19,7 +19,7 @@ describe('Feature: Pre-Bash Orchestration Nudge Hook', () => {
   });
 
   afterEach(() => {
-    fs.rmSync(testDir, { recursive: true, force: true });
+    fs.rmSync(testDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   });
 
   /**

--- a/tests/hooks/pre-compact.test.ts
+++ b/tests/hooks/pre-compact.test.ts
@@ -18,7 +18,7 @@ describe('Feature: PreCompact Hook', () => {
   });
 
   afterEach(() => {
-    fs.rmSync(testDir, { recursive: true, force: true });
+    fs.rmSync(testDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   });
 
   function runHook(input: object, env: Record<string, string> = {}): string {

--- a/tests/hooks/pre-edit-recall.test.ts
+++ b/tests/hooks/pre-edit-recall.test.ts
@@ -20,7 +20,7 @@ describe('Feature: Pre-Edit Recall Hook', () => {
   });
 
   afterEach(() => {
-    fs.rmSync(testDir, { recursive: true, force: true });
+    fs.rmSync(testDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   });
 
   // Pass cwd: testDir (a non-git tmp dir) so getProjectName resolves via the

--- a/tests/hooks/session-start.test.ts
+++ b/tests/hooks/session-start.test.ts
@@ -20,7 +20,7 @@ describe('Feature: Session Start Hook', () => {
   });
 
   afterEach(() => {
-    fs.rmSync(testDir, { recursive: true, force: true });
+    fs.rmSync(testDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   });
 
   function runHook(input: object, env: Record<string, string> = {}): Record<string, unknown> {

--- a/tests/hooks/session-summary.test.ts
+++ b/tests/hooks/session-summary.test.ts
@@ -19,7 +19,7 @@ describe('Feature: Session Summary (Stop Hook)', () => {
   });
 
   afterEach(() => {
-    fs.rmSync(testDir, { recursive: true, force: true });
+    fs.rmSync(testDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   });
 
   function writeTranscript(entries: object[]): void {

--- a/tests/hooks/user-prompt-intent.test.ts
+++ b/tests/hooks/user-prompt-intent.test.ts
@@ -282,7 +282,7 @@ describe('Feature: User Prompt Intent Hook', () => {
     });
 
     afterEach(() => {
-      rmSync(tmpHome, { recursive: true, force: true });
+      rmSync(tmpHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
     });
 
     function runHook(input: object | string, extraEnv: NodeJS.ProcessEnv = {}) {

--- a/tests/hooks/write-hook-invariants.test.ts
+++ b/tests/hooks/write-hook-invariants.test.ts
@@ -28,7 +28,7 @@ describe('write-hook invariants (fake-working gates)', () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   });
 
   it('captureEntity keeps entities_fts in sync, so hook-written memories are FTS-recallable', () => {

--- a/tests/knowledge-graph-batch.test.ts
+++ b/tests/knowledge-graph-batch.test.ts
@@ -19,7 +19,7 @@ describe('KnowledgeGraph batch hydration', () => {
   afterEach(() => {
     closeDatabase();
     delete process.env.MEMESH_DB_PATH;
-    fs.rmSync(testDir, { recursive: true, force: true });
+    fs.rmSync(testDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   });
 
   it('returns empty array for empty ids', () => {

--- a/tests/knowledge-graph.test.ts
+++ b/tests/knowledge-graph.test.ts
@@ -29,7 +29,7 @@ describe('Feature: Knowledge Graph', () => {
     try {
       closeDatabase();
     } catch {}
-    fs.rmSync(testDir, { recursive: true, force: true });
+    fs.rmSync(testDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   });
 
   describe('Remember (Create)', () => {

--- a/tests/migration-atomicity.test.ts
+++ b/tests/migration-atomicity.test.ts
@@ -43,7 +43,7 @@ describe('Feature: index migration atomicity', () => {
 
   afterEach(() => {
     try { closeDatabase(); } catch { /* already closed */ }
-    fs.rmSync(dir, { recursive: true, force: true });
+    fs.rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   });
 
   /** Put the database back into the pre-segmentation state. */

--- a/tests/recall-empty-query-vectors.test.ts
+++ b/tests/recall-empty-query-vectors.test.ts
@@ -66,7 +66,7 @@ describe('Feature: an unsearchable query reaches no vector supplement', () => {
 
   afterEach(() => {
     try { closeDatabase(); } catch { /* already closed */ }
-    fs.rmSync(dir, { recursive: true, force: true });
+    fs.rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   });
 
   it.each([['???'], ['@#$%'], ['🎉'], ['...']])(

--- a/tests/recall-hits-instrumentation.test.ts
+++ b/tests/recall-hits-instrumentation.test.ts
@@ -49,7 +49,7 @@ describe('recall_hits ownership', () => {
   afterEach(() => {
     try { db?.close(); } catch { /* already closed */ }
     delete process.env.MEMESH_DB_PATH;
-    rmSync(tmpHome, { recursive: true, force: true });
+    rmSync(tmpHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   });
 
   function getHits(name: string): number {

--- a/tests/reindex-reports-what-happened.test.ts
+++ b/tests/reindex-reports-what-happened.test.ts
@@ -112,7 +112,7 @@ describe('Feature: reindex reports what it actually wrote', () => {
     else process.env.MEMESH_DIR = savedMemeshDir;
     if (savedKey === undefined) delete process.env.OPENAI_API_KEY;
     else process.env.OPENAI_API_KEY = savedKey;
-    fs.rmSync(dir, { recursive: true, force: true });
+    fs.rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   });
 
   it('a run that writes nothing is not reported as a run that embedded everything', async () => {

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -16,7 +16,7 @@ beforeEach(() => {
 
 afterEach(() => {
   closeDatabase();
-  fs.rmSync(tmpDir, { recursive: true, force: true });
+  fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
 });
 
 // ── Remember ────────────────────────────────────────────────────────────

--- a/tests/transports/analytics.test.ts
+++ b/tests/transports/analytics.test.ts
@@ -17,7 +17,7 @@ beforeEach(() => {
 
 afterEach(() => {
   closeDatabase();
-  fs.rmSync(tmpDir, { recursive: true, force: true });
+  fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
 });
 
 // ── Analytics computation ──────────────────────────────────────────────────

--- a/tests/transports/cli-config-list.test.ts
+++ b/tests/transports/cli-config-list.test.ts
@@ -22,7 +22,7 @@ describe('memesh config list', () => {
   });
 
   afterEach(() => {
-    fs.rmSync(home, { recursive: true, force: true });
+    fs.rmSync(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   });
 
   function runList(config: object): string {

--- a/tests/transports/dream-http.test.ts
+++ b/tests/transports/dream-http.test.ts
@@ -36,7 +36,7 @@ afterAll(async () => {
   });
   closeDatabase();
   delete process.env.MEMESH_UPDATE_CHECK_PATH;
-  fs.rmSync(tmpDir, { recursive: true, force: true });
+  fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
 });
 
 async function req(method: string, urlPath: string, body?: unknown): Promise<{ status: number; body: any }> {

--- a/tests/transports/http.test.ts
+++ b/tests/transports/http.test.ts
@@ -32,7 +32,7 @@ afterAll(async () => {
   });
   closeDatabase();
   delete process.env.MEMESH_UPDATE_CHECK_PATH;
-  fs.rmSync(tmpDir, { recursive: true, force: true });
+  fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
 });
 
 // ── Helper ───────────────────────────────────────────────────────────────────
@@ -522,7 +522,7 @@ describe('HTTP Transport: startServer host guard', () => {
       else process.env.MEMESH_DB_PATH = previousDbPath;
       if (previousToken === undefined) delete process.env.MEMESH_REMOTE_TOKEN;
       else process.env.MEMESH_REMOTE_TOKEN = previousToken;
-      fs.rmSync(remoteTmpDir, { recursive: true, force: true });
+      fs.rmSync(remoteTmpDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
     }
   });
 
@@ -578,7 +578,7 @@ describe('HTTP Transport: startServer host guard', () => {
       else process.env.MEMESH_DB_PATH = previousDbPath;
       if (previousToken === undefined) delete process.env.MEMESH_REMOTE_TOKEN;
       else process.env.MEMESH_REMOTE_TOKEN = previousToken;
-      fs.rmSync(remoteTmpDir, { recursive: true, force: true });
+      fs.rmSync(remoteTmpDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
     }
   });
 });
@@ -626,7 +626,7 @@ describe('HTTP Transport: Startup validation', () => {
     } finally {
       if (previousDbPath === undefined) delete process.env.MEMESH_DB_PATH;
       else process.env.MEMESH_DB_PATH = previousDbPath;
-      fs.rmSync(badTmpDir, { recursive: true, force: true });
+      fs.rmSync(badTmpDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
       // Reopen the original db so subsequent tests in afterAll can closeDatabase
       // and so other concurrent tests are not affected.
       openDatabase(path.join(tmpDir, 'test.db'));
@@ -656,7 +656,7 @@ describe('HTTP Transport: Startup validation', () => {
       closeDatabase();
       if (previousDbPath === undefined) delete process.env.MEMESH_DB_PATH;
       else process.env.MEMESH_DB_PATH = previousDbPath;
-      fs.rmSync(portTmpDir, { recursive: true, force: true });
+      fs.rmSync(portTmpDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
     }
   });
 });

--- a/tests/vector-index-safety.test.ts
+++ b/tests/vector-index-safety.test.ts
@@ -58,7 +58,7 @@ describe('Feature: an unreadable config does not delete embeddings', () => {
     stderrSpy.mockRestore();
     if (savedMemeshDir === undefined) delete process.env.MEMESH_DIR;
     else process.env.MEMESH_DIR = savedMemeshDir;
-    fs.rmSync(dir, { recursive: true, force: true });
+    fs.rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   });
 
   function storedDimension(): number | undefined {

--- a/tests/version-check.test.ts
+++ b/tests/version-check.test.ts
@@ -113,7 +113,7 @@ describe('version check', () => {
   });
 
   afterEach(() => {
-    fs.rmSync(testDir, { recursive: true, force: true });
+    fs.rmSync(testDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   });
 
   it('writes successful fresh checks to cache', async () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -23,7 +23,18 @@ export default defineConfig({
 
     // Force test timeout to prevent hanging
     testTimeout: 30000, // 30 seconds max per test
-    hookTimeout: 10000, // 10 seconds for hooks
+    // 30s, not 10s. Every DB test's afterEach closes SQLite and recursively
+    // removes a temp directory, and on Windows that is routinely slower than
+    // on POSIX — SQLite leaves -wal/-shm beside the database, and the OS (plus
+    // whatever scans files on a CI runner) can hold a handle open for a moment
+    // after close. Measured: `tests/core/export-import.test.ts` hit
+    // "Hook timed out in 10000ms" on windows-latest / Node 24 in CI, in a
+    // docs-only pull request. The removal was not failing, it was slow; a
+    // budget that only fits the fastest platform turns that into a red build
+    // on an unrelated change. The retries added alongside this (maxRetries /
+    // retryDelay on every recursive rmSync in tests/) handle the other half —
+    // a handle that is briefly still open.
+    hookTimeout: 30000,
 
     // Environment configuration
     environment: 'node',


### PR DESCRIPTION
## What happened

A pull request that changed **only `CHANGELOG.md`** went red on `windows-latest`:

```
FAIL tests/core/export-import.test.ts > exportMemories > respects limit
Error: Hook timed out in 10000ms.
  at useTestDatabase tests/helpers/db-fixture.ts:55:3
```

## Not a flake to re-run

`hookTimeout: 10000` fits POSIX and does not fit Windows. Every DB test's `afterEach` closes SQLite and recursively removes a temp directory; SQLite leaves `-wal`/`-shm` beside the database, and the OS — plus whatever scans files on a CI runner — can hold a handle open for a moment after close.

**The removal was not failing. It was slow.** A budget that only fits the fastest platform turns that into a red build on a change that touched no code.

## Two causes, two halves

| Cause | Fix |
|---|---|
| removals that **succeed but are slow** | `hookTimeout` 10s → 30s |
| a handle **briefly still open** (`EBUSY`/`EPERM`) | every recursive `rmSync` in `tests/` now passes `maxRetries: 5, retryDelay: 100` — the documented Windows mitigation. **74 call sites; exactly one already had it**, which is its own evidence that someone hit this before and fixed it in one place only. |

The shared DB fixture additionally treats a failed removal as **non-fatal**. A directory under `os.tmpdir()` that will not delete is the operating system's problem and gets swept by the platform; failing a test over it turns a machine-local file lock into a red build — which is the defect being fixed, not a different one.

## Why this is systematic, not one bad test

Three instances now, on three different files:

| Where | Symptom |
|---|---|
| local | `tests/cli/remember-quick.test.ts` — 81s |
| local | `tests/hooks/hook-output-contract.test.ts` — 30s |
| **CI, windows-latest / Node 24** | `tests/core/export-import.test.ts` — hook timeout at 10s |

I flagged the first two earlier as intermittent and did not act. CI producing a third on a third file is what makes it a class.

## Verification

```
node scripts/run-tests-isolated.mjs -> 98 files, 1415 tests passed (253.62s)
npm run typecheck / lint            -> exit 0
```

**The platform this fixes is Windows, so CI on this PR is the real check** — a green local run on macOS proves only that nothing regressed.

Blocks #98 (the 4.2.11 release), which is the PR that went red.
