### PR TITLE
ci: harden the workflows — leaked-token surface, hung jobs, racing runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,12 +105,38 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ matrix.node }}
           cache: 'npm'
+
+      # The ~98 MB ONNX embedding model, cached across runs.
+      #
+      # Six test files spawn the CLI or a hook under a per-test HOME, and the
+      # model caches per-HOME by default — so before MEMESH_MODEL_CACHE_DIR
+      # existed, every one of those tests fetched the whole model again, on
+      # every leg of this matrix. That is fixed; this step removes what is left:
+      # the FIRST download per run, and with it the last hard dependency on
+      # huggingface.co being reachable. Without the cache, a HuggingFace outage
+      # turns the entire matrix red with nothing wrong in the code, and nothing
+      # in the failure output says so.
+      #
+      # `actions/cache` is first-party GitHub, the same trust level as the
+      # checkout and setup-node actions already pinned above, and is pinned by
+      # commit SHA for the same reason they are.
+      #
+      # A cache miss is not a failure: the model downloads as before and the
+      # step saves it for next time. The key carries the model id, so changing
+      # the model invalidates it rather than silently serving the old weights.
+      - name: Cache the local embedding model
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ${{ github.workspace }}/.memesh-model-cache
+          key: onnx-Xenova-all-MiniLM-L6-v2-${{ runner.os }}-v1
 
       - name: Install dependencies
         run: npm ci
@@ -205,6 +231,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -229,6 +257,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -261,6 +291,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,10 +12,18 @@ on:
   schedule:
     - cron: '0 0 * * 1'
 
+# Supersede an in-flight run when a new commit arrives on the same ref.
+# Without this, pushing three times in a minute leaves three full runs
+# competing for runners and only the last one's result matters.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       actions: read
       contents: read
@@ -32,6 +40,8 @@ jobs:
       # resolved 2026-05-04 from refs/tags/v4. Bump together when upgrading.
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@ed410739ba306e4ebe5e123421a6bd694e494a2b # v4

--- a/.github/workflows/deprecate-npm.yml
+++ b/.github/workflows/deprecate-npm.yml
@@ -26,6 +26,7 @@ on:
 jobs:
   deprecate:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     permissions:
       contents: read

--- a/.github/workflows/multi-model-review.yml
+++ b/.github/workflows/multi-model-review.yml
@@ -14,9 +14,17 @@ permissions:
   contents: read
   pull-requests: write
 
+# Supersede an in-flight run when a new commit arrives on the same ref.
+# Without this, pushing three times in a minute leaves three full runs
+# competing for runners and only the last one's result matters.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   changed-files:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       diff_size: ${{ steps.size.outputs.diff_size }}
     env:
@@ -24,6 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          persist-credentials: false
           fetch-depth: 0
       - name: Compute diff size
         id: size
