### PR TITLE
ci: delete the develop branch and stop re-running the matrix on it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,19 @@ name: CI
 
 on:
   push:
-    branches: [main, develop]
+    # `main` is the only long-lived branch. `develop` used to be listed here
+    # and was deleted along with this line: it had been fast-forwarded from
+    # `main` after every merge and never merged into, so every sync re-tested a
+    # byte-for-byte identical tree — 10 jobs, on a matrix whose slowest leg has
+    # taken over 13 minutes. Free on a public repo (GitHub reports
+    # `billable.duration_ms = 0` for every leg), which is exactly why it went
+    # unnoticed: the currency here is wall-clock feedback time and queue slots,
+    # not money.
+    #
+    # Pull requests are unaffected — the `pull_request` trigger below has no
+    # branch filter, deliberately, so a PR based on another feature branch is
+    # still built and tested.
+    branches: [main]
   # Every pull request, not only the ones landing on main/develop.
   #
   # The filter used to be `branches: [main, develop]`, which reads as "test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to MeMesh are documented here.
 
 ## [Unreleased]
 
+### Changed
+
+- **`develop` is gone, and CI no longer re-runs the whole matrix on it** (`.github/workflows/ci.yml`, `CLAUDE.md`) — the branch was fast-forwarded from `main` after every merge and never merged into, so every sync re-tested a byte-for-byte identical tree: **10 jobs**, on a matrix whose slowest leg has taken over 13 minutes. Free on a public repo — GitHub reports `billable.duration_ms = 0` for every leg — which is exactly why it went unnoticed; the currency is wall-clock feedback time and queue slots, not money.
+
+  Keeping it as a passive mirror was the first answer and deleting it is the better one: a branch that only ever receives a copy of `main` answers no question that a git tag or `CHANGELOG.md`'s `[Unreleased]` section does not already answer. `main` is now the only long-lived branch. Pull requests are unaffected — the `pull_request` trigger has no branch filter, deliberately, so a PR based on another feature branch is still built and tested.
+
+
 ### Performance
 
 - **The test suite went from 253s to 40s, because every isolated HOME was re-downloading a 98 MB model** (`src/core/embedder.ts`, `scripts/run-tests-isolated.mjs`, `.github/workflows/ci.yml`) — the local embedding model `all-MiniLM-L6-v2` caches at `~/.memesh/models`, which is right for a real install and wrong for anything that isolates `HOME`. Six test files spawn the CLI or a hook under a per-test `HOME`, so each of those tests fetched the whole model from HuggingFace again.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,16 +60,16 @@ have passed while the thing they guarded was removed.
 ### Git
 
 - **Short-lived branch → PR → `main`. Never push directly to `main`.** That is
-  the whole flow; branch protection enforces it. `develop` is a passive mirror
-  of `main`, kept for anyone whose tooling expects it — it is not a stage work
-  passes through, and nothing is ever merged *into* it. This used to read
+  the whole flow, and `main` is the only long-lived branch. This used to read
   "`main` ← `develop`", which described git-flow: a model for software with
   several release lines under support at once, and one whose own author now
   warns against using it for continuously delivered projects. Nothing here has
   release lines, and the branch proved it — `develop` sat 58 commits behind
   `main` and 0 ahead, through four releases, while every PR went straight to
-  `main`. A rule nobody follows and nothing enforces is worse than no rule: it
-  makes this file lie to whoever reads it next.
+  `main`. It was kept briefly as a passive mirror and then deleted: a branch
+  that only ever receives a copy of `main` answers no question that a tag or
+  `CHANGELOG.md` does not already answer, and it cost a full matrix re-run on
+  every sync.
 - Releases are tags on `main`. "Merged but not yet published" is answered by
   `CHANGELOG.md`'s `[Unreleased]` section, which is why a branch does not need
   to answer it.


### PR DESCRIPTION
`develop` was fast-forwarded from `main` after every merge and never merged into, so **every sync re-tested a byte-for-byte identical tree** — 10 jobs, on a matrix whose slowest leg has taken over 13 minutes.

Free on a public repo (GitHub reports `billable.duration_ms = 0` for every leg), which is exactly why it went unnoticed: the currency is wall-clock feedback time and queue slots, not money.

## Mirror, or delete?

Keeping it as a passive mirror was the first answer. Deleting it is the better one — a branch that only ever receives a copy of `main` answers no question that a git tag or `CHANGELOG.md`'s `[Unreleased]` section does not already answer. `main` is now the only long-lived branch, which is what the flow has actually been for months.

`CLAUDE.md`'s git section is updated to match; it described `develop` as a passive mirror one commit ago.

## Pull requests are unaffected

The `pull_request` trigger has no branch filter, deliberately — a PR based on another feature branch still gets built and tested, which was itself a fix.

## Outside the diff

The remote branch and its protection rule are repository state, not files. They are removed separately and reported explicitly.

## Verification

```
node scripts/run-tests-isolated.mjs -> 99 files, 1420 tests passed (38.63s)
bash scripts/verify-docs-sync.sh    -> exit 0
node scripts/check-version-coherence.mjs -> exit 0
```

The real check for a trigger change is that this PR's own CI runs at all — via the `pull_request` path.