### PR TITLE
docs(changelog): correct the 4.2.11 notes, and gate the state that caused them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,18 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
+          # `check-version-coherence.mjs` asks whether the version `main`
+          # declares was ever tagged, and a default checkout fetches no tags at
+          # all. The check refuses to pass on an empty tag list — "not checked"
+          # is not "no problem found" — so without this it would fail every run
+          # on main rather than silently agree with itself.
+          fetch-tags: true
+          # Measured, against this repository: `git clone --depth 1` brings down
+          # 0 of the 65 `v*` tags. Full history is 24 MB / 1667 commits and
+          # clones in 0.83s, so `fetch-depth: 0` buys certainty for a cost that
+          # does not register next to a 13-minute matrix leg — and it is not a
+          # guess about how `fetch-tags` behaves at depth 1.
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ A git tag freezes the file it points at, so the 4.2.11 notes cannot be corrected
 where they were published. They are corrected here, and whichever release ships
 next carries the corrected copy.
 
+### Added
+
+- **`main` can no longer declare a version nobody can install**
+  (`scripts/lib/published-version.mjs`, `scripts/check-version-coherence.mjs`,
+  `.github/workflows/ci.yml`) — the gate above this one asks whether the seven
+  version anchors agree with each other. They agreed with each other throughout
+  the five days `main` said `4.2.11` and npm's `latest` said `4.2.10`; agreement
+  says nothing about whether the version they agree on was ever released.
+
+  On `main`, `package.json`'s version must now have a matching `v<version>` tag.
+  The rule it enforces is that **a version bump never rides in a feature or docs
+  pull request**: `main` carries the last published version, work accumulates
+  under `[Unreleased]`, and a release bumps, tags and publishes in one sitting —
+  so the window this check is red for is minutes rather than days.
+
+  A release branch and a pull-request ref are skipped, since both legitimately
+  carry the bump before the tag exists. **An empty tag list fails rather than
+  passes**: `actions/checkout` fetches no tags by default — measured, `git clone
+  --depth 1` brings down 0 of this repository's 65 `v*` tags — and "found no
+  mismatch among zero tags" would have made the check unable to fail, which is
+  the shape of the two dead gates 4.2.11 removed. The checkout now fetches full
+  history (0.83s, against a 13-minute matrix leg).
+
+  Pinned in both directions by `tests/main-declares-published-version.test.ts`,
+  and break-tested: making the empty-tag-list branch return success kills 2 of
+  the 7 cases, and making the missing-tag branch return success kills 1.
+
 ### Fixed
 
 - **The 4.2.11 notes opened by denying their own release.** They said "4.2.11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,422 +4,675 @@ All notable changes to MeMesh are documented here.
 
 ## [Unreleased]
 
+A git tag freezes the file it points at, so the 4.2.11 notes cannot be corrected
+where they were published. They are corrected here, and whichever release ships
+next carries the corrected copy.
+
+### Fixed
+
+- **The 4.2.11 notes opened by denying their own release.** They said "4.2.11
+  was never published", which was true when the sentence was written — the
+  version had been bumped and no tag pushed — and false a few hours later, when
+  `v4.2.11` was tagged, released and published to npm as `latest`. Nothing
+  removed it before publishing.
+
+- **They gave two different sizes for the MCP surface.** One entry said nine
+  tools; the summary and the `consolidate` entry said eight. Eight is correct —
+  `consolidate` was retired in 4.2.11.
+
+- **They described CI as running on `main`/`develop`** in the same section that
+  records `develop` being deleted.
+
+- **The sample update-check response still showed 4.2.8 / 4.2.9**
+  (`docs/api/API_REFERENCE.md`).
+
+### Changed
+
+- **The 4.2.11 notes are roughly half their previous length.** They had grown
+  into an account of how the work was done — which review found what, which
+  internal gates were re-broken to test them — rather than what changed for
+  someone using MeMesh. What a reader acts on is kept in full: the breaking
+  changes, the one-time index rebuild on first open, the benchmark retraction
+  and correction, the fixes that stop embeddings being deleted, and the security
+  fixes stated as what changed.
+
 ## [4.2.11] — 2026-08-03
 
-This release exists because the headline benchmark figure was measuring the
-wrong code. `benchmarks/longmemeval/run.mjs` carried its own table creation,
-its own FTS5 query building and its own ranking, so the published **95.40% R@5**
-scored that reimplementation and not the product. Measured through the function
-a real `recall` call actually reaches, the same 500 questions scored **5.20%**,
-with 473 of them returning nothing at all. Four compounding retrieval defects
-were each hiding the others.
+This release exists because the headline benchmark figure was measuring the wrong
+code. `benchmarks/longmemeval/run.mjs` carried its own table creation, its own
+FTS5 query building and its own ranking, so the published **95.40% R@5** scored
+that reimplementation and not the product. Measured through the function a real
+`recall` call actually reaches, the same 500 questions scored **5.20%**, with 473
+of them returning nothing at all. Four compounding retrieval defects were each
+hiding the others.
 
-Everything below follows from that: the defects are fixed, the benchmark now
-runs through the shipped path, and every published claim that no longer matched
-the code has been corrected against source. The number is now **95.60%**, and it
-is the product's number.
+They are fixed, the benchmark now runs through the shipped path, and every
+published claim that no longer matched the code has been corrected against
+source. The number is **95.60%**, and it is the product's number.
 
-Auditing for the same shape turned up two more places reporting success without
-doing the work, and both are fixed here. `verify_agent_work` returned
-`pass: true` when given nothing to check against — so `memesh verify … && deploy`
-deployed on a check that never ran — and the dashboard's auth screen carried
-translation fallbacks that could never execute. The common root cause is an
-optimistic default: `?? true` and `|| 'fallback'` turn a missing input into a
-reported success, when the honest answer is "not checked".
+**Breaking changes when upgrading from 4.2.10:**
+
+- **`consolidate` is gone** — the MCP tool, `POST /v1/consolidate` and
+  `memesh consolidate`. The endpoint answers `410 Gone` and the CLI prints where
+  to go; the MCP surface is **8** tools now. See **Removed**.
+- **Node 20 is no longer supported.** `engines.node` is `>=22.5.0`.
 
 Upgrading rebuilds the full-text index once, on first open, to add CJK
 segmentation. Existing memories are re-indexed from the entity and observation
 rows, which are never touched — nothing is deleted and nothing needs re-entering.
 
-**4.2.11 was never published.** The version was bumped and this section written
-on 2026-07-29, but no `v4.2.11` tag was ever pushed and npm's `latest` stayed at
-4.2.10 — so everything below shipped to nobody. Rather than burn a version
-number on that, the work done since has been folded into the same release. The
-part written on 2026-07-29 is further down, under its own marker.
+### Added
 
-**Upgrading from 4.2.10, the two things that will change under you:**
+- **Anthropic memory tool (`memory_20250818`) backed by the knowledge graph**
+  (`src/core/memory-tool.ts`, exported from the package root) — for applications
+  that call the **Messages API directly** rather than through MCP. Claude gets a
+  memory tool whose storage is MeMesh instead of a folder of text files, so it
+  also gets FTS5 search, multi-factor ranking, auto-decay, relations and
+  namespaces without knowing they are there. Not a ninth MCP tool, and not on the
+  HTTP or CLI surface.
 
-- **`consolidate` is gone** — the MCP tool, `POST /v1/consolidate` and
-  `memesh consolidate`. The endpoint answers `410 Gone` and the CLI prints where
-  to go; the MCP surface is 8 tools now. See **Removed** below for why.
-- **Node 20 is no longer supported.** `engines.node` is `>=22.5.0`.
+  Each entity renders as one file whose lines are its observations, **ordered by
+  observation id — insertion order, never score.** `view` and the edit that
+  follows it are separate turns, and a hook can write in between; if the order
+  came from a ranking, the line numbers the model read would address different
+  content by the time it sent them back. Two behaviours differ from a filesystem
+  on purpose: `delete` **archives**, because a model asked for it and not the
+  person whose memory it is, and `str_replace` **refuses an ambiguous `old_str`**
+  and returns every match's line number rather than editing the first. Writes are
+  bounded to 256 KB per memory and 16 000 characters per `view`, and paths are
+  validated before they resolve — `..`, encoded traversal, backslashes, NUL
+  bytes, unknown namespaces and anything outside `/memories` are refused.
 
----
+- **`memesh doctor` reports the runtime it is running on** (`src/core/doctor.ts`)
+  — Node version, ABI, platform/arch, whether that version satisfies
+  `engines.node`, and whether `node:sqlite` is present. Below the supported floor
+  the row fails with an upgrade instruction; previously a user below it saw hooks
+  misbehaving and a red native-binding row with nothing naming the one fact that
+  explains both. Anything the version comparison cannot parse is reported as
+  "not checked" rather than guessed at.
 
-**Written on 2026-08-03.**
-### Security
+- **`memesh reindex --fts` rebuilds the keyword index on demand**, and
+  `memesh doctor` reports when you need it. The segmentation marker only moves
+  forward, so it cannot describe a database migrated by a newer build and then
+  written to by an older one — reachable by a downgrade, or by an npm-global and
+  a plugin-marketplace install side by side. That state was silent by
+  construction: every health signal stayed green while the affected memories were
+  unfindable by any partial-phrase query.
 
-- **Every `actions/checkout` now sets `persist-credentials: false`** (all five workflows, 9 steps) — by default `checkout` writes the job's `GITHUB_TOKEN` into `.git/config`, where every later step can read it. That includes `npm ci`, which in this repository **runs install scripts** (`better-sqlite3` builds a native binding) on pull-request code. A compromised dependency's postinstall could have read the token straight out of the working copy. No step here pushes with the token, so nothing needed it.
+- **`memesh reindex --vectors`** drops and recreates the vector table at the
+  configured dimension and immediately refills it — the supported way to switch
+  embedding provider. It refuses when no provider can actually produce a vector,
+  and refuses `--namespace` alongside it, because `entities_vec` is one table for
+  the whole database and the rebuild would drop every namespace's embeddings
+  while refilling only one.
 
 ### Changed
 
-- **Workflow hardening: job timeouts and concurrency where they were missing** (`.github/workflows/*.yml`) — `ci.yml` had `timeout-minutes` on all four jobs and the other four workflows had none, so a hung CodeQL analysis or a stuck review job held a runner for GitHub's six-hour default. Every job now has a budget. `codeql.yml` and `multi-model-review.yml` gained a `concurrency` group so a new commit supersedes an in-flight run instead of racing it; `publish-npm.yml` and `deprecate-npm.yml` deliberately did **not** — cancelling a publish half-way is worse than letting it finish.
+- **The supported Node floor is `>=22.5.0`** (`package.json`,
+  `.github/workflows/*.yml`, all 11 `README*.md` badges, `CONTRIBUTING.md`) —
+  **nothing was broken on Node 20.** It reached end of life on 2026-03-24, so the
+  package was promising a runtime that receives no security patches. `22.5.0`
+  rather than `22.0.0` because that is the release where `node:sqlite` became
+  available. CI now runs 22 and 24 on three operating systems, plus 26 on Linux;
+  a test fails the build if any workflow pins a Node below `engines.node`, or if
+  no job runs the declared floor.
 
-- **`develop` is gone, and CI no longer re-runs the whole matrix on it** (`.github/workflows/ci.yml`, `CLAUDE.md`) — the branch was fast-forwarded from `main` after every merge and never merged into, so every sync re-tested a byte-for-byte identical tree: **10 jobs**, on a matrix whose slowest leg has taken over 13 minutes. Free on a public repo — GitHub reports `billable.duration_ms = 0` for every leg — which is exactly why it went unnoticed; the currency is wall-clock feedback time and queue slots, not money.
+  Node 26 is Linux-only because `better-sqlite3@12.9.0` publishes no prebuilt
+  binary for its ABI (147). It builds from source in 18s where a toolchain
+  exists — but a plugin-marketplace install runs with `--ignore-scripts`, so
+  there is neither a prebuild to download nor a build step to run.
 
-  Keeping it as a passive mirror was the first answer and deleting it is the better one: a branch that only ever receives a copy of `main` answers no question that a git tag or `CHANGELOG.md`'s `[Unreleased]` section does not already answer. `main` is now the only long-lived branch. Pull requests are unaffected — the `pull_request` trigger has no branch filter, deliberately, so a PR based on another feature branch is still built and tested.
+- **`develop` is gone; `main` is the only long-lived branch** — it was
+  fast-forwarded from `main` after every merge and never merged into, so every
+  sync re-tested a byte-for-byte identical tree. A branch that only ever receives
+  a copy of `main` answers no question a git tag or `CHANGELOG.md`'s
+  `[Unreleased]` section does not already answer.
 
-### Performance
+- **CI runs on every pull request** (`ci.yml`, `codeql.yml`) — the `pull_request`
+  trigger carried a branch filter, so a PR stacked on another feature branch got
+  no build, no tests and no CodeQL while still collecting automated review
+  comments: reviewed, never compiled, never scanned, and indistinguishable from
+  healthy on a page of green checks.
 
-- **CI caches the embedding model between runs** (`.github/workflows/ci.yml`) — the shared-cache change above removed the *per-test* re-download; this removes the first one too, and with it the last hard dependency on `huggingface.co` being reachable. A HuggingFace outage would otherwise turn the entire matrix red with nothing wrong in the code, and nothing in the failure output would say so. `actions/cache` is first-party GitHub, pinned by commit SHA like the actions already in use, and a cache miss simply downloads as before.
+- **Workflow hardening** (`.github/workflows/*.yml`) — every job now has a
+  `timeout-minutes` budget instead of GitHub's six-hour default, and CodeQL and
+  the review workflow supersede an in-flight run when a new commit arrives. The
+  publish and deprecate workflows deliberately do not: cancelling a publish
+  half-way is worse than letting it finish.
 
-- **The test suite went from 253s to 40s, because every isolated HOME was re-downloading a 98 MB model** (`src/core/embedder.ts`, `scripts/run-tests-isolated.mjs`, `.github/workflows/ci.yml`) — the local embedding model `all-MiniLM-L6-v2` caches at `~/.memesh/models`, which is right for a real install and wrong for anything that isolates `HOME`. Six test files spawn the CLI or a hook under a per-test `HOME`, so each of those tests fetched the whole model from HuggingFace again.
+- **`verify_agent_work` reports three states, not two** (`src/core/verifier.ts`,
+  `cli.ts`, `handlers.ts`) — `pass: boolean` is replaced by
+  `verdict: 'pass' | 'fail' | 'unverified'` on both the result and its nested
+  `reality_check`. A `pass` now requires that something was actually checked;
+  `unverified` also covers the runs where the check could not look at all.
+  `memesh verify` prints `UNVERIFIED` and **exits 2**, distinct from 0 and 1, so
+  a gate written as `memesh verify … && deploy` cannot read "checked nothing" as
+  success. `pass` remains as a deprecated alias for `verdict === 'pass'`, so
+  callers upgrading from 4.2.10 keep working; both are removed together in a
+  later minor.
 
-  Measured, first write in a fresh `HOME`: **19.4s wall clock, 1.21s user, 8% CPU** — almost entirely network wait, which is why it looked like slow tests rather than a download.
+- **A query with no searchable terms returns empty** (`src/knowledge-graph.ts`) —
+  `"???"` and the like fell through to the recent list, so unmatched memories
+  came back labelled as results. A genuinely empty query still lists recent.
+  **Behaviour change.**
 
-  | | before | after |
-  |---|---|---|
-  | `tests/hooks/hook-output-contract.test.ts` | 86.4s | **3.1s** |
-  | `tests/cli/remember-quick.test.ts` | 52.5s | **2.2s** |
-  | `tests/transports/http.test.ts` | 18.2s | **1.0s** |
-  | whole suite | 253.6s | **40.0s** |
+- **The two relation types that do something are now described to the model**
+  (`handlers.ts`, `src/core/types.ts`, `docs/api/API_REFERENCE.md`) —
+  `supersedes` **archives the target entity** on write and `contradicts` makes
+  both memories surface as a conflict on every recall, and the `remember` schema
+  named neither, offering two inert examples instead. `findConflicts()` runs on
+  every recall and could therefore only ever return `[]`, which all three
+  transports render as "no conflicts" — a clean bill of health from a check whose
+  input was unreachable.
 