@@ -36,6 +45,7 @@ jobs:
     needs: changed-files
     if: needs.changed-files.outputs.diff_size != '0'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     env:
       BASE_SHA: ${{ github.event.pull_request.base.sha }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -45,6 +55,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          persist-credentials: false
           fetch-depth: 0
       - name: Generate diff
         run: |
@@ -87,6 +98,7 @@ jobs:
     needs: changed-files
     if: needs.changed-files.outputs.diff_size != '0'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     env:
       BASE_SHA: ${{ github.event.pull_request.base.sha }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -96,6 +108,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          persist-credentials: false
           fetch-depth: 0
       - name: Generate diff
         run: |
@@ -136,6 +149,7 @@ jobs:
     needs: [claude-review, codex-review]
     if: always() && needs.changed-files.outputs.diff_size != '0'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     env:
       PR_NUMBER: ${{ github.event.pull_request.number }}
       REPO: ${{ github.repository }}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     permissions:
       contents: read
@@ -15,6 +16,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to MeMesh are documented here.
 
 ## [Unreleased]
 
+### Security
+
+- **Every `actions/checkout` now sets `persist-credentials: false`** (all five workflows, 9 steps) — by default `checkout` writes the job's `GITHUB_TOKEN` into `.git/config`, where every later step can read it. That includes `npm ci`, which in this repository **runs install scripts** (`better-sqlite3` builds a native binding) on pull-request code. A compromised dependency's postinstall could have read the token straight out of the working copy. No step here pushes with the token, so nothing needed it.
+
+### Changed
+
+- **Workflow hardening: job timeouts and concurrency where they were missing** (`.github/workflows/*.yml`) — `ci.yml` had `timeout-minutes` on all four jobs and the other four workflows had none, so a hung CodeQL analysis or a stuck review job held a runner for GitHub's six-hour default. Every job now has a budget. `codeql.yml` and `multi-model-review.yml` gained a `concurrency` group so a new commit supersedes an in-flight run instead of racing it; `publish-npm.yml` and `deprecate-npm.yml` deliberately did **not** — cancelling a publish half-way is worse than letting it finish.
+
+### Performance
+
+- **CI caches the embedding model between runs** (`.github/workflows/ci.yml`) — the shared-cache change above removed the *per-test* re-download; this removes the first one too, and with it the last hard dependency on `huggingface.co` being reachable. A HuggingFace outage would otherwise turn the entire matrix red with nothing wrong in the code, and nothing in the failure output would say so. `actions/cache` is first-party GitHub, pinned by commit SHA like the actions already in use, and a cache miss simply downloads as before.
+
+
 ### Changed
 
 - **`develop` is gone, and CI no longer re-runs the whole matrix on it** (`.github/workflows/ci.yml`, `CLAUDE.md`) — the branch was fast-forwarded from `main` after every merge and never merged into, so every sync re-tested a byte-for-byte identical tree: **10 jobs**, on a matrix whose slowest leg has taken over 13 minutes. Free on a public repo — GitHub reports `billable.duration_ms = 0` for every leg — which is exactly why it went unnoticed; the currency is wall-clock feedback time and queue slots, not money.


### PR DESCRIPTION
Read all five workflows against the checklist, not only the one that was asked about. Three gaps, plus one performance item.

## 1. The token was readable by every step, including `npm ci`

`actions/checkout` writes the job's `GITHUB_TOKEN` into `.git/config` by default. Every later step in that job can read it.

That matters more here than in most repos: **`npm ci` runs install scripts** — `better-sqlite3` builds a native binding — **on pull-request code**. A compromised dependency's `postinstall` could have read the token straight out of the working copy.

`persist-credentials: false` on all **9** checkout steps across all five workflows. No step here pushes with the token, so nothing needed it.

## 2. Seven jobs could hang for six hours

`ci.yml` had `timeout-minutes` on all four of its jobs. The other four workflows had **none**, so a hung CodeQL analysis or a stuck review job held a runner for GitHub's six-hour default.

| Workflow | Job | Budget |
|---|---|---|
| `codeql.yml` | analyze | 30 |
| `publish-npm.yml` | publish | 20 |
| `deprecate-npm.yml` | deprecate | 10 |
| `multi-model-review.yml` | changed-files | 5 |
| `multi-model-review.yml` | claude-review | 20 |
| `multi-model-review.yml` | codex-review | 20 |
| `multi-model-review.yml` | diff-findings | 10 |

## 3. Two workflows raced themselves

`concurrency` added to `codeql.yml` and `multi-model-review.yml` — a new commit now supersedes an in-flight run instead of competing with it for runners.

`publish-npm.yml` and `deprecate-npm.yml` deliberately do **not** get one: cancelling a publish half-way is worse than letting it finish.

## 4. CI no longer needs HuggingFace to be up

`actions/cache` on the ONNX model directory. #100 removed the *per-test* re-download; this removes the first one too, and with it the last hard dependency on `huggingface.co` being reachable.

Without it, a HuggingFace outage turns the **whole matrix** red with nothing wrong in the code — and nothing in the failure output says so.

`actions/cache` is first-party GitHub, the same trust level as the `checkout` and `setup-node` actions already pinned here, and is pinned by commit SHA for the same reason. A cache miss simply downloads as before and saves it for next time; the key carries the model id, so changing the model invalidates it rather than silently serving old weights.

## Deliberately not changed

**`runs-on: *-latest` stays.** Pinning runner images would make builds reproducible — and would also stop them receiving OS security updates without a human noticing. For a workflow that executes pull-request code, that is the worse failure.

## Verification

```
python3 yaml.safe_load on all five workflows -> parse OK, every job enumerated
node scripts/run-tests-isolated.mjs          -> 99 files, 1420 tests passed (40.76s)
bash scripts/verify-docs-sync.sh             -> exit 0
```

Workflow changes are only truly verified by CI running them — which is what this PR does. Check that the `Cache the local embedding model` step appears and that a second run on this branch reports a cache hit.