-  `MEMESH_MODEL_CACHE_DIR` points the cache somewhere stable; the default is unchanged. The isolated test runner and CI both set it. On CI this was being paid **on every leg of the matrix**, and it made every leg depend on HuggingFace being reachable — a third-party outage would have turned the whole matrix red with nothing wrong in the code.
+- **The `recall` MCP tool tells the model how its query will be read** — OR-joined,
+  ranked by BM25, capped at 32 terms, with ubiquitous words removed. The
+  description said only "uses FTS5 full-text search", so an agent choosing
+  between a keyword and a sentence had nothing to go on.
 
-  This is also the root cause of the hook-timeout failures fixed above: those tests were not slow, they were downloading.
+- **Every published claim that no longer matched the code has been corrected**
+  (`README.md` + 10 locales, `docs/ARCHITECTURE.md`, `skills/memesh/SKILL.md`) —
+  each checked against source rather than adjusted by eye: the R@5 figure
+  (95.40% → **95.60%**, now named together with the code path that produces it),
+  the scoring weights (`frequency` 18% / `confidence` 17%, not 15% / 15%),
+  `temporal validity` as a scoring factor (removed from `scoring.ts` in 2026-05,
+  and a constant 1.0 no-op before that), and `~18ms/query` (that number was
+  9.2s ÷ 500 questions, and each question includes building a fresh 50-session
+  database; a recall itself measures ~4ms).
 
+- **The LongMemEval benchmark measures the shipped retrieval path**
+  (`benchmarks/longmemeval/`) — it seeds through `KnowledgeGraph.createEntity()`
+  and retrieves through `recallEnhanced()`, the calls `remember()` and every
+  transport make, and records `run_info.measures: "shipped_recall_path"` so a
+  result file states what produced it. Modes name real product configurations —
+  A without embeddings, B with them. Earlier result files are kept unmodified and
+  labelled. Two published claims were retracted rather than quietly dropped: that
+  the figure was measured with "the same retrieval engine MeMesh uses in
+  production", and that the benchmark was "a conservative lower bound" on
+  production quality.
 
-### Tests
-
-- **A docs-only pull request went red on Windows because a temp directory was slow to delete** (`vitest.config.ts`, `tests/**`) — `hookTimeout` was 10 seconds, which fits POSIX and does not fit Windows: every DB test's `afterEach` closes SQLite and recursively removes a temp directory, SQLite leaves `-wal`/`-shm` beside the database, and the OS (plus whatever scans files on a CI runner) can hold a handle open for a moment after close. Measured — `tests/core/export-import.test.ts` hit `Hook timed out in 10000ms` on `windows-latest` / Node 24, in a pull request that changed only `CHANGELOG.md`.
-
-  Two halves, because there are two causes. The budget is now 30 seconds, for removals that succeed but are slow. And every recursive `rmSync` in `tests/` (74 of them; exactly one already had it) now passes `maxRetries: 5, retryDelay: 100` — the documented Windows mitigation for the `EBUSY`/`EPERM` a still-open handle produces. The shared DB fixture additionally treats a failed removal as non-fatal: a directory under `os.tmpdir()` that will not delete is the operating system's problem and gets swept by the platform, and failing a test over it turns a machine-local file lock into a red build on an unrelated change.
-
+- **The publish path enforces what the review path enforces**
+  (`.github/workflows/publish-npm.yml`) — version coherence, mirror drift and the
+  doctor manifest gate ran on every pull request and on no release, while
+  `.claude-plugin/*.json` ship inside the tarball, so a partial version bump could
+  reach plugin-marketplace users unchecked. `npm run verify:release` is now the
+  single answer to "is this shippable", with a tag-versus-`package.json` check
+  before anything is installed and `prepublishOnly` so a manual publish cannot
+  bypass it.
 
 ### Removed
 
-- **`consolidate` is retired — MCP tool, HTTP endpoint and CLI command** (`src/core/consolidator.ts` deleted; `handlers.ts`, `server.ts`, `cli.ts`, `schema-export.ts`, `types.ts`, `schemas.ts`) — **this is a breaking change.** MeMesh now exposes **8** MCP tools.
+- **`consolidate` — MCP tool, HTTP endpoint and CLI command**
+  (`src/core/consolidator.ts` deleted) — **this is a breaking change.** MeMesh
+  now exposes **8** MCP tools.
 
-  What it did: deleted an entity's observations and wrote an LLM summary in their place, immediately, with no proposal and nothing to restore from. Three defects were measured in it before the decision to retire, and each is one the reviewed path (`dreamer`) was already designed against:
+  What it did: deleted an entity's observations and wrote an LLM summary in their
+  place, immediately, with no proposal and nothing to restore from. Three defects
+  were measured in it before the decision to retire, and each is one the reviewed
+  path was already designed against. A failure between the delete and the write
+  destroyed the entity and reported that nothing had happened. It ignored pins,
+  so `memesh consolidate` with no arguments swept pinned entities in with the
+  rest. And it reset `confidence` to 1.0 on success — compression removes text
+  and adds no evidence, and since a model could call it, a model could raise its
+  own memories to maximum confidence by asking for a summary.
 
-  - **A failure between the delete and the write destroyed the entity and reported that nothing had happened.** The removals were a loop of independently committing statements; a bare `catch` then added the original count to `observations_after` and returned no error. Measured, with the replacement write made to fail: `OBSERVATIONS LEFT ON DISK : 0 []` against `REPORTED observations_after: 6`, no error.
-  - **It ignored pins.** `dreamer` has always refused `metadata.pin === true`; this did not, so `memesh consolidate` with no arguments swept pinned entities in with the rest of `listRecent(100)`.
-  - **It reset `confidence` to 1.0 on success.** Compression removes text and adds no evidence — and since it was an MCP tool the model itself could call, a model could raise its own memories to maximum confidence (0.17 of the ranking score) by asking for a summary.
-
-  Its only acceptance test on the LLM's output was that it returned *fewer strings* than it was given.
-
-  **`dream` is the surviving compression path** and the reviewed form of the same idea: it proposes, applies nothing until a proposal is accepted, keeps `source_ids`, archives sources instead of deleting them, refuses semantic types and pinned entities, and caps compaction depth. It is **not** a like-for-like replacement — it merges *clusters* of episodic memories (commits, session notes) into a digest, so compressing the observations *within* one named entity has no reviewed equivalent today. That is stated plainly in the docs rather than papered over.
-
-  Retired with signposts, not silently:
+  **`dream` is the surviving compression path** and the reviewed form of the same
+  idea: it proposes, applies nothing until a proposal is accepted, keeps
+  `source_ids`, archives sources instead of deleting them, refuses semantic types
+  and pinned entities, and caps compaction depth. It is **not** a like-for-like
+  replacement — it merges *clusters* of episodic memories, so compressing the
+  observations *within* one named entity has no reviewed equivalent today.
 
   | Surface | Before | Now |
   |---|---|---|
   | MCP | `consolidate` tool | gone from the registry |
-  | HTTP | `POST /v1/consolidate` | `410 Gone` + what to use instead — **not** 404, which reads as a typo or a bad base URL and invites a retry |
-  | CLI | `memesh consolidate` | prints where to go, exits `1` — deleting it outright makes Commander answer "unknown command", which reads as a broken install |
+  | HTTP | `POST /v1/consolidate` | `410 Gone` + what to use instead — not 404, which reads as a typo and invites a retry |
+  | CLI | `memesh consolidate` | prints where to go, exits `1` — deleting it outright reads as a broken install |
 
-  Both signposts are verified at runtime, not merely asserted against the source: `curl -i` returns `HTTP/1.1 410 Gone` for the retired route and `HTTP/1.1 404 Not Found` for a genuinely missing one, and `memesh consolidate --name foo` prints the message and exits 1.
-
-- **`cleanup.consolidateHint`, a dead dashboard string in 11 locales** (`dashboard/src/lib/i18n.ts`) — no component has ever read this key. It was advice to use the tool that has now been retired, translated eleven times, rendered zero times.
-
-### Added
-
-- **Anthropic memory tool (`memory_20250818`) backed by the knowledge graph** (`src/core/memory-tool.ts`, exported from the package root) — for applications that call the **Messages API directly** rather than through MCP. Claude gets a memory tool whose storage is MeMesh instead of a folder of text files, so it also gets FTS5 search, multi-factor ranking, auto-decay, relations and namespaces without knowing they are there. Anthropic's contract states that `/memories` is "a prefix that your handler maps onto real storage, such as a per-user directory or keys in a database", so this is the documented shape of the integration rather than a workaround.
-
-  Not a tenth MCP tool, and not on the HTTP or CLI surface. The nine MCP tools serve an agent that already speaks MeMesh; this serves an application that speaks only the Messages API. Folding them together would make one surface answer to two contracts.
-
-  Each entity renders as one file whose lines are its observations, **ordered by observation id — insertion order, never score.** That is the load-bearing decision: `view` and the edit that follows it are separate turns, and between them one of the seven hooks can write a new observation. If the order the model saw came from a ranking, the line numbers it read would address different content by the time it sent them back — a silent wrong write rather than an error. An observation may itself contain newlines, so the line-to-memory map is computed from the rendered text rather than assumed one-to-one.
-
-  Two behaviours differ from a filesystem on purpose. `delete` **archives**: the person whose memory it is did not ask for the deletion, a model did, so it disappears from the model's view and stays restorable from theirs. `str_replace` **refuses an ambiguous `old_str`** and returns the line numbers of every occurrence rather than editing the first match — it is a write, and the wrong one is silent.
-
-  Three defects found by `/review` before merge, each reproduced before fixing. **A directory view no longer touches ranking state**: it went through `KnowledgeGraph.listRecent()`, which calls `trackAccess()` — and since the API injects "ALWAYS VIEW YOUR MEMORY DIRECTORY BEFORE DOING ANYTHING ELSE" into the system prompt, every conversation was incrementing `access_count` on every memory in the database (measured: 0 to 4 apiece after four views). `frequency` is 0.18 of the ranking score and `last_accessed_at` feeds `recency` at 0.25, so a read was flattening both signals and defeating auto-decay. Listings now query for the two facts they need and hydrate nothing. **`rename` no longer leaves the old name searchable**: `entities_fts` is contentless, so a delete must be issued with the text that was indexed; renaming the row first and rebuilding after deleted with the NEW name, matched nothing, and layered the new tokens on top of the old. Measured: after renaming `kangaroo-notes` to `wallaby-notes`, `MATCH kangaroo` still returned the row. The FTS row is now removed under the old name, then reinserted under the new one, in one transaction. **Writes are bounded**: 256 KB per memory and 16 000 characters per `view`, both required by the contract's security section.
-
-  Path-traversal validation is on the implementer per Anthropic's own warning, and is enforced here even though nothing touches a filesystem: `..` cannot reach `secrets.env`, but it can resolve to a different namespace or memory than the one named. Refused: anything outside `/memories` (including `/memories-of-you/...`, which passes a naive `startsWith`), `.`/`..`/empty segments, `%2e%2e`, backslashes, NUL bytes, paths deeper than `namespace/memory`, unknown namespaces, writes to a directory, and deleting or renaming the root or a namespace.
-
-- **`memesh doctor` now reports the runtime it is running on** (`src/core/doctor.ts`) — Node version, ABI, platform/arch, whether that version satisfies `package.json` `engines.node`, and whether the built-in `node:sqlite` module is present. A user below the supported floor previously saw hooks misbehaving and a red native-binding row with nothing anywhere naming the one fact that explains both. Below the floor the row FAILS with an upgrade instruction.
-
-  The version comparison understands `>=X.Y.Z` and nothing else, on purpose: this row is allowed to fail, so a parser that guessed at `^`, `||` or `<` ranges would sometimes tell a healthy install it is broken. Anything it cannot parse is reported as "not checked", which is the true statement, and reported informationally so it cannot move `Overall`.
-
-  The `node:sqlite` probe **resolves** the module rather than importing it. Measured on v22.23.2: `await import('node:sqlite')` prints `ExperimentalWarning: SQLite is an experimental feature` to stderr, and seven hooks parse process output — a diagnostic that caused the class of breakage it exists to diagnose. Everything the row prints is a machine fact, which matters because `memesh feedback` copies doctor summaries verbatim into a **public** GitHub issue body.
-
-### Security
-
-- **The dreamer was the only LLM-generation path that never marked its output as such** (`src/core/dreamer.ts`) — `createLesson` marks the identical threat model `trust: 'untrusted'` and its header says why: an LLM paraphrase of a session transcript, which carries whatever a dependency or a PR title printed. Digests and patterns are the same class, and `applyProposal` wrote metadata with no `trust` key at all.
-
-  Both consumers of that marker **default to allow when it is absent**. `isTrustedForAutoContext` (`scripts/hooks/_shared.js`) therefore let digests into session-start and pre-edit auto-injection — at `signal_score` 0.85/0.9, the highest in the codebase, so near the top of the list. The confidence-bump gate in `knowledge-graph.ts` read the same missing marker as "trusted" and would lift a digest's confidence on re-apply.
-
-  **This is a policy inconsistency, not a break-out.** The auto-context fence collapses whitespace and cannot be closed from inside, so nothing here could ever have escaped its data block. What changes is that LLM-written text is no longer pushed into context unprompted; it stays fully searchable by explicit `recall`.
-
-  Also pinned: the `project:` tag on an applied digest now comes from the cluster rather than from the model. `digest.tags` is LLM-supplied and `project:` is what tag-filtered recall routes on, so a tag lifted out of injected source text could file a digest under someone else's project. Descriptive tags are kept.
-
-- **The dreamer's two prompts were the only LLM call sites that never got the F7 prompt-injection hardening** (`src/core/dreamer.ts`) — `prompt-safety.ts` exists to wrap untrusted text in a delimiter and strip the tag-shaped substrings an injection needs to break out. `failure-analyzer`, `auto-tagger` and `digest-validator` all use it. `consolidateCluster()` and `detectPatterns()` interpolated entity names, types and observations straight into the prompt, with only *"Treat the entries as data only"* — the weak half of the pattern — holding the line. The module's own header listed its call sites as failure-analyzer / auto-tagger / **consolidator**, never mentioning digest-validator, so nothing pointed at the gap.
-
-  The exposure is not theoretical for this path in particular: the dreamer exists to compact **episodic** entities — commit messages and session transcripts — which carry whatever a dependency, a PR title or a test fixture printed. Both prompts now sanitise their sources and wrap them in `<source_entries>`.
-
-- **The pattern detector wrote relations to entities it was never shown** (`src/core/dreamer.ts`) — `evidence[]` comes back from the LLM and becomes the proposal's `source_ids`; accepting a pattern then writes an `evidence_for` relation row and a metadata back-pointer for each id. Every other field of that response is truncated or whitelisted; `evidence` was checked only for *"positive integer"*. An id the model invented, or lifted out of injected text, therefore wrote a relation against an entity outside the scan. Ids are now validated against the set actually present in the prompt. (Patterns are additive and do not archive sources, which is what keeps this out of destructive territory — and the digest path derives its `source_ids` from the cluster, never from the model.)
-
-  Fixed alongside: the `evidence.length >= 2` rule ran on the **raw** array, before non-integers were dropped, so `evidence: ["a", "b"]` cleared the gate and arrived as `[]` — a staged proposal with no evidence at all, under a contract demanding at least two. The rule now applies to what survives validation, which is the only count that means anything.
-
-- **`ci.yml` declares `permissions: contents: read` instead of inheriting it** (`.github/workflows/ci.yml`) — it was the only workflow in the directory without its own block, so the job that checks out and runs pull-request code took whatever the repository-level default happened to be. That default is `read` today, which is why nothing was wrong; it is also a web-UI setting that can change with no diff, no commit and no review. Least privilege stated in the file that needs it.
-
-### Changed
-
-- **The supported Node floor is now `>=22.5.0`** (`package.json`, `package-lock.json`, `.github/workflows/*.yml`, all 11 `README*.md` badges, `CONTRIBUTING.md`) — **nothing was broken on Node 20.** All three of its OS legs were green the morning it was removed; this is a support-policy change, not a fix. Node 20 reached end of life on 2026-03-24, so the package was promising a runtime that receives no security patches, and the CI comment written when the matrix grew already set the condition for removal: *"the leg goes when the claim goes, not before."* The claim went.
-
-  `22.5.0` rather than `22.0.0` because that is the release where `node:sqlite` became available. The floor is where a future migration off `better-sqlite3` needs it to be, and `memesh doctor`'s `node:sqlite` row can now state a fact about every supported runtime instead of one that is sometimes absent.
-
-  Three jobs still pinned `node-version: '20'` after the matrix moved, and one of them was **`publish-npm.yml`** — the publish path would have run `prepublishOnly` → `verify:release` (which does `npm pack`, installs into a consumer tree, and audits it) on a runtime the package it was publishing declares unsupported. All five literal pins across the three workflows now read `'22'`.
-
-  `tests/ci-matrix-covers-engines.test.ts` is what keeps them together from here: it fails if any workflow pins a Node below `engines.node`, **and** if no job runs the declared floor. The second half matters more than it looks — legs get deleted for wall-clock time, floors get raised on purpose, so "we claim 22.5 and test only 24" is the likelier accident, and it leaves the oldest runtime users are entitled to run as the one runtime nobody runs.
-
-- **A test named "emits nothing on stderr" never read stderr** (`tests/core/node-runtime-check.test.ts`) — it used `execFileSync`, which returns **stdout**; piping stderr captures it and discards it on success. So the variable called `stderr` held the child's stdout, and the assertion that it was empty was true no matter how loudly the probe warned. Measured: a child that writes to stderr and exits 0 leaves the old assertion green. It now uses `spawnSync` and asserts on `result.stderr` and `result.status`, and the fix was mutation-verified **on Node 22** — the only line in the matrix where importing `node:sqlite` actually emits the `ExperimentalWarning` this guards against, so verifying anywhere else would have proved nothing. Caught by an independent review of the diff; it is the same defect class as the shipped bugs this stack fixes, in the test written to prevent them.
-
-- **Node 26 broke every dashboard test that touches `localStorage`** (`vitest.config.ts`, `tests/setup/webstorage.ts`) — found by the new Node 26 CI leg on its first run, which is what it is for. Node 26 ships the Web Storage API, so `localStorage` exists as a global before any test environment is set up, and without `--localstorage-file` its value is `undefined`. vitest's happy-dom environment skips names that are already present, so under `@vitest-environment happy-dom` the window and the global are one object with an undefined `localStorage`, and five `OnboardingBanner` tests died on `Cannot read properties of undefined (reading 'clear')`. Measured broken on v26.5.1 and fine on v20.20.2 / v22.23.2 / v24.15.0; happy-dom 20.11.1, the newest release, does not change it.
-
-  A setup file now installs happy-dom's own `Storage`, borrowed from a throwaway `Window`, so Node 26 exercises the same implementation as every other version instead of a hand-written stand-in — and only for DOM environments, so the `node`-environment suite keeps exactly the globals the real runtime gives it. `happy-dom` is loaded with a dynamic `import()` inside that branch: as a static import it would load in all ~90 node-environment files, which neither have a DOM nor want one, and a resolution failure there would take the node suite down before the guard could rule it out. `--no-experimental-webstorage` would have been tidier and was tried first: vitest replaces `poolOptions.forks.execArgv` with its own list so the flag never reaches the worker, and Node 20 rejects the flag outright.
-
-- **CI now runs on every pull request, not only those landing on `main`/`develop`** (`.github/workflows/ci.yml`, `.github/workflows/codeql.yml`) — the `branches: [main, develop]` filter on `pull_request` reads as "test what reaches the trunk" and behaved as "skip anything stacked". A PR based on another feature branch got no Build & Test and no CodeQL, while `multi-model-review.yml` — which has no filter — still posted its reviews. Reviewed, never compiled, never scanned, and indistinguishable from healthy on a page of green checks. Found the honest way: by stacking a PR that changed the test matrix and watching the matrix not run on it. `push` still fires only for `main`/`develop`, so this costs one run per PR, not two.
-
-- **CI tests Node 24, and Node 26 on Linux** (`.github/workflows/ci.yml`) — the matrix was `[20, 22]`, so Krypton, the LTS line released over a year ago, had no coverage at all. Node 20 reached end of life on 2026-03-24 and was still tested at the time, because `engines` still said `>=20`; the leg goes when the claim goes, not before. Both went, in the entry above, before either shipped.
-
-  Node 26 is Linux-only, and the reason is worth recording: **`better-sqlite3@12.9.0` publishes no prebuilt binary for Node 26's ABI (147)**. Measured — `prebuild-install warn install No prebuilt binaries found (target=26.5.1 runtime=node arch=arm64 platform=darwin)`, followed by a `node-gyp rebuild` that succeeded in 18s on macOS/arm64. It works, but it needs a full toolchain (MSVC on Windows), so one Linux leg buys early warning without paying for a source build on three runners. The same gap has a user-facing edge: a plugin-marketplace install runs with `--ignore-scripts`, so on Node 26 there is neither a prebuild to download nor a build step to run.
+- **`cleanup.consolidateHint`, a dead dashboard string in 11 locales**
+  (`dashboard/src/lib/i18n.ts`) — advice to use the tool that has now been
+  retired, translated eleven times and rendered zero times.
 
 ### Fixed
 
-- **Two checks that could not fail, found by retiring one tool** (`scripts/verify-docs-sync.sh`, `tests/core/schema-export.test.ts`) — both claimed to compare the MCP registry against something and neither did.
+- **`recall` finds the memory when you ask a question in your own words**
+  (`src/knowledge-graph.ts`, `src/core/operations.ts`) — four defects compounded
+  into near-total recall failure for anything but a single keyword, and each one
+  hid the others.
 
-  `verify-docs-sync.sh` compared the code's tool count to the literal `9`, and compared the docs' side by counting **every** `### ` heading in `API_REFERENCE.md` — 43 of them — then checking `-lt 9`, which no version of that document could ever fail. It now reads the number the document actually claims (`MeMesh exposes N tools via MCP`) and fails if the registry disagrees, if the sentence is missing, or if its own pattern stops matching.
+  1. **Query terms were AND-ed.** Every word of the query — including `what`,
+     `did` and `with` — had to appear in the same memory, so recall got *worse*
+     the more precisely you asked: R@5 fell from 62.5% at one keyword to 41% at
+     two, 29% at three and 18% at five. Terms are OR-ed now.
+  2. **Relevance was discarded before ranking.** The SQL ordered by `e.id DESC`
+     and applied `LIMIT`, so the *newest* matches survived to the scorer and the
+     best match was thrown away before it could be scored — unreachable at any
+     database size once 26 memories mentioned a term. Ordering is by BM25 `rank`
+     now; recency is still one of the five scoring factors, it just no longer
+     decides what gets scored.
+  3. **The relevance signal was flattened.** Every hit entered the scorer at a
+     hard-coded `1.0`, tying them all and letting recency and frequency re-sort
+     them, undoing the ordering the search had just computed. Relevance is graded
+     by BM25 position now. Invisible in a fresh database and decisive in an aged
+     one, which is why it ships alongside the others rather than after them.
+  4. **Punctuation inside a word turned it into a phrase requirement.**
+     `kitchen's` became the FTS5 phrase `kitchen s`, matching only a memory with
+     those words adjacent and in that order; a memory that said "kitchen" was
+     missed outright. Queries are split on the boundaries `unicode61` itself
+     uses, over an NFC-normalised query, which keeps non-Latin scripts alive — a
+     plain `[^a-zA-Z0-9]` strip would reduce a CJK query to the empty string and
+     fall through to the recent-list path looking like a successful search.
 
-  `schema-export.test.ts` asserted a hardcoded `9` and a hardcoded name list under the titles "matches MCP registry" — it matched nothing, it restated. Both are now derived from `TOOL_DEFINITIONS`, which immediately surfaced a real drift the duplicate had hidden: the OpenAI export listed `memesh_learn` third while the MCP registry lists it sixth. `schema-export.ts` now mirrors the registry order, so the two lists are literally comparable.
+  Measured end to end on the same 500 LongMemEval-S questions, through
+  `recallEnhanced()`: **R@5 5.20% → 95.60%, R@10 5.20% → 97.80%,
+  MRR 0.0520 → 0.8929, and questions returning zero results 473/500 → 0/500.**
 
-- **The two relation types that do something were the two nothing told the model about** (`src/transports/mcp/handlers.ts`, `src/core/types.ts`, `docs/api/API_REFERENCE.md`) — a relation type is a free string and most are inert labels, but `supersedes` **archives the target entity** on write and `contradicts` makes both memories surface as a conflict on every recall. The MCP `remember` schema described the field as `Relation type (e.g., "implements", "related-to")` — and that description is the only thing a model ever reads about relation types. Both examples were inert; both behavioural types were unnamed.
+  OR raises recall and lowers precision: a query now returns weaker partial
+  matches below the strong ones instead of returning nothing, and result lists
+  are longer. Ranking, not exclusion, is what keeps the top of the list clean.
 
-  The visible consequence: `findConflicts()` runs on **every** recall and could only ever return `[]`, because nothing in the model's view named the relation that feeds it. All three transports render that as "no conflicts", which reads as *checked, nothing wrong* — a clean bill of health from a check whose input was unreachable. The less visible one: a destructive action, archiving an entity, was gated on guessing a word.
+- **Every spaceless script is searchable by part of a phrase, not only by its
+  exact stored text** (`src/storage/fts-index.ts`, `src/knowledge-graph.ts`,
+  `src/db.ts`) — FTS5's `unicode61` tokenizer puts no boundary between CJK
+  characters, so an unbroken run indexed as **one token**. A memory holding
+  「資料庫遷移前一定要先備份」 could be found by searching that exact string and by
+  nothing else. Measured on a mixed corpus, Chinese recall was **2/9** where
+  English was 4/4 — which is why it stayed invisible. For anyone whose notes are
+  in one of these scripts, keyword recall was effectively broken.
 
-  The schema now names both and states what each does. `BEHAVIOURAL_RELATION_TYPES` in `core/types.ts` is the single source of truth, and `tests/relation-types-documented.test.ts` fails in both directions: if the code branches on a relation type the map omits, and if a type in the map is missing from the schema description — name **or** consequence, since `"supersedes"` sitting in a list of examples reads as one more inert label. A third case keeps an inert example in the text so the field does not start reading as an enum; it is not one.
+  Text now passes through `segmentUnspacedScripts()` on the way into the index
+  and on the way into a query, cutting unspaced runs into overlapping character
+  bigrams. Latin text is returned byte-for-byte unchanged, so English behaviour
+  is untouched and the 500-question run is identical before and after. Chinese
+  recall on the same corpus goes **2/9 → 9/9**. Chosen over FTS5's `trigram`
+  tokenizer, which measured 3/9 for 4× the index size.
 
-- **`memesh reindex --vectors` no longer deletes every embedding on the word of a config file** (`src/core/embedder.ts`, `src/db.ts`, `src/transports/cli/cli.ts`) — the consent gate refused to authorise the drop unless something could refill the index afterwards, and asked `isEmbeddingAvailable()`. That function reports which provider the config *names*: for `openai` and `ollama` it returns `true` without checking a key, reaching an endpoint, or comparing a dimension. An expired key, a key typed after the provider name, or a stopped Ollama therefore authorised dropping every vector in the database, and the refill then wrote nothing back. The precondition is now `canRefillVectorIndex()`, which embeds one string and measures the result against the width the table is about to be declared with — a proof rather than a claim. `allowVectorIndexRebuild` is async as a result, and the refusal message now names what to check.
+  The first version of this listed the scripts that had been *reported* — CJK
+  ideographs, kana, hangul — rather than the property that makes them need
+  fixing, so **Thai, Lao, Khmer, half-width katakana and CJK Extension B kept the
+  exact defect**, invisibly, because no test used one. All five are covered now,
+  and segmentation is code-point aware: Extension B lives above the BMP, so
+  building bigrams over UTF-16 code units had been cutting surrogate pairs in
+  half. Spaced scripts are unaffected — Cyrillic, Greek and Devanagari are
+  asserted to pass through byte-for-byte.
 
-- **Consent to rebuild the vector index is bound to the database it was granted for** (`src/db.ts`) — it was a module-level boolean, so in the HTTP server, or any process that opens more than one database, a grant recorded for A could be spent by an unrelated `openDatabase(B)` that ran first. B's vectors, never consented to and never asked about, would be the ones dropped. The grant now records a resolved path and is refused for any other.
+  Known bound, pinned by a test rather than chased: a single-character query
+  becomes a prefix match, so it reaches any bigram starting with that character
+  but not one where it sits last (「收」 will not find 「營收」).
 
-- **A reindex that regenerated nothing no longer reports success** (`src/core/operations.ts`, `src/transports/cli/cli.ts`) — the end-state check asked "does every entity have a vector", which a full index satisfies with the *stale* vectors the run was asked to replace. So when a provider switch made every write fail, `countMissingVectors` returned 0, the reindex-needed flag was cleared, `✅ Reindex complete` printed, and the command exited `0` — in exactly the situation it exists for. `ReindexResult` now carries `failed`, and the verdict, the exit code and the flag all require both halves: every memory holds a vector *and* every attempted write landed. Entities whose observations are all whitespace are counted separately (`nothing_to_embed`) so they cannot hold the flag open forever, matching the exclusion `countMissingVectors` already made.
+- **Text stored in decomposed (NFD) form was unreachable** (`fts-index.ts`,
+  `knowledge-graph.ts`) — the index side never normalised Unicode and the query
+  side normalised *after* segmenting, so decomposed Hangul was never split into
+  bigrams and text arriving as NFD could not be found in either spelling. NFD is
+  not exotic input: macOS filesystem APIs, Finder and several Korean and
+  Vietnamese input methods emit it, and the hooks capture it from file paths.
+  `toIndexForm()` now owns "text → index tokens" for both sides.
 
-- **The dashboard's auth field reports itself invalid for a rejected token, not only an empty one** (`dashboard/src/components/AuthPrompt.tsx`) — the rejected branch rendered a `role="alert"` message but left `aria-invalid="false"` and no `aria-describedby`, so a screen-reader user heard the announcement and then found a control that disagreed with it. Both messages now own one stable id and both reach the field.
+  The same disagreement had a second edge, after archiving. Archived rows leave
+  FTS5, so that branch matches with `LIKE` against the raw columns while its
+  terms come from a NFC-normalising tokenizer — measured, a Vietnamese memory
+  stored NFD was returned by `search('dữ liệu')` and absent from the same search
+  with `includeArchived: true`. A deterministic `memesh_nfc()` SQL function now
+  normalises the stored side too.
 
----
+- **A query of combining marks alone claimed to be searchable**
+  (`src/storage/fts-index.ts`) — the tokenizer accepted a run of marks with no
+  base character, which `unicode61` treats as separators, so the phrase built
+  from one could never hit a row. `hasSearchableTerms` answered true and
+  `search()` returned 0 — and because the vector supplement is gated on that
+  answer, those queries skipped the keyword result and got semantically-nearest
+  memories instead. A term must start with a letter or a number now; marks that
+  follow one are untouched, so Thai tone marks, Devanagari matras, Arabic harakat
+  and Hebrew niqqud all still tokenise as part of their word.
 
-**Written on 2026-07-29, when this section was first opened.**
+- **`include_archived` searches for what you asked, not for a literal substring
+  of it** (`src/knowledge-graph.ts`) — the `LIKE` branch interpolated the whole
+  raw query, so a question phrased in your own words found the active copy of a
+  memory and missed the archived one, and a CJK query missed entirely because it
+  was never segmented. It now matches the same terms the FTS path produces, with
+  `LIKE` metacharacters escaped.
+
+- **Recall was not reproducible** (`src/knowledge-graph.ts`) — `ORDER BY f.rank`
+  had no tiebreaker and BM25 ties are the common case, so which rows survived
+  `LIMIT` to reach the scorer was left to SQLite. Ties break by recency now.
+
+- **The vector index could be destroyed on evidence the guard exists to
+  distrust** (`src/db.ts`, `src/core/config.ts`, `src/core/embedder.ts`,
+  `cli.ts`) — four ways, all ending in a BYOK user's embeddings being dropped
+  with no backup, no prompt, and a paid re-embed to recover.
+
+  `readConfig()` returned `{}` for both "no config" and "config could not be
+  read", and the embedding dimension derived from it drives a `DROP TABLE
+  entities_vec` on mismatch — so a truncated write or a bad permission bit read
+  as "user configured nothing", fell back to 384 dimensions, and dropped a
+  1536-dimension index. The guard against that was keyed to the config being
+  *absent*, which every foreign-`HOME` case defeats when that `HOME` happens to
+  contain a config file. `memesh reindex --vectors` asked
+  `isEmbeddingAvailable()` before authorising the drop, and that function reports
+  which provider the config *names* — an expired key or a stopped Ollama
+  authorised dropping every vector and then wrote nothing back. And consent was a
+  module-level boolean, so in any process that opens more than one database a
+  grant recorded for A could be spent by an unrelated open of B.
+
+  The refusal now follows the consequence rather than the evidence: any
+  disagreement between the stored and configured dimension keeps the existing
+  index, because a stale index still works and is recoverable by fixing the
+  config, while a dropped one is gone. The precondition for a deliberate rebuild
+  is `canRefillVectorIndex()`, which embeds one string and measures the result
+  against the width the table is about to be declared with — a proof rather than
+  a claim. Consent records a resolved database path. The `DROP`, marker, `CREATE`
+  and dimension stamp are one transaction, so a crash between them can no longer
+  leave `memesh doctor` reporting a healthy install over an emptied index.
+
+- **`memesh reindex` reported success for work it had not done**
+  (`src/core/embedder.ts`, `src/core/operations.ts`, `cli.ts`) — `embedAndStore()`
+  has six exits and exactly one writes a vector, but it returned `void` from all
+  six, so the only signal a caller got was "it didn't throw". A provider whose
+  dimension no longer matched therefore produced a full `Embedded:` count over an
+  index nothing had been written to, cleared the flag that tells `memesh doctor`
+  the index still needs refilling, printed `✅ Reindex complete` and exited `0`.
+
+  `embedAndStore` returns which of the six happened now, and the decision to
+  clear the flag is taken from the **database** — active memories with
+  observation text but no vector row — rather than from what the loop believed it
+  did. The verdict additionally requires that every attempted write landed, since
+  a full index of *stale* vectors satisfies "does every entity have a vector" in
+  exactly the situation the command exists for. An incomplete run prints
+  `⚠️  Reindex incomplete` with a per-reason breakdown, leaves the flag set, and
+  exits `1`. Memories whose observations are all whitespace are counted
+  separately, so they cannot hold the flag open forever. The count deciding the
+  user-facing verdict is scoped to the run while the count deciding the
+  database-wide flag is not — sharing one number made a `--namespace` run report
+  failure after doing everything it was asked to do.
+
+- **A memory written while the index rebuilt could vanish from search,
+  permanently** (`src/db.ts`, `scripts/hooks/_shared.js`) — the rebuild read its
+  source rows *before* opening its transaction, and better-sqlite3's default
+  `BEGIN DEFERRED` takes no write lock until the first statement inside it. Seven
+  hooks, the MCP server, the HTTP server and the CLI all open this database, so
+  an entity committed in that window was erased by `delete-all` and never
+  reinserted — and the version marker then committed, so it never retried. The
+  entity row survived, which is why nothing noticed. Migrations run through one
+  helper that takes `BEGIN IMMEDIATE` and re-checks the version under the lock
+  now, and backs off 24h after a failure instead of re-scanning the whole corpus
+  on every process start. Hooks run the same migration; they previously did not,
+  leaving hook-only users with a permanently half-segmented index.
+
+- **The segmentation upgrade did not reach any existing database** (`src/db.ts`)
+  — `rebuildFtsIndex` carried a fast path justified by "v2 differs from v1 only
+  by NFC-normalising before segmenting", which was true when the target was 2.
+  Version 3 also widens the script class, and **none of the newly-covered scripts
+  has a canonical decomposition**, so the probe returned false for exactly the
+  corpora the widening exists to fix. Measured: a database holding Thai and
+  half-width katakana came out of the upgrade with its marker stamped 3, its
+  index still holding old whole-run tokens, and every fragment query returning
+  nothing. The marker only moves forward, so it never self-healed. The skip is
+  gone; a version-keyed shortcut is only sound while someone re-derives its
+  premise at every bump.
+
+- **A failed database open poisoned the whole process** (`src/db.ts`) —
+  `openDatabase` assigned its module singleton *before* finishing initialisation,
+  so any throw after `new Database()` — a peer holding the write lock, a
+  read-only file, a failed extension load — left `db` pointing at a handle with
+  no schema, no migrations and no sqlite-vec, and every later caller got it for
+  the life of the process. The singleton is published only on success now, and
+  the abandoned handle is closed.
+
+- **The vector half of "hybrid search" was doing nothing**
+  (`src/core/embedder.ts`, `src/core/operations.ts`) — `entities_vec` is declared
+  with no `distance_metric`, so sqlite-vec measures **L2**, a 0…2 range over unit
+  vectors; both constants assumed a 0…1 cosine scale. `MAX_VECTOR_DISTANCE = 1`
+  discarded 995 of 1000 vector hits, and `1 - distance` sent 98.8% of the rest to
+  exactly 0.0 relevance. Embeddings were being generated, stored, searched, and
+  thrown away before anything could use them. The cut-off is **1.30** and the
+  mapping `1 - distance/2`, extracted as `vectorSimilarity()` next to the
+  constant it shares a scale with — keeping them in separate files is how they
+  drifted apart.
+
+  **This does not raise the benchmark score**, and that is worth stating plainly:
+  R@5 is unchanged. What changes is that the feature is no longer inert, and a
+  query matching nothing lexically can now be answered semantically. Re-measured
+  over all 500 questions, 14 result lists differ between embeddings-off and
+  embeddings-on where before they were identical to sixteen decimal places; two
+  questions move the correct session, both at ranks no one would scroll to, for
+  89× the wall clock. This refutes a prediction the benchmark docs used to make —
+  that the remaining failures were "dominated by vocabulary mismatch — exactly
+  what a working vector supplement would cover". The docs say so instead of
+  quietly dropping the claim. Recall stays LLM-free and embeddings stay opt-in.
+
+- **Recorded, not fixed: a vector hit cannot outrank the best keyword hit,
+  however certain it is** (`src/core/operations.ts` docstring) — FTS relevance is
+  *positional* (the top row gets 1.0 no matter how weak the match) while a vector
+  hit's is *absolute*, and a genuinely good semantic match sits near 0.4. Rank
+  fusion is the fix; it was implemented, measured and **not adopted** — on this
+  corpus it recovered 4 of 5 misses and cost R@5 95% → 92%, and LongMemEval's
+  haystack is padded with generic public Q&A that scores high on semantic
+  similarity while being nobody's memory, so it is the wrong corpus to tune
+  fusion on.
+
+- **A query term present in most of the corpus no longer drags the whole index
+  into the scan** (`src/knowledge-graph.ts`, `src/db.ts`) — query terms are
+  OR-ed, so the cost of a search is the union of their postings and one
+  ubiquitous word dominates it. `dropUbiquitousTerms()` removes terms appearing
+  in more than half the indexed rows. Measured with a 12-term query:
+  **0.411 → 0.079 ms at 500 rows (−81%), 4.147 → 0.481 ms at 5 000 (−88%),
+  80.15 → 8.57 ms at 100 000 (−89%)**. The dropped terms are the ones BM25
+  already scores near zero, so this removes work rather than signal — R@5 is
+  unchanged. Two edges are pinned by tests: a query made entirely of common words
+  keeps its rarest term rather than filtering to nothing, and the guard does not
+  apply below 25 rows, where a term in most of the corpus is the subject rather
+  than a stopword. Preventive rather than remedial.
+
+- **`recall_hits` has one owner again** (`src/storage/conflicts.ts`,
+  `src/knowledge-graph.ts`) — the column was written by two paths with
+  incompatible definitions. The Stop hook writes it to mean "a memory we injected
+  was actually used", recording a hit *or* a miss; `search()` also wrote it to
+  mean "this memory was returned", which can only add to the hit side. The
+  impact score reads the pair as a ratio, which is meaningful only if both sides
+  answer the same question. Retrieval paths track access only now — "was
+  returned" is already recorded by `access_count`, in the same statement.
+
+- **`verify_agent_work` passed on a claim it never evaluated**
+  (`src/core/verifier.ts`) — with no discoverable git base, `expected_files` was
+  never compared, and with neither a claim nor a report supplied it counted
+  changed files, which is not a check against anything, and then reported
+  `pass: true`. It also wrote a permanent memory tagged `verification:pass`,
+  which a later `recall` hands to another agent as evidence the work was checked.
+  The root cause was two absences multiplying into a pass — `realityCheck()`
+  returning true with no claim, and a missing report defaulting to true. See the
+  `verdict` tri-state under **Changed**.
+
+- **The dashboard's auth screen was unusable with a screen reader, and silent on
+  a rejected token** (`dashboard/src/components/AuthPrompt.tsx`,
+  `dashboard/src/App.tsx`, `dashboard/src/lib/i18n.ts`) — the error had no live
+  region, the input was not focused on a screen reached involuntarily by a 401,
+  `required` made the empty-token message unreachable, and pasting a rejected
+  token produced no message in any locale. The rejected branch also left
+  `aria-invalid="false"` and no `aria-describedby`, so a screen-reader user heard
+  an announcement and then found a control that disagreed with it. Both messages
+  own one stable id now and both reach the field.
+
+  Five lookups on that screen were written as `t('auth.x') || 'English literal'`,
+  which reads as a safety net and cannot be one — `t()` returns the key string on
+  a miss, and a non-empty string is truthy, so the right-hand branch is
+  unreachable. When those keys were genuinely missing this screen rendered
+  `auth.title` at a remote operator. They are removed; English is already the
+  fallback inside `t()`. The token input's `placeholder` was a hardcoded
+  `"paste token here"` and is now translated in all 11 locales.
+
+- **Two checks that could not fail** (`scripts/verify-docs-sync.sh`,
+  `src/core/schema-export.ts`) — both claimed to compare the MCP registry against
+  something and neither did. The shell gate compared the code's tool count to a
+  literal, and counted the docs' side by counting *every* `### ` heading in
+  `API_REFERENCE.md` — 43 of them — then checking `-lt 9`, which no version of
+  that document could fail. It reads the number the document actually claims now.
+  The schema test asserted a hardcoded count and name list under the title
+  "matches MCP registry"; it matched nothing, it restated. Deriving both from
+  `TOOL_DEFINITIONS` immediately surfaced a real drift the duplicate had hidden:
+  the OpenAI export listed `memesh_learn` third where the MCP registry lists it
+  sixth.
+
+- **A docs gate reported FAIL on a correct tree** (`scripts/verify-docs-sync.sh`)
+  — the hook count recursed into subdirectories, so a build-generated mirror took
+  it from 7 to 9 and the gate failed every run. A gate that fails on a healthy
+  repo gets ignored, and then it is not a gate.
+
+- **Committed build output could drift from source**
+  (`scripts/check-generated-mirror.mjs`, `scripts/generate-skills-manifest.mjs`)
+  — `dist/` is tracked because plugin-marketplace installs run it directly:
+  they install with `--ignore-scripts` and never build. Nothing verified it
+  matched `src/`, and the one channel that ships committed output was the one no
+  gate covered. `npm publish` was never exposed, because `prepublishOnly`
+  rebuilds first — which is precisely why it could persist. The manifest also
+  carried a `generated_at` timestamp, written and never read, so every build
+  produced a different file and "is the committed output current?" had no answer
+  a diff could give; it is gone and the build is reproducible.
+
+- **The committed dashboard bundle could not be reproduced on Windows**
+  (`.gitattributes`, `scripts/build-dashboard.mjs`, `ci.yml`) — `.gitattributes`
+  listed the ten extensions whose CRLF breakage had been noticed and left `.css`
+  and `.html` out, so Windows checked those out with CRLF, vite **inlined** them
+  into `dashboard/dist/index.html`, and the carriage returns landed mid-line
+  inside a shipped artifact. The rule is `* text=auto eol=lf` now: line endings
+  are a property of text, not of a suffix list somebody remembered to extend. The
+  build also ran `npm install` rather than `npm ci`, and CI built the dashboard
+  twice with the second build landing *after* the release gates — so the gate
+  diffed an artifact produced by an unpinned install.
+
+- **`memesh doctor` reported a healthy index as damaged**
+  (`src/core/doctor.ts`, `src/storage/fts-index.ts`) — its predicate assumed a
+  segmenting build cannot emit a term longer than a bigram that starts with an
+  unspaced-script character. False: a *lone* unspaced character is left
+  untouched and `unicode61` then joins it to adjacent ASCII, so an ordinary
+  database holds terms like `第1章`. The predicate requires three consecutive
+  unspaced-script characters now, which segmentation can never emit. The message
+  also embedded an example term taken from the index; since `memesh feedback`
+  copies doctor summaries verbatim into a pre-filled **public** GitHub issue
+  body, it reports a count instead — just as actionable: rebuild, re-run doctor,
+  expect 0.
+
+- **A failing database reported both `pass` and `fail`** (`src/core/doctor.ts`)
+  — the "Database opened successfully" row was pushed as soon as the entity count
+  came back, so anything that threw afterwards appended a *second* row with the
+  same id and status `fail`. The overall verdict was right and the row a reader
+  looks at was wrong. The block stages its rows and emits exactly one now.
+
+- **One hook and two commands were not guaranteed executable**
+  (`scripts/set-executable-bits.mjs`) — the chmod list had drifted from
+  `package.json` `bin` in both directions, and `dist/transports/cli/cli.js` — the
+  `memesh` command itself — was committed at mode 100644. Both lists are derived
+  from their manifests now.
+
+- **`package-lock.json` carried the version from four releases ago** — its two
+  self-version fields read `4.2.6` through v4.2.7, v4.2.8, v4.2.9 and v4.2.10,
+  because the lockfile was missing from the version-anchor checklist. Only those
+  two fields changed; all 520 dependency entries are byte-identical.
+
+- **Published benchmark results no longer record the absolute path of the machine
+  that produced them** (`benchmarks/longmemeval/run.mjs`) — `run_info.dataset`
+  held the full path to the dataset file, which in a public repository means
+  publishing a local home directory. It records the basename now;
+  `dataset_sha256`, which is what actually identifies the dataset, is unchanged.
+
+- **A retrieval-quality floor now runs on every CI leg**
+  (`tests/recall-quality.test.ts`) — the LongMemEval dataset is a 278 MB download
+  and committing a slice is dataset redistribution, so the gate uses a small
+  synthetic corpus: ten memories, ten questions phrased as a person would ask
+  them, and thirty function-word notes so `limit: 5` has to choose which rows
+  reach the scorer. It asserts an aggregate R@5 floor of 80% and is calibrated to
+  catch collapse, not drift — AND-joined terms take it to 0% and ordering by
+  `e.id DESC` takes it to 20%.
+
+### Security
+
+- **`actions/checkout` no longer persists the job token**
+  (`.github/workflows/*.yml`, 9 steps) — by default `checkout` writes the job's
+  `GITHUB_TOKEN` into `.git/config`, where every later step can read it. That
+  includes `npm ci`, which in this repository **runs install scripts** on
+  pull-request code. No step here pushes with the token, so nothing needed it.
+  `ci.yml` also declares `permissions: contents: read` in the file rather than
+  inheriting a repository-level default that can change with no diff and no
+  review.
+
+- **The local embedding runtime is no longer installed by default**
+  (`package.json`) — `@huggingface/transformers` is an optional peer dependency
+  now, so a plain `npm i @pcircle/memesh` no longer pulls `onnxruntime-node` and
+  `sharp`, which between them carried five high-severity advisories with no fix
+  available upstream. Recall does not need it: the published 95.60% R@5 is
+  Mode A, measured with **no embeddings at all**. Users who want local ONNX
+  embeddings install it alongside; BYOK OpenAI/Ollama embeddings are unaffected.
+  Verified on a real consumer install of the packed tarball: neither package
+  present, no advisories, English and Chinese recall both still working.
+
+- **The dependency gate measures what ships, not what this repo has**
+  (`scripts/check-consumer-audit.mjs`) — `npm audit --omit=dev` run in the repo
+  audits the repo's own tree, and npm applies `overrides` only at the install
+  root, so the overrides added here changed what this project tests and changed
+  nothing for a consumer. `npm run audit:prod` packs the tarball, installs it the
+  way a user does, and audits there — and refuses to pass if the install produced
+  no tree.
+
+- **LLM-written memories are marked as such, and no longer auto-injected into
+  context** (`src/core/dreamer.ts`, `scripts/hooks/_shared.js`) — `applyProposal`
+  wrote metadata with no `trust` key at all, while the identical threat model
+  elsewhere is marked `trust: 'untrusted'`. Both consumers of that marker
+  **default to allow when it is absent**, so digests entered session-start and
+  pre-edit auto-injection at the highest signal score in the codebase, and the
+  confidence gate read the same missing marker as "trusted". This is a policy
+  inconsistency, not a break-out — the auto-context fence collapses whitespace
+  and cannot be closed from inside. What changes is that LLM-written text is no
+  longer pushed into context unprompted; it stays fully searchable by explicit
+  `recall`. Also pinned: the `project:` tag on an applied digest comes from the
+  cluster rather than from the model, since `project:` is what tag-filtered
+  recall routes on.
+
+- **The dreamer's two prompts now get the same prompt-injection hardening as
+  every other LLM call site** (`src/core/dreamer.ts`) — they interpolated entity
+  names, types and observations straight into the prompt with only "treat the
+  entries as data only" holding the line. The exposure is not theoretical for
+  this path in particular: the dreamer exists to compact **episodic** entities —
+  commit messages and session transcripts — which carry whatever a dependency, a
+  PR title or a test fixture printed. Both prompts sanitise their sources and
+  wrap them in a delimiter now.
+
+- **The pattern detector wrote relations to entities it was never shown**
+  (`src/core/dreamer.ts`) — `evidence[]` comes back from the LLM and becomes the
+  proposal's `source_ids`; accepting a pattern then writes a relation row and a
+  metadata back-pointer for each id. Every other field of that response is
+  truncated or whitelisted; `evidence` was checked only for "positive integer",
+  so an id the model invented, or lifted out of injected text, wrote a relation
+  against an entity outside the scan. Ids are validated against the set actually
+  present in the prompt now. Fixed alongside: the "at least two pieces of
+  evidence" rule ran on the **raw** array, before non-integers were dropped, so
+  `evidence: ["a", "b"]` cleared the gate and arrived as `[]`.
+
+- **The prompt-injection fence did not own its own fence**
+  (`scripts/hooks/_shared.js`) — `buildReferenceContext()` declares its contents
+  to be data rather than instructions, then interpolated caller text verbatim, so
+  a stored memory containing a newline and a triple-backtick closed the fence and
+  had the rest read as instructions. The renderer guarantees it now: whitespace is
+  collapsed and the fence outgrows any backtick run in the content.
+
+- **`.gitignore` re-included a subtree over the top of the global rules** —
+  `!benchmarks/longmemeval/**` is a recursive negation and a later negation wins,
+  so it overrode `.env` and `data/` for that whole subtree, in a public
+  repository, in the directory `REPRODUCE.md` tells people to download a dataset
+  into. The line was also unnecessary.
 
 ### Performance
 
-- **A query term present in most of the corpus no longer drags the whole index into the scan** (`src/knowledge-graph.ts`, `src/db.ts`, `scripts/hooks/_shared.js`) — query terms are OR-ed, so the cost of a search is the union of their postings and one ubiquitous word dominates it. `dropUbiquitousTerms()` removes terms appearing in more than half the indexed rows, using a new `fts_vocab` (`fts5vocab`) view that stores nothing of its own. Measured with a 12-term query, 200 iterations, including the lookup's own cost: **0.071 → 0.039 ms at 50 rows (−45%), 0.411 → 0.079 ms at 500 (−81%), 4.147 → 0.481 ms at 5 000 (−88%), 80.15 → 8.57 ms at 100 000 (−89%)**.
-
-  The dropped terms are the ones BM25 already scores near zero — a word in every row has no inverse document frequency — so this removes work rather than signal. R@5 on LongMemEval is unchanged at cut-offs of 90%, 70% and 50%, and falls at 30% (94.0% → 93.0%); 50% takes the speed with margin against that cliff. The full 500-question run holds at R@5 95.60% / R@10 97.80%.
-
-  Two edges are pinned by tests, because they are where a frequency filter goes wrong: a query made entirely of common words keeps its rarest term rather than filtering to nothing, and the guard does not apply below 25 rows, where a term in most of the corpus is the subject rather than a stopword. A missing `fts_vocab` falls back to searching every term.
-
-  Preventive rather than remedial — no one is at a scale where this bites today, which is why it had to be free at every size to justify shipping.
-
-### Security
-
-- **The local embedding runtime is no longer installed by default** (`package.json`) — `@huggingface/transformers` is an optional peer dependency now, so a plain `npm i @pcircle/memesh` no longer pulls `onnxruntime-node` (→ `adm-zip`) and `sharp`, which between them carried five high-severity advisories with no fix available upstream. Recall does not need it: the published 95.60% R@5 is Mode A, measured with **no embeddings at all**, and Mode B with embeddings scores identically. The code already degraded gracefully when the package was absent. Users who want local ONNX embeddings install it alongside; BYOK OpenAI/Ollama embeddings are unaffected.
-
-  Measured on a real consumer install of the packed tarball: before, `sharp@0.34.5` + `adm-zip@0.5.18` and 5 high advisories; after, neither package present, no advisories, and English and Chinese recall both still work.
-
-- **The dependency gate now measures what ships, not what this repo has** (`scripts/check-consumer-audit.mjs`) — `npm audit --omit=dev` run in the repo audits the repo's own tree, and npm applies `overrides` only at the install root, so the overrides added here changed what this project tests and changed nothing for a consumer. A gate reporting success against a tree nobody installs is the same defect as the benchmark that scored a reimplementation. `npm run audit:prod` now packs the tarball, installs it the way a user does, and audits there — and refuses to pass if the install produced no tree.
-
-### Fixed
-
-- **A memory written while the index rebuilt could vanish from search, permanently** (`src/db.ts`, `scripts/hooks/_shared.js`) — the rebuild read its source rows *before* opening its transaction, and better-sqlite3's default transaction is `BEGIN DEFERRED`, so no write lock existed until the first statement inside it. Seven hooks, the MCP server, the HTTP server and the CLI all open this database, so an entity committed in that window was erased by `delete-all` and never reinserted; the version marker then committed, so it never retried. The entity row survived, which is why nothing noticed. Migrations now run through one helper that takes `BEGIN IMMEDIATE`, re-checks the version under the lock, and backs off 24h after a failure instead of re-scanning the whole corpus on every process start. Hooks run the same migration — they previously did not, leaving hook-only users with a permanently half-segmented index and a "database disk image is malformed" message on stderr.
-
-- **An unreadable config deleted every embedding** (`src/core/config.ts`, `src/db.ts`) — `readConfig()` returned `{}` for both "no config" and "config could not be read", and the embedding dimension derived from it drives a `DROP TABLE entities_vec` on mismatch. A truncated write or a bad permission bit therefore read as "user configured nothing", fell back to 384-dim, and dropped a BYOK user's entire 1536-dim vector index — unrecoverable, no backup, no prompt, and regenerating it costs money on an API provider. `readConfigResult()` reports which case it is; an unknown dimension now keeps the existing table. The vector migration's `DROP`, marker, `CREATE` and dimension stamp are one transaction, so a crash between them can no longer leave `memesh doctor` reporting a healthy install over an emptied index.
-
-- **Non-Latin memories stored in decomposed form were unreachable** (`src/storage/fts-index.ts`, `src/knowledge-graph.ts`) — CJK search was half fixed. The index side never normalised Unicode at all, and the query side normalised *after* segmenting, so decomposed Hangul was never split into bigrams. Text arriving as NFD — which macOS filesystem APIs, Finder and several Korean and Vietnamese IMEs emit, and which the hooks capture from file paths — could not be found in either spelling. `toIndexForm()` now owns "text → index tokens" for both sides. Existing databases rebuild their index once, through the locked path above.
-
-- **The committed dashboard bundle could not be reproduced on Windows** (`.gitattributes`, `scripts/build-dashboard.mjs`, `.github/workflows/ci.yml`) — found the moment the build-output gate started actually building. `.gitattributes` listed the ten extensions whose CRLF breakage had been noticed and left `.css` and `.html` out, so Windows checked out `dashboard/index.html` and `dashboard/src/styles/global.css` with CRLF, vite **inlined** them into `dashboard/dist/index.html`, and the carriage returns landed mid-line inside a shipped artifact — a real content difference that line-ending normalisation cannot undo. The rule is now `* text=auto eol=lf`: line endings are a property of text, not of a suffix list somebody remembered to extend. Renormalising changed no file, confirming nothing had been stored with CRLF.
-
-  Two compounding causes alongside it. `build-dashboard.mjs` ran `npm install` rather than `npm ci`, justified as tolerating lockfile drift in development — but the only moment `dashboard/node_modules` is absent is a clean CI checkout, so the convenience applied where it was never needed and the pinning was missing where it always is. And CI built the dashboard **twice**, once inside `npm run build` and again in a later step, with the second build landing *after* the release gates — so the gate diffed the artifact produced by the unpinned install. The redundant steps are gone. Verified by deleting `dashboard/node_modules` and rebuilding: the locked install reproduces the committed bundle byte-for-byte.
-
-- **A docs gate reported FAIL on a correct tree** (`scripts/verify-docs-sync.sh`) — the hook count was `find scripts/hooks -name '*.js' ! -name '_shared.js'`, which recurses, so when the build-generated mirror `scripts/hooks/_generated/` arrived the count went 7 → 9 and the gate failed every run. A gate that fails on a healthy repo gets ignored, and then it is not a gate. It now counts top-level files that are not underscore-prefixed — the convention already in use for "lives here but is not a hook".
-
-- **A failed database open poisoned the whole process** (`src/db.ts`) — pre-existing, found while reviewing this branch. `openDatabase` assigned its module singleton BEFORE finishing initialisation, so any throw after `new Database()` — a peer holding the write lock during `SCHEMA_SQL`, a read-only file, a failed extension load — left `db` pointing at a handle with no schema, no migrations and no sqlite-vec. `if (db) return db` then handed that handle to every later caller for the life of the process. Reproduced: with a peer holding `BEGIN EXCLUSIVE` the first call threw "database is locked" and the next returned the poisoned handle, throwing "no such table: memesh_metadata". The migration machinery's transient-error backoff exists precisely so a held lock is retried later, and it never got the chance. The singleton is now published only on success, and the abandoned handle is closed.
-
-- **A memory stored decomposed became unfindable the moment it was archived** (`src/knowledge-graph.ts`, `src/storage/fts-index.ts`) — pre-existing. Archived rows leave FTS5, so that branch matches with `LIKE` against the raw `name`/`content` columns — while its terms come from `tokenizeQuery`, which NFC-normalises. The two halves of one `search()` call therefore disagreed about normalisation, and only after archiving. Measured: a Vietnamese memory stored NFD was returned by `search('dữ liệu')` and absent from `search('dữ liệu', {includeArchived: true})` while its NFC twin was returned. A deterministic `memesh_nfc()` SQL function now normalises the stored side too, so both halves answer the same question. NFD is not exotic input — macOS filesystem APIs, Finder and several Korean and Vietnamese IMEs emit it.
-
-- **A query of combining marks alone claimed to be searchable** (`src/storage/fts-index.ts`) — pre-existing. `tokenizeQuery` accepted `[\p{L}\p{N}\p{M}]+`, which matches a run of marks with no base character. FTS5's `unicode61 remove_diacritics 1` treats those marks as separators for non-Latin scripts, so the `MATCH` phrase built from one can never hit a row. Measured for U+0E4D, U+0301, U+0951, U+064F and U+3099: `hasSearchableTerms` answered true and `search()` returned 0 — and because `recallEnhanced` gates the vector supplement on that answer, those queries skipped the keyword result and got semantically-nearest memories instead. A term must now start with a letter or a number; marks that follow one are untouched, so Thai tone marks, Devanagari matras, Arabic harakat and Hebrew niqqud all still tokenise as part of their word.
-
-- **The segmentation upgrade did not reach any existing database** (`src/db.ts`) — found by a six-specialist review of this branch, and the most serious thing in it. `rebuildFtsIndex` carried a fast path, `if (fromVersion === 1 && !hasDecomposedText(db)) return;`, justified by "v2 differs from v1 ONLY by NFC-normalising before segmenting". True when the target was 2. Version 3 also widens the script class, and **none of the newly-covered scripts has a canonical decomposition**, so the probe returned false for exactly the corpora the widening exists to fix. Measured: a v1 database holding Thai and half-width katakana came out of the upgrade with its marker stamped 3, its index still holding v1 whole-run tokens, and every fragment query returning nothing. The marker only moves forward, so it never self-heals.
-
-  It was also a **regression**: the query side does segment, so half-width katakana and CJK Extension B lost the exact-full-string query that worked before the upgrade. And `_shared.js`'s hook-side twin never had the skip, so the same database ended in one of two index states depending on which process opened it first — with doctor calling one of them damaged.
-
-  The skip is gone. A version-keyed shortcut is only sound while someone re-derives its premise at every bump, and nobody does; rebuilding unconditionally is also what makes the core and hook halves agree by construction. It bought back 140ms against 13ms on a 20k-entity database, once per database per bump.
-
-- **`memesh doctor` reported a healthy index as damaged, and put a line of your memories in a public issue body** (`src/core/doctor.ts`, `src/storage/fts-index.ts`) — two defects in the check added earlier in this release. Its predicate was "a term longer than a bigram that starts with an unspaced-script character", on the premise that a segmenting build cannot produce one. False: `segmentUnspacedScripts` leaves a LONE unspaced character untouched, and `unicode61` then joins it to adjacent ASCII, so an ordinary healthy database holds terms like `第1章` and `語abc`. Both were flagged, and both memories were findable — so the verdict was wrong, not merely noisy. The predicate now requires **three consecutive** unspaced-script characters, which segmentation can never emit.
-
-  The message also embedded an example term taken straight from `fts_vocab`. `memesh feedback` and the dashboard's feedback widget copy every doctor summary verbatim into a pre-filled **public** GitHub issue body, and diagnostics are opt-out — so that example was a line of the user's own memories staged for publication. It now reports a count, which is just as actionable: rebuild, re-run doctor, expect 0.
-
-- **Every spaceless script now segments, not only CJK** (`src/storage/fts-index.ts`, `src/db.ts`) — the fix above listed the scripts that had been reported (CJK ideographs, kana, hangul) rather than the property that makes them need fixing, so Chinese, Japanese and Korean started working and **Thai, Lao, Khmer, half-width katakana and CJK Extension B kept the exact defect**, invisibly, because no test used one. Measured on a fresh database: each stored correctly and was unfindable by any fragment of itself. All five are findable now, verified through the real index and the real query builder.
-
-  Segmentation is also code-point aware. Extension B lives above the BMP, so building bigrams over UTF-16 code units cut surrogate pairs in half — and a run of *only* non-BMP characters still matched, by accident of even alignment, which is why this needed a mixed-width case to expose. With one BMP character beside one above it, the bigram straddling the boundary was `[low surrogate] + 「資」`, so the legitimate token was never produced and no query could reach it.
-
-  `FTS_SEGMENTATION_VERSION` goes to 3, so existing databases rebuild their keyword index once on first open, through the locked migration path. Entity and observation rows are not touched. Spaced scripts are unaffected: Cyrillic, Greek and Devanagari are asserted to pass through byte-for-byte, since widening a character class is precisely how a script that *does* use spaces gets bigrammed by mistake.
-
-- **`memesh reindex --fts`** rebuilds the keyword index on demand, and **`memesh doctor` now reports when you need it** (`src/core/doctor.ts`). The version marker only moves forward, so it cannot describe a database migrated by a newer build and then written to by an older one — reachable by a downgrade, or by an npm-global and a plugin-marketplace install side by side. Two comments claimed doctor detected this state; nothing did, so it was silent by construction: `entities` stays intact, every health signal stays green, and the affected memories are simply unfindable by any partial-phrase query, permanently. The new `fts_segmentation` check looks for what the old rules leave behind — an indexed term longer than a bigram made entirely of unspaced-script characters, which a segmenting build cannot produce — and names the offending term so you can tell whether the rebuild worked.
-
-- **A failing database reported both `pass` and `fail`** (`src/core/doctor.ts`) — the "Database opened successfully" row was pushed as soon as the entity count came back, so anything that threw afterwards was caught and appended a *second* row with the same `database` id and status `fail`. The overall verdict was right and the row a reader looks at was wrong: `checks.find(c => c.id === 'database')` returned the passing one. The block now stages its rows and emits exactly one, whichever way it ends. Found by mutation-testing the check above — with the duplicate present, deliberately breaking the new check left the whole suite green.
-
-- **`verify_agent_work` still passed on a claim it never evaluated** (`src/core/verifier.ts`) — with no discoverable git base, `expected_files` was never compared, yet a report saying `pass: true` produced an unqualified `pass`. A supplied claim that could not be evaluated is now `unverified`. `pass` returns as a deprecated alias for `verdict === 'pass'`, so callers upgrading from 4.2.10 keep working — but an unverified run reads `false`, which is what the old boolean got wrong.
-
-- **A query with no searchable terms returned recent memories** (`src/knowledge-graph.ts`) — `"???"`, `"@#$%"` and the like fell through to the recent list, so unmatched memories came back labelled as results. It returns empty now. A genuinely empty query still lists recent. **Behaviour change.**
-
-- **Recall was not reproducible** (`src/knowledge-graph.ts`) — `ORDER BY f.rank` had no tiebreaker and BM25 ties are the common case, so which rows survived `LIMIT` to reach the scorer was left to SQLite. Ties now break by recency.
-
-- **The prompt-injection fence did not own its own fence** (`scripts/hooks/_shared.js`) — `buildReferenceContext()` declares its contents to be data rather than instructions, then interpolated caller text verbatim. `pre-edit-recall.js` passed raw observation text, so a stored memory containing a newline and a triple-backtick closed the fence and had the rest read as instructions. The renderer now guarantees it: whitespace is collapsed and the fence outgrows any backtick run in the content.
-
-- **`.gitignore` re-included a subtree over the top of the global rules** — `!benchmarks/longmemeval/**` is a recursive negation, and a later negation wins, so it overrode `.env` and `data/` for that whole subtree, in a public repo, in the directory `REPRODUCE.md` tells people to download a dataset into. The line was also unnecessary.
-
-- **The publish path enforced less than the review path** (`.github/workflows/publish-npm.yml`) — version coherence, F5 mirror drift and the doctor manifest gate ran on every PR and on no release. `.claude-plugin/*.json` ship inside the tarball, so a partial version bump reached plugin-marketplace users unchecked. `npm run verify:release` is now the one place that answers "is this shippable": lint, typecheck, version coherence, F5 mirror drift and the consumer-tree dependency audit, with the doctor manifest gate as its own step in the same workflow, plus a tag-vs-`package.json` check before anything is installed, plus `prepublishOnly` so a manual publish cannot bypass them.
-
-  Lint and typecheck were added to it because the asymmetry reappeared in the other direction: CI hard-gates on `eslint --max-warnings 0`, `verify:release` did not, and a variable left dead by a fix earlier in this release turned CI red for several commits while every local gate stayed green. A check that only one of the two paths runs is the defect this entry describes, whichever path is missing it. Break-tested: with the dead variable restored, `npm run verify:release` exits 1; without it, 0.
-
-- **One hook and two commands were not guaranteed executable** (`scripts/set-executable-bits.mjs`, `tests/installation.test.ts`) — the chmod list omitted `user-prompt-intent.js`, and had drifted from `package.json` `bin` in both directions: `dist/transports/cli/cli.js`, the `memesh` command itself, was committed at mode 100644. Both lists are derived from their manifests now, and the packaged smoke test checks the mode rather than only the file's presence.
-
-- **The auth screen gave a screen-reader user nothing, and a wrong token no feedback at all** (`dashboard/src/components/AuthPrompt.tsx`, `dashboard/src/App.tsx`) — the error had no live region, the input was not focused on a screen reached involuntarily by a 401, `required` made the empty-token message unreachable, and pasting a rejected token produced no message in any locale. Fixed, with `auth.invalid` added to all 11 catalogues.
-
-- **Published claims that no longer matched the code** — README.md and six locales still advertised LLM query expansion, removed in v4.2.0. `REPRODUCE.md`'s "verify the aggregation" recipe loaded the retired adapter result, so following it recomputed the 95.40% this release retracts. `RESULTS.md` cited the superseded v4.2.10 run as "the shipped path" and never named the two 2026-07-29 files every published number comes from. `METHODOLOGY.md` documented the vector-similarity formula this release replaced, overstated what the CI floor guards, and was still headed v4.0.4. `MANUAL-VERIFICATION.md` audits the retired adapter and is now labelled historical instead of being cited as evidence for the current figure.
-
-- **The auth screen's translation fallbacks were dead code** (`dashboard/src/components/AuthPrompt.tsx`, `dashboard/src/lib/i18n.ts`) — five lookups were written as `t('auth.x') || 'English literal'`, which reads as a safety net and cannot be one: `t()` returns the key string itself on a miss, and a non-empty string is truthy, so the right-hand branch is unreachable. When those keys were genuinely missing from every locale, this screen rendered `auth.title` at a remote operator and the fallback did nothing. The keys and a guard test both landed earlier; the dead branches did not, leaving five unsynced copies of the English strings that no build step compares against the catalogue. They are removed — English is already the fallback inside `t()` (locale → en → key), and `tests/dashboard-i18n.test.ts` fails the build if a key used in a component is absent from the English catalogue.
-
-  Found while auditing that file: the token input's `placeholder` was a hardcoded `"paste token here"`, the one string on this screen that never went through translation. Now `auth.tokenPlaceholder`, added to all 11 locales.
-
-- **`verify_agent_work` no longer reports a pass when it verified nothing** (`src/core/verifier.ts`, `src/transports/cli/cli.ts`, `src/transports/mcp/handlers.ts`, `src/core/schema-export.ts`) — both `claim` and `report` are optional. With neither supplied the tool counted changed files, which is not a check against anything, and then said so with `pass: true`.
-
-  Measured before changing anything, calling it with only a workdir:
-
-  ```json
-  {
-    "pass": true,
-    "reality_check": {
-      "match": null,
-      "expected_files": null,
-      "summary": "18 files changed (no claim to check against)"
-    },
-    "external_report": null
-  }
-  ```
-
-  It also wrote a permanent memory reading `Agent <id> verification: PASS`, tagged `verification:pass`, which a later `recall` hands to another agent as evidence the work was checked. And `memesh verify` printed `PASS` and **exited 0**, so a gate written as `memesh verify … && deploy` deployed on a check that never ran.
-
-  The root cause was two absences multiplying into a pass: `realityCheck()` returned `pass: true` when there was no claim, and the overall verdict was `rc.pass && (input.report?.pass ?? true)` — a missing report defaulting to true. Absence of evidence was being read as evidence.
-
-  `pass: boolean` is replaced by `verdict: 'pass' | 'fail' | 'unverified'` on both the result and its nested `reality_check`. One tri-state rather than a boolean plus a `verified` flag, because two fields describing one fact is how the `recall_hits` double-writer happened. A `pass` now requires that something was actually checked — a matched file claim, or a supplied external report; any `fail` still wins over both. `unverified` also covers the cases where the check could not run at all (no git base discoverable, `git diff` failed), which previously returned `pass: false` and read as "the agent's work failed" rather than "this tool could not look".
-
-  Recording a snapshot without a claim — the mode a test called "informational" — still works and still reports what it saw. It just stops calling itself a pass.
-
-  Surfaces updated so none of them can round the third state back to two: the entity tag is `verification:unverified`, the stored observation reads `UNVERIFIED`, the MCP and OpenAI-function tool descriptions tell the model that calling with neither argument checks nothing, and `memesh verify` prints `UNVERIFIED`, says what to pass to actually verify something, and **exits 2** — distinct from 0 (pass) and 1 (fail) so a shell gate cannot confuse "checked nothing" with success. A caller still reading `pass` — on the result or on the nested `reality_check` — gets a deprecated alias for `verdict === 'pass'` at both levels, so upgrading from 4.2.10 does not break it, and an unverified run now reads `false` where the old boolean read `true`. Both are removed together in a later minor.
-
-  Pinned by seven cases in `tests/core/verifier.test.ts` covering each cell of the claim × report matrix plus the stored tags and observation text. Proven non-vacuous by restoring the old combining rule: **3 of 19 tests fail**, and pass again once reverted.
-
-- **`recall_hits` has one owner again** (`src/storage/conflicts.ts`, `src/knowledge-graph.ts`) — the column was written by two code paths with incompatible definitions. The Stop hook writes it to mean "a memory we injected was actually used", checking the transcript and recording a hit *or* a miss; `search()` also wrote it to mean "this memory was returned", which can only ever add to the hit side. `scoring.ts::impactScore` reads the pair as `(hits+1)/(hits+misses+2)`, a ratio that is only meaningful if both sides answer the same question. Retrieval paths now track access only — "was returned" is already recorded by `access_count`, in the same statement. Measured on a real 91-entity database the two definitions had not yet collided (29 hits against 365 misses; the impact factor's median sat exactly at the neutral 0.5), but OR-joined query terms return far more rows per search than the old AND semantics did, which is when a one-sided writer starts to matter. The `incrementHits` option is gone with its last caller.
-
-- **`include_archived` searches for what you asked, not for a literal substring of it** (`src/knowledge-graph.ts`) — archived rows are removed from FTS5 by `archiveEntity()`, so they are matched with `LIKE`, and that branch interpolated the whole raw query. A question phrased in your own words therefore found the active copy of a memory and missed the archived one, and a CJK query missed entirely because it was never segmented. The branch now matches the same terms `buildMatchExpression()` produces — same tokenising, same document-frequency guard — OR-ed together, with `LIKE` metacharacters escaped.
-
-- **The `recall` MCP tool now tells the model how its query will be read** (`src/transports/mcp/handlers.ts`) — the description said only "uses FTS5 full-text search", while the query is OR-ed, ranked by BM25, capped at 32 terms, and has ubiquitous words removed. An agent choosing between a keyword and a sentence had nothing to go on.
-
-- **The packaged-artifact smoke test says so when it passes, and checks every hook** (`scripts/smoke-packed-artifact.mjs`) — it printed nothing on success, which is indistinguishable from not having run. That is the exact failure mode this release has spent several changes removing from the product.
-
-  Its required-files list also stopped at five hooks while the project ships seven, so `pre-bash-orchestration-nudge.js` and `user-prompt-intent.js` were packaged but never verified — a narrowed `files` glob would have produced a tarball this test called good. The list is not corrected to seven; the hooks are now **derived from `hooks/hooks.json`**, so a hook that the plugin manifest can invoke cannot go unchecked no matter how many there are. `_shared.js` and the two build-generated files under `scripts/hooks/_generated/` are asserted too — hooks cannot import from `dist/`, so those three are the whole of their dependency surface, and without them every hook throws on first require.
-
-- **Published benchmark results no longer record the absolute path of the machine that produced them** (`benchmarks/longmemeval/run.mjs`) — `run_info.dataset` held the full path to the dataset file, which in a public repository means publishing a local home directory. It records the basename now; `dataset_sha256`, which is what actually identifies the dataset, is unchanged. The two result files already committed with a path had that one field edited and the edit is stated in `benchmarks/longmemeval/results/README.md`; every measurement in them is byte-identical. Note that the earlier path remains in git history, in the commit that first added those files.
-
-- **`package-lock.json` carried the version from four releases ago** — its two self-version fields read `4.2.6` through v4.2.7, v4.2.8, v4.2.9 and v4.2.10, because the lockfile was missing from the version-anchor checklist. Only those two fields changed; all 520 dependency entries are byte-identical.
-
-- **The vector half of "hybrid search" was doing nothing, and now does what it says** (`src/core/embedder.ts`, `src/core/operations.ts`) — two constants encoded the same wrong assumption about what `entities_vec` returns. The table is declared `vec0(embedding float[N])` with no `distance_metric`, so sqlite-vec measures **L2**; over unit vectors that is a 0…2 range, and related text lands at 1.0–1.44. Both constants assumed a 0…1 cosine-distance scale:
-  - `MAX_VECTOR_DISTANCE = 1` discarded essentially every hit. Measured over 50 LongMemEval questions: **5 of 1000 vector hits survived it (0.5%)**, while the correct session sat at a median distance of 1.187 — above the cut. Embeddings were being generated, stored and searched, and the results thrown away before anything could use them.
-  - `1 - distance` as the similarity mapping sent **98.8% of hits to exactly 0.0** relevance, which is the value `rankEntities` treats as "no signal".
-
-  The cut-off is now **1.30** and the mapping `1 - distance/2`, extracted as `vectorSimilarity()` next to the constant it shares a scale with — keeping them in separate files is how they drifted apart. 1.30 is calibrated, not derived: the geometric answer (√2, exactly cosine 0) turned out to sit in the *middle* of the noise, because MiniLM's space is roughly isotropic and unrelated text lands at cosine 0 rather than below it. Measured, a nonsense query's nearest neighbour is at 1.371–1.430 while genuinely related text is at 0.872–1.157. Recall cost of choosing the tight end: none — R@5 measured identical (95.0%) at thresholds 1.20, 1.35, 1.50 and 2.00.
-
-  **What this does not do is raise the benchmark score**, and that is worth stating plainly rather than implying otherwise: R@5 is unchanged. What changes is that the feature is no longer inert, a query matching nothing lexically can now be answered semantically, and a nonsense query still honestly returns nothing.
-
-  Re-measured on the release tree, with the full 500 questions run in both modes: **14 of 500 result lists now differ** between embeddings-off and embeddings-on, where before the fix they were identical to sixteen decimal places. Only two questions move the correct session — one from "not found" to rank 14, one from rank 14 to 16 — so R@5 and R@10 are unchanged and MRR moves 0.8929348706848708 → 0.8930598706848707, a gain of 0.000125 for 89× the wall-clock (807.7s against 9.1s). This **refutes a prediction the benchmark docs used to make**, that the remaining failures were "dominated by vocabulary mismatch — exactly what a working vector supplement would cover". The supplement works now and covers one of the 22, at a rank no one would ever scroll to. MiniLM-L6 at 384 dimensions is not the cure for that class, and the docs say so instead of quietly dropping the claim. Recall stays LLM-free and embeddings stay opt-in.
-
-- **Recorded, not fixed: a vector hit cannot outrank the best keyword hit, however certain it is** (`src/core/operations.ts` docstring) — the two relevance values are not on the same scale. FTS relevance is *positional* (the top row gets 1.0 no matter how weak the match); a vector hit's is *absolute*, and a genuinely good semantic match sits near 0.4. Measured over 100 LongMemEval questions: of the 5 the keyword search missed, the vector index ranked the correct session **#1 in three of them**, and none surfaced in the top 5 at any distance threshold. The fix is rank fusion (score both sides by position, e.g. RRF); it was implemented and measured and **not adopted** — on this corpus it recovered 4 of the 5 misses and cost more elsewhere, R@5 95% → 92%. LongMemEval's haystack is padded with generic public Q&A that scores high on semantic similarity while being nobody's memory (`METHODOLOGY.md` §4.1), so it is the wrong corpus to tune fusion on. Revisiting it needs a corpus of personal notes where the question's vocabulary differs from the note's.
-
-- **Chinese, Japanese and Korean memories are searchable by part of a phrase, not only by their exact stored text** (`src/storage/fts-index.ts`, `src/knowledge-graph.ts`, `src/db.ts`) — FTS5's `unicode61` tokenizer classifies every CJK character as a letter and puts no boundary between them, so an unbroken run indexed as **one token**. A memory holding 「資料庫遷移前一定要先備份」 could be found by searching that exact string and by nothing else: 「資料庫遷移」 matched nothing, 「備份」 matched nothing. Measured on a mixed corpus, Chinese recall was **2/9** while English was 4/4 — which is why it stayed invisible. For anyone whose notes are in one of these scripts, keyword recall was effectively broken.
-
-  Text now passes through `segmentUnspacedScripts()` on the way into the index and on the way into a query, cutting unspaced-script runs into overlapping character bigrams (「資料庫遷移」 → 「資料 料庫 庫遷 遷移」). Latin text is returned byte-for-byte unchanged, so English behaviour is untouched — the 500-question LongMemEval-S run is identical before and after (R@5 95.60%, R@10 97.80%, MRR 0.8931 at the commit where this was measured; the release figure is 0.8929 after the later vector-threshold and document-frequency changes — see `benchmarks/longmemeval/RESULTS.md`). Chinese recall on the same mixed corpus goes **2/9 → 9/9**.
-
-  Chosen over migrating `entities_fts` to FTS5's `trigram` tokenizer, which measured **3/9** on the same corpus for **4×** the index size, against 9/9 and 1.6× here — and which would have meant recreating the virtual table rather than only its contents. Because the segmentation lives in `fts-index.ts`, the hooks' always-on capture path picks it up through the build-generated mirror (`scripts/hooks/_generated/fts-index.js`) with no hook change at all.
-
-  **Existing databases rebuild their index once, automatically, on the next open** (`fts_segmentation_version` in `memesh_metadata`, following the `embedding_dimension` idiom). Without it the change would take CJK recall from bad to zero on upgrade, silently, since English would keep working. Measured at 19ms for 5,000 entities, so it runs inline; a failure logs and retries next start rather than blocking the database from opening.
-
-  Known bound, pinned by a test rather than chased: a single-character query becomes a prefix match, so it reaches any bigram starting with that character but not one where it sits last (「收」 will not find 「營收」). Fixing that means indexing every character as well, for a rare query shape.
-
-- **`memesh reindex` reported success for work it had not done** (`src/core/embedder.ts`, `src/core/operations.ts`, `src/transports/cli/cli.ts`) — pre-existing. `embedAndStore()` has six exits and exactly one of them writes a vector, but it returned `void` from all six, so the only signal a caller got was "it didn't throw". `reindex()` read that as success: `await embedAndStore(...); embedded++`. A provider whose dimension no longer matched the index therefore produced a full `Embedded:` count over an index nothing had been written to — and because `clearPendingReindexFlag()` then ran unconditionally, the one piece of state telling `memesh doctor` the index still needed refilling was erased too. The command printed `✅ Reindex complete` and exited `0`.
-
-  `embedAndStore` now returns which of the six things happened, `reindex` counts by outcome, and the decision to clear the flag is taken from the **database** — active memories that have observation text but no vector row — rather than from what the loop believed it did. An incomplete run prints `⚠️  Reindex incomplete` with a per-reason breakdown, leaves the flag set, and exits `1`, so a script that shells out to it can tell the two apart. Memories whose observations are all blank are excluded: they can never have a vector, and requiring one would keep the flag set forever.
-
-- **The vector index could still be destroyed on evidence the guard exists to distrust** (`src/db.ts`, `src/transports/cli/cli.ts`) — pre-existing, and the other half of the unreadable-config fix above. That guard was keyed to the config being *absent*, on the argument that an absent config is weak evidence for deleting a BYOK user's embeddings. It is — but `configDir()` follows `MEMESH_DIR`/`HOME` while `getDbPath()` follows `MEMESH_DB_PATH`, and every foreign-`HOME` case it was written for behaves identically when that `HOME` happens to *contain* a config file: a container image's default `config.json`, a second machine profile, an unrelated edit that dropped the embedder key. The guard then treated it as authoritative for a database it had never seen and took the `DROP` branch.
-
-  The refusal now follows the consequence instead of the evidence. Any disagreement between the stored dimension and the configured one keeps the existing index, because a stale index still works and is recoverable by fixing the config, while a dropped one is gone and on an API embedder has to be bought a second time. Deliberate embedder switches go through the new **`memesh reindex --vectors`**, which drops and recreates the table at the new dimension and immediately refills it — and which refuses if no embedding provider is available, rather than dropping the index and having nothing to refill it with. The refusal message also used to name `memesh reindex`, which cannot change a `vec0` table's width, so following the instruction led straight back to the same refusal.
-
-  Two more places where the destruction would have been wider than the repair, both found by reviewing the fix itself. `--vectors --namespace X` is now refused: `entities_vec` is one table for the whole database, so the rebuild drops *every* namespace's vectors while `--namespace` would refill only `X` — the rest would lose their embeddings permanently, silently, and outside anything the user asked for. And the count deciding the user-facing verdict is now scoped to the run, while the count deciding the database-wide `pending_reindex` flag stays unscoped; sharing one number made `memesh reindex --namespace personal` print `⚠️  Reindex incomplete` and exit `1` after a run in which everything it was asked to do worked — the same defect as the false success, pointed the other way.
-
-### Changed
-
-- **Every published claim that no longer matched the code has been corrected** (`README.md` + 10 locales, `docs/ARCHITECTURE.md`, `skills/memesh/SKILL.md`) — a sweep prompted by finding that the headline benchmark figure described a different implementation. Each was checked against source before being rewritten, not adjusted by eye:
-  - **The R@5 figure, 11 READMEs × 4 places.** 95.40% was the benchmark's own reimplementation; the shipped path measures **95.60%**. The comparison row now names the code path (`MeMesh (Mode A, via recallEnhanced())`) so the number cannot be read as describing something else again.
-  - **The scoring weights.** READMEs said `frequency (15%) + confidence (15%)`; `DEFAULT_WEIGHTS` in `src/core/scoring.ts` has been `0.18` / `0.17` since the temporal-validity factor was removed.
-  - **`temporal validity` as a scoring factor.** Listed in all 11 READMEs and in `skills/memesh/SKILL.md`, in two places each. It was deleted from `scoring.ts` in 2026-05 — the `valid_from` / `valid_until` columns it read were never written by any code path, so it had been a constant 1.0 no-op even before that.
-  - **`~18ms/query`.** That figure was 9.2s ÷ 500 questions, and each question includes *building a fresh 50-session database*. A recall itself measures ~4ms on that corpus (300-call mean). Restated as per-recall.
-  - **`README.th.md`** additionally advertised LLM query expansion on `recall`; `query-expander.ts` was removed in v4.2.0 and recall has been strictly LLM-free since.
-  - **`docs/ARCHITECTURE.md`** attributed 95.40% / 9.2s / "within 1.2pp" to this codebase; those came from the harness. Now 95.60% / 9.1s / 1.0pp, with the provenance of the old figure stated.
-
-- **The LongMemEval benchmark now measures the shipped retrieval path** (`benchmarks/longmemeval/run.mjs`, `benchmarks/longmemeval/*.md`, `tests/recall-quality.test.ts`) — the runner used to carry its own `CREATE TABLE`, its own FTS5 query construction and its own ranking, so the published 95.40% R@5 scored that reimplementation rather than MeMesh. The two had drifted: the runner OR-joined query terms and ordered by BM25 `rank` while the shipped `search()` AND-joined and ordered by `e.id DESC`. On the same 500 questions the runner reported 95.40% and the product scored 5.20%, with 473 of 500 questions returning nothing — the defects fixed earlier in this release. A benchmark that reimplements the thing it measures cannot fail when the thing breaks.
-
-  The runner now seeds through `KnowledgeGraph.createEntity()` (the call `remember()` makes) and retrieves through `recallEnhanced()` (the call every transport makes), and records `run_info.measures: "shipped_recall_path"` so a result file states what produced it. Modes now name real product configurations — A without embeddings, B with them — instead of adapter-internal fusion strategies; mode C applied a 60/40 weighted fusion MeMesh has never implemented and is removed. Result files from before the change are kept unmodified and labelled in `benchmarks/longmemeval/results/README.md`.
-
-  Two published claims were corrected rather than quietly dropped. `RESULTS.md` said the figure was "measured using FTS5 full-text search — the same retrieval engine MeMesh uses in production"; it was not. `METHODOLOGY.md` §3 concluded that the benchmark was "a conservative lower bound on MeMesh's production retrieval quality — the full system would score at least as well, likely better", which the 5.20% measurement disproved in the most direct way available. §4.2 had listed OR-joining as an adapter *limitation* while the product AND-joined — the divergence was written down next to the number and read as a caveat about the harness.
-
-### Fixed
-
-- **Committed build output could drift from source, and only the install channel that cannot notice was affected** (`scripts/generate-skills-manifest.mjs`, `scripts/check-generated-mirror.mjs`) — `dist/` is tracked in git because plugin-marketplace installs run it directly: they install with `--ignore-scripts` and never build. Nothing verified it matched `src/`. Found during review of this branch — a source-only commit had left `dist/db.js.map` stale, and every gate reported green.
-
-  `npm publish` was never exposed, because `prepublishOnly` rebuilds first. That is precisely why it could persist: the one channel that ships committed output is the one no gate covered.
-
-  The reason no gate existed is worth naming. `dist/skills-manifest.json` carried a `generated_at` timestamp, so **every build produced a different file** and "is the committed output current?" had no answer a diff could give. The field was written and never read — `doctor.ts` verifies `entries[].sha256` and nothing else — so it is gone, and the build is now reproducible (verified by building twice and comparing bytes). `check-generated-mirror.mjs` then extends from the hook mirror alone to all three committed build outputs, and counts untracked files too, since a new compiled file that was never committed is exactly as stale as a modified one. Break-tested: changing `FTS_SEGMENTATION_VERSION` and rebuilding without committing exits 1.
-
-### Tests
-
-- **A mutation sweep over this release's fixes, and the five gaps it found** (`tests/vector-index-safety.test.ts`, `tests/gitignore-scope.test.ts`, `tests/migration-atomicity.test.ts`, `tests/recall-relevance.test.ts`, `tests/hooks/pre-edit-recall.test.ts`) — every fix above was re-broken one line at a time in a throwaway worktree to see whether any test noticed. Eleven of nineteen died as intended; the rest exposed fixes shipping unwatched, and one test of ours that was watching nothing:
-
-  - **The vector-index guard had no test at all** — the fix that stops an unreadable config from deleting a BYOK user's embeddings is two lines in two files, and reverting *either* left the whole suite green. It was measured during development and never pinned. `tests/vector-index-safety.test.ts` now seeds a real 1536-dim vector, truncates the config, and asserts the vectors are still there.
-  - **The migration backoff was written but never read** — the existing case asserted an attempt timestamp gets recorded. Nothing asserted it *suppresses* the next attempt, so deleting the check passed. Both halves are now pinned.
-  - **A peer's lock was not distinguished from a broken migration** — `isTransientDbError` could be made to always return false undetected. Tested by throwing the lock error directly: while a lock is genuinely held, the catch block's own marker write is blocked too, so the two branches are indistinguishable from outside.
-  - **The determinism test asserted a property SQLite already had** — it ran the same query five times against unchanged data and compared. That passes with or without a tiebreaker. It now names the expected set (`tied-29 … tied-25`), because the tiebreaker does not merely reorder the answer, it decides which memories are in it.
-  - **The `.gitignore` fix had no test, and the obvious test would have lied** — `git check-ignore -v` exits 0 when a **negation** matches, so a first version of the helper reported a leaked `.env` as safely ignored. The plain form is the honest signal. Both directions are asserted: the secrets stay ignored and the 16 tracked benchmark files stay trackable.
-
-  A second round then covered the fixes the first had never enumerated — nineteen hand-picked lines is not the same as covering the release. All four survived, and one of the tests written for them found two more live instances of the bug it was written for:
-
-  - **`pre-compact` announcing a save that may not have happened** had no test. Forced through `captureEntity`'s null path with a CHECK constraint — `INSERT OR IGNORE` skips the violating row, so the follow-up SELECT finds nothing — without stubbing anything.
-  - **Two more undefined CSS tokens were still live** (`--bg-elevated` and `--surface` in `SettingsTab.tsx`), the same class as the `--font-mono` typo this release fixed. Custom properties fail silently, so those elements simply rendered wrong and no runtime test could see it. `tests/dashboard-design-tokens.test.ts` now asserts every `var(--x)` names a token the stylesheets define, and that no dead `t(...) || literal` branch exists — the shape `tests/dashboard-i18n.test.ts` skips by design.
-  - **The guard that stops the dependency gate passing on an empty tree** was itself unpinned. `tests/consumer-audit-gate.test.ts` stubs `npm` so every step reports success while installing nothing; the script has to refuse to pass.
-  - **The AuthPrompt fix was only half covered**, and the covered half was the incidental one. The token typo and the dead `t(...) ||` branches are caught by the test above; what the fix was actually about — a screen reader being told nothing, and a wrong token producing no feedback at all — was not. `tests/dashboard/AuthPrompt.test.tsx` asserts the announced state: `role="alert"` on both error surfaces, `aria-invalid` plus `aria-describedby` wired to the message's id, and silence before the operator has tried anything.
-  - **`release-verify.sh` no longer editing the maintainer's real config** had no test. Structural, deliberately: the regression is not "the output changed", it is "the script started writing to `~/.memesh/config.json` again", and a test that ran it for real would need a real config to damage.
-
-  The one property first written off as untestable is now pinned too. `reindexFts()` commits its rebuild and its marker in a single transaction, and the earlier conclusion — that observing it needs the process killed mid-transaction — was a failure to design the test, not a property that cannot be seen. A `BEFORE INSERT` trigger on `memesh_metadata` fails the marker write exactly where a crash would, in-process and deterministically; splitting the transaction then leaves a rebuilt index under a stale marker, which the test catches. `.immediate()` on that same call is separately confirmed as NOT load-bearing — `rebuildFtsIndex` runs a write first there, so DEFERRED takes the lock at the same instant — and `src/db.ts` says so rather than implying the keyword is doing work it is not.
-
-- **A retrieval-quality floor that runs on every CI leg** (`tests/recall-quality.test.ts`) — the LongMemEval dataset is a 278 MB download and committing a slice is dataset redistribution, so the gate uses a small synthetic corpus instead: ten memories, ten questions phrased as a person would ask them, and thirty function-word notes so `limit: 5` has to choose which rows reach the scorer. It asserts an aggregate R@5 floor of 80% (measured 100%) and is calibrated to catch collapse, not drift. Measured by breaking each fix in turn: AND-joined terms take it to 0% and ordering by `e.id DESC` takes it to 20%, both failing the gate; flat relevance (100%) and whitespace tokenising (90%) do not breach it, because they cost individual terms and positions rather than whole answers. That split is recorded in the test file — those two are pinned by the targeted cases in `tests/recall-relevance.test.ts`, where one mechanism can be isolated. Use the gate for "did retrieval collapse", the targeted file for "did this mechanism regress".
-
-### Fixed
-
-- **`recall` now finds the memory when you ask a question in your own words** (`src/knowledge-graph.ts`, `src/core/operations.ts`) — four defects in the retrieval path compounded into near-total recall failure for anything but a single keyword, and each one hid the others.
-
-  1. **Query terms were AND-ed.** `search()` joined the quoted tokens with a bare space, which is FTS5's implicit AND, so every word of the query — including `what`, `did`, `I`, `with` — had to appear in the same memory. Recall therefore got *worse* the more precisely you asked: measured over LongMemEval-S, R@5 fell from 62.5% with one keyword to 41% with two, 29% with three and 18% with five. Terms are now OR-ed, so a memory matching more of the query ranks higher instead of being excluded outright.
-  2. **Relevance was discarded before ranking.** The SQL ordered by `e.id DESC` and applied `LIMIT` — so the *newest* matches survived to the multi-factor scorer and the best match was thrown away before it could ever be scored. FTS5's `rank` (BM25) column was available and unused. With 26 or more memories mentioning a term, the most relevant one became unreachable at any database size — a failure that grows silently as a memory base fills up. Ordering is now by `rank`; recency still counts as one of the five scoring factors, it just no longer decides what gets scored.
-  3. **The relevance signal was flattened.** Every FTS hit entered `rankEntities()` with a hard-coded relevance of `1.0`, tying them all on the 0.30 relevance weight and letting the scorer re-sort purely on recency/frequency/confidence — undoing the ordering the search had just computed. Relevance is now graded by BM25 position. This one is invisible in a fresh database (equal factors, ties preserve order) and decisive in an aged one, which is why it ships with the others rather than after them.
-  4. **Punctuation inside a word turned it into a phrase requirement.** Tokens were split on whitespace and then quoted whole, so `kitchen's` became the FTS5 phrase `kitchen s` and `gardening-related` became `gardening related` — matching only a memory containing those words adjacent and in that order. A memory that said "kitchen", or "gardening", was missed outright. Queries are now split on the boundaries FTS5's `unicode61` tokenizer uses: `[^\p{L}\p{N}\p{M}]+` over an NFC-normalised query. `\p{L}\p{N}` keeps non-Latin scripts alive — a plain `[^a-zA-Z0-9]` strip would reduce a CJK query to the empty string, which silently falls through to the recent-list path and looks like a successful search. `\p{M}` and the NFC normalisation both address decomposed text, where splitting on a combining mark cut the word in half: NFD `naïve` became the two OR-ed terms `nai` and `ve`, neither of which is a token in the index (unicode61 folds the mark, so the indexed token is `naive`). For Latin either mechanism alone is sufficient; both are kept because they fail differently, and for scripts where unicode61 treats marks as separators rather than folding them, keeping the mark makes the query a phrase of adjacent fragments instead of a bag of OR-ed letters — same recall, better precision.
-
-  Measured end to end on the same 500 LongMemEval-S questions the published benchmark uses, through `recallEnhanced()` — the code path a real `recall` call takes: **R@5 5.20% → 95.60%, R@10 5.20% → 97.80%, MRR 0.0520 → 0.8929, and questions returning zero results 473/500 → 0/500.**
-
-  Limit at the time of this fix, and the reason the CJK entry above exists: `unicode61` treats an unbroken run of CJK characters as a single token, so a substring of it could not match. That was left standing here and lifted later in this same release — by bigram segmentation rather than the trigram tokenizer this note originally proposed, which measured worse on both recall and index size.
-
-  Behaviour note: OR raises recall and lowers precision. A query now returns weaker partial matches below the strong ones instead of returning nothing, and result lists are longer. Ranking, not exclusion, is what keeps the top of the list clean. The hooks are unaffected — `pre-edit-recall` searches a single file basename and `session-start` issues no query.
-
-### Tests
-
-- **Regression suite for the recall-quality class the old tests structurally could not catch** (`tests/recall-relevance.test.ts`) — the pre-existing `search()` tests always queried with the *exact literal string that was stored* (`observations: ['shared query terms']` then `search('shared query terms')`), so AND semantics could never fail and relevance ordering was never exercised. The new cases pin what a memory layer actually has to hold: a question whose words are scattered through the memory still finds it, a memory matching more terms ranks first, a relevant older memory beats 40 newer passing mentions (both in `search()` and after the `recall()` scoring pass), and a query sharing no term with anything still returns nothing. Two older assertions in `tests/core/operations.test.ts` and `tests/core/integration.test.ts` were pinning result *counts* that only held under AND; they now assert the archiving contract they were actually written for.
+- **The test suite went from 253s to 40s** (`src/core/embedder.ts`,
+  `scripts/run-tests-isolated.mjs`, `ci.yml`) — the local embedding model caches
+  at `~/.memesh/models`, which is right for a real install and wrong for anything
+  that isolates `HOME`, so every test that spawned the CLI or a hook under a
+  per-test `HOME` re-downloaded 98 MB. Measured on a first write in a fresh
+  `HOME`: 19.4s wall clock, 1.21s user, 8% CPU — almost entirely network wait,
+  which is why it looked like slow tests rather than a download.
+  `MEMESH_MODEL_CACHE_DIR` points the cache somewhere stable; the default is
+  unchanged. CI was paying this on every leg of the matrix, and it made the whole
+  matrix depend on `huggingface.co` being reachable — a third-party outage would
+  have turned it red with nothing wrong in the code. CI also caches the model
+  between runs now, removing the first download too.
 
 ## [4.2.10] — 2026-07-25
 

--- a/docs/api/API_REFERENCE.md
+++ b/docs/api/API_REFERENCE.md
@@ -598,8 +598,8 @@ Use `?cached=1` to read the cached state only. Without it, MeMesh prefers a fres
 {
   "success": true,
   "data": {
-    "currentVersion": "4.2.8",
-    "latestVersion": "4.2.9",
+    "currentVersion": "4.2.10",
+    "latestVersion": "4.2.11",
     "checkedAt": "2026-04-24T10:15:00.000Z",
     "lastAttemptAt": "2026-04-24T10:15:00.000Z",
     "lastSuccessfulCheckAt": "2026-04-24T10:00:00.000Z",

--- a/scripts/check-version-coherence.mjs
+++ b/scripts/check-version-coherence.mjs
@@ -23,7 +23,9 @@
 
 import fs from 'fs';
 import path from 'path';
+import { execFileSync } from 'child_process';
 import { fileURLToPath } from 'url';
+import { checkMainDeclaresPublishedVersion } from './lib/published-version.mjs';
 
 // Windows note: `new URL(import.meta.url).pathname` returns a leading-slash
 // drive path on Windows (e.g. "/D:/..."), which `path.resolve` then
@@ -164,6 +166,38 @@ for (const docPath of ['docs/ARCHITECTURE.md', 'docs/api/API_REFERENCE.md']) {
       errors.push(`${docPath} (${m[1]}) !== package.json (${pkgVersion})`);
     }
   }
+}
+
+// --- `main` must not declare a version nobody can install ---
+//
+// Every check above asks "do these seven files agree with each other?", which
+// they did throughout the five days `main` claimed a 4.2.11 that npm did not
+// have. Agreement among the anchors says nothing about whether the version they
+// agree on was ever released. See scripts/lib/published-version.mjs.
+function gitLines(args) {
+  try {
+    return execFileSync('git', args, { cwd: repoRoot, encoding: 'utf8' })
+      .split('\n')
+      .map(s => s.trim())
+      .filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+// GITHUB_REF_NAME is `main` on a push to main and `<n>/merge` on a pull
+// request, so a release PR — which legitimately carries the bump before the tag
+// exists — is skipped by the same rule that catches a merged one.
+const branch =
+  process.env.GITHUB_REF_NAME ?? (gitLines(['rev-parse', '--abbrev-ref', 'HEAD']) ?? [null])[0];
+const publishedTag = checkMainDeclaresPublishedVersion({
+  branch,
+  pkgVersion,
+  tags: gitLines(['tag', '--list', 'v*']) ?? [],
+});
+findings.push(`main-declares-published-version: ${publishedTag.status} — ${publishedTag.message}`);
+if (publishedTag.status === 'error') {
+  errors.push(publishedTag.message);
 }
 
 console.log('Version coherence audit:');

--- a/scripts/lib/published-version.mjs
+++ b/scripts/lib/published-version.mjs
@@ -1,0 +1,64 @@
+// Does `main` declare a version that anyone can actually install?
+//
+// v4.2.11 was bumped on 2026-07-29 and not tagged until 2026-08-03. For five
+// days `main` said `4.2.11` while npm's `latest` said `4.2.10`, and the
+// CHANGELOG grew a paragraph explaining the gap — a paragraph that was still
+// there, and by then false, when the release finally shipped. Nothing detected
+// any of it, because nothing was looking.
+//
+// The rule this enforces: **a version bump never rides in a feature or docs
+// PR.** `main` carries the last PUBLISHED version and work accumulates under
+// `CHANGELOG.md`'s `[Unreleased]`. A release bumps the anchors, renames the
+// section, tags and publishes in one sitting — so the window where `main`
+// declares an uninstallable version is minutes, and this check is what makes
+// those minutes loud instead of silent.
+//
+// Kept as a pure function, separate from the script that runs it, so both
+// directions can be pinned by a test without a repository to mutate. A gate
+// nobody break-tested is the defect class this repository keeps finding.
+
+/**
+ * @param {object} input
+ * @param {string|null} input.branch      Current branch, or null if undiscoverable.
+ * @param {string}      input.pkgVersion  `package.json` version.
+ * @param {string[]}    input.tags        Every `v*` tag visible to the checkout.
+ * @returns {{status: 'ok'|'skipped'|'error', message: string}}
+ */
+export function checkMainDeclaresPublishedVersion({ branch, pkgVersion, tags }) {
+  if (branch !== 'main') {
+    return {
+      status: 'skipped',
+      message:
+        `not on main (branch: ${branch ?? 'undiscoverable'}) — a release branch ` +
+        'legitimately carries the bump for the minutes before the tag exists',
+    };
+  }
+
+  // Absence is not evidence. `actions/checkout` fetches no tags by default, and
+  // an empty list would otherwise read as "no mismatch found" — the gate would
+  // pass on every run while checking nothing, which is precisely the shape of
+  // the checks 4.2.11 spent a release removing. Say "could not run" and fail.
+  if (!Array.isArray(tags) || tags.length === 0) {
+    return {
+      status: 'error',
+      message:
+        'no `v*` tag is visible, so this check could not run. A shallow ' +
+        '`actions/checkout` fetches no tags — set `fetch-tags: true` on the ' +
+        'checkout step. Reporting "not checked" rather than passing.',
+    };
+  }
+
+  if (tags.includes(`v${pkgVersion}`)) {
+    return { status: 'ok', message: `v${pkgVersion} is tagged` };
+  }
+
+  return {
+    status: 'error',
+    message:
+      `main declares ${pkgVersion} and no \`v${pkgVersion}\` tag exists — ` +
+      'that version is not installable by anyone. Either finish the release ' +
+      `(tag v${pkgVersion} and \`gh release create\`, which is what triggers ` +
+      'publish-npm.yml — a bare tag push does not), or revert the bump and put ' +
+      'the work back under `## [Unreleased]`.',
+  };
+}

--- a/tests/main-declares-published-version.test.ts
+++ b/tests/main-declares-published-version.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Pins the gate that stops `main` declaring a version nobody can install.
+ *
+ * v4.2.11 was bumped on 2026-07-29 and tagged on 2026-08-03. For five days
+ * every version anchor agreed with every other version anchor — which is all
+ * `check-version-coherence.mjs` used to ask — while the version they agreed on
+ * did not exist anywhere a user could reach.
+ *
+ * Both directions are asserted, because a gate that can only pass is the defect
+ * this repository keeps finding. In particular: an empty tag list must FAIL.
+ * `actions/checkout` fetches no tags by default, and "found no mismatch in zero
+ * tags" would otherwise report success on every CI run forever.
+ */
+import { describe, it, expect } from 'vitest';
+import { checkMainDeclaresPublishedVersion } from '../scripts/lib/published-version.mjs';
+
+describe('main must declare a published version', () => {
+  it('passes when the declared version is tagged', () => {
+    const r = checkMainDeclaresPublishedVersion({
+      branch: 'main',
+      pkgVersion: '4.2.11',
+      tags: ['v4.2.10', 'v4.2.11'],
+    });
+    expect(r.status).toBe('ok');
+  });
+
+  it('FAILS when main declares a version that was never tagged', () => {
+    const r = checkMainDeclaresPublishedVersion({
+      branch: 'main',
+      pkgVersion: '4.2.12',
+      tags: ['v4.2.10', 'v4.2.11'],
+    });
+    expect(r.status).toBe('error');
+    // The message has to name the two ways out, or the next person hits the
+    // same five days with a red build and no instruction.
+    expect(r.message).toContain('v4.2.12');
+    expect(r.message).toContain('[Unreleased]');
+  });
+
+  it('FAILS rather than passes when no tags are visible at all', () => {
+    const r = checkMainDeclaresPublishedVersion({
+      branch: 'main',
+      pkgVersion: '4.2.11',
+      tags: [],
+    });
+    expect(r.status).toBe('error');
+    expect(r.message).toContain('fetch-tags');
+  });
+
+  it('FAILS rather than passes when the tag list could not be read', () => {
+    const r = checkMainDeclaresPublishedVersion({
+      branch: 'main',
+      pkgVersion: '4.2.11',
+      tags: null as unknown as string[],
+    });
+    expect(r.status).toBe('error');
+  });
+
+  it('skips on a release branch, which carries the bump before the tag exists', () => {
+    const r = checkMainDeclaresPublishedVersion({
+      branch: 'chore/release-4.2.12',
+      pkgVersion: '4.2.12',
+      tags: ['v4.2.11'],
+    });
+    expect(r.status).toBe('skipped');
+  });
+
+  it('skips on a pull-request ref, which GitHub names <n>/merge', () => {
+    const r = checkMainDeclaresPublishedVersion({
+      branch: '103/merge',
+      pkgVersion: '4.2.12',
+      tags: ['v4.2.11'],
+    });
+    expect(r.status).toBe('skipped');
+  });
+
+  it('skips when the branch cannot be discovered', () => {
+    const r = checkMainDeclaresPublishedVersion({
+      branch: null,
+      pkgVersion: '4.2.12',
+      tags: ['v4.2.11'],
+    });
+    expect(r.status).toBe('skipped');
+  });
+});


### PR DESCRIPTION
The published 4.2.11 release notes open with **"4.2.11 was never published."**
That was true when it was written — the version was bumped and no tag pushed —
and false a few hours later, when `v4.2.11` was tagged, released and published to
npm as `latest`. Nothing removed it before publishing, so the section denies its
own release.

Two commits: the correction, and the gate that stops the underlying state from
happening again.

---

## 1 · `docs(changelog)` — correct and shorten the 4.2.11 notes

- **"4.2.11 was never published"** — removed.
- **The MCP surface was given two different sizes.** One entry said nine tools;
  the summary and the `consolidate` entry said eight. Eight is correct —
  `consolidate` was retired in 4.2.11 and `handlers.ts` registers eight.
- **CI was described as running on `main`/`develop`**, in the same section that
  records `develop` being deleted.
- **The sample update-check response** in `docs/api/API_REFERENCE.md` still
  showed 4.2.8 / 4.2.9.

The section went from **13,333 words to 6,180**. It had grown into an account of
how the work was done rather than what changed for someone using MeMesh. Kept in
full: the breaking changes (`consolidate` retired, Node `>=22.5.0`), the one-time
index rebuild on first open, the benchmark retraction and the 95.40% → 95.60%
correction, the fixes that stop embeddings being deleted, and the security fixes.

The duplicated headings (Fixed ×5, Changed ×3, Security ×3, Tests ×3) are merged
into one set. They existed only to separate two writing sessions, and the note
explaining them was the false sentence above.

## 2 · `ci(release)` — fail when `main` declares a version that was never tagged

`check-version-coherence.mjs` asks whether seven files agree **with each other**.
They agreed with each other for the whole five days `main` said `4.2.11` while
npm's `latest` said `4.2.10`. Agreement among the anchors says nothing about
whether the version they agree on was ever released, and nothing else was asking.

**The rule this enforces:** a version bump never rides in a feature or docs pull
request. `main` carries the last **published** version, work accumulates under
`[Unreleased]`, and a release bumps the anchors, renames the section, tags and
runs `gh release create` in one sitting — so the window this check is red for is
minutes, not days.

Two decisions worth stating:

- **An empty tag list fails.** `actions/checkout` fetches no tags by default —
  measured, `git clone --depth 1` against this repository brings down **0 of its
  65 `v*` tags** — so "found no mismatch among zero tags" would have made the
  check unable to fail on every CI run forever. That is the same shape as the two
  dead gates 4.2.11 removed, and it would have been introduced by the commit
  adding a gate against exactly that class. It reports "could not run" and exits
  1. The checkout now sets `fetch-depth: 0`: 24 MB / 1667 commits, 0.83s, against
  a matrix leg that has taken over 13 minutes.
- **Release branches and PR refs are skipped**, since both legitimately carry the
  bump for the minutes before the tag exists. `GITHUB_REF_NAME` is `main` on a
  push to main and `<n>/merge` on a pull request, so one branch test covers both.

The predicate lives in `scripts/lib/published-version.mjs`, separate from the
script that runs it, so both directions can be pinned without a repository to
mutate.

---

## What changed since the first version of this PR

The first version bumped all seven anchors to **4.2.12**. Merging that without
tagging would have left `main` declaring a version nobody could install — the
exact state this PR documents. The bump is reverted; the correction sits under
`## [Unreleased]` and ships with whichever release comes next.

## Verification

| Gate | Result |
|---|---|
| `node scripts/run-tests-isolated.mjs` | **100 files, 1427 tests passed** (was 99 / 1420) |
| `npm run verify:release` | exit 0 |
| `npm run lint` / `npm run typecheck` | exit 0 / exit 0 |
| `bash scripts/verify-docs-sync.sh` | exit 0 |

**The new gate is break-tested, not just written:**

- Mutation — making the empty-tag-list branch return success kills 2 of the 7
  cases; making the missing-tag branch return success kills 1. Restored: 7/7.
- End to end, through real git plumbing — on this branch the check reports
  `skipped` and the script exits 0; with `GITHUB_REF_NAME=main` it reports
  `ok — v4.2.11 is tagged` and exits 0; in a `--depth 1 --no-tags` clone with
  `GITHUB_REF_NAME=main` it prints the `fetch-tags` message and **exits 1**.

Node v24.15.0.
