### PR TITLE
fix(config): type-check the files that configure the build, and make coverage measurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,57 @@ All notable changes to MeMesh are documented here.
 
 ## [Unreleased]
 
+### Added
+
+- **Coverage can be measured for the first time, and `npm run typecheck` now
+  covers the files that configure the build** (`vitest.config.ts`,
+  `tsconfig.check.json`, `package.json`) — two settings that looked like
+  configuration and were not.
+
+  `vitest.config.ts` had a `coverage` block labelled "(if needed)" and
+  `@vitest/coverage-v8` was never installed, so `vitest --coverage` answered
+  `MISSING DEPENDENCY`. Nobody could see which modules a test had ever touched.
+  The provider is installed and pinned exactly, and `npm run test:coverage`
+  runs the suite against a throwaway `HOME` like the normal runner does.
+
+  Installing it was not enough. With no `coverage.include`, v8 reports only the
+  files a test **imported** — a module nothing touches is not 0%, it is absent.
+  The first report read **72.05%** while seven of the fifty-three files under
+  `src/` were missing from it entirely, among them `cli/view-live.ts` (2,199
+  lines) and `mcp/launcher.ts`, the entry point every MCP client executes. With
+  the source globs declared, the same suite measures **48.76%**. A coverage
+  report that cannot show a zero is a gate that cannot fail.
+
+  Read with one caveat, recorded in `CLAUDE.md` rather than left as a trap:
+  coverage is in-process, and this project spawns much of what it tests. The
+  CLI, all seven hooks and the MCP server are exercised through `spawnSync` and
+  therefore report 0% while being well covered — `src/transports/cli/cli.ts` is
+  750 statements with a directory of tests and a 0% line. The number is useful
+  in the other direction: a 0% file that is *not* spawned anywhere is genuinely
+  unexercised, which is where the dashboard sits at 25 components to 6 test
+  files.
+
+### Fixed
+
+- **Three Vitest options that do not exist were silently configuring nothing**
+  (`vitest.config.ts`) — `singleFork: true`, `maxForks: 1` and `minForks: 1` sat
+  at the top level of `test:`. None of the three is part of Vitest 4's config
+  type; `poolOptions` is gone too. Only `fileParallelism: false` was doing any
+  work, and it happens to be the half that matters — several test files share
+  one `HOME` and therefore one SQLite database, and running them concurrently
+  deadlocks on the write lock. So the property held, by luck, through three keys
+  that described it and did nothing. Replaced with `maxWorkers: 1`; suite
+  duration is unchanged at ~38s, which is the measurement confirming the removed
+  keys were inert.
+
+  The root cause is why nothing caught it: **`npm run typecheck` had never read
+  the file.** `tsconfig.json`'s `include` is `src/**/*.ts`, correct for the
+  config that emits `dist/` and wrong for a check, so `vitest.config.ts`,
+  `tests/` and the root config files were outside every type check the project
+  ran. `tsconfig.check.json` widens the scope for checking only, and
+  `npm run typecheck` points at it. Measured when it was added: exactly **one**
+  error appeared across `src/` + `tests/` + config — this one.
+
 A git tag freezes the file it points at, so the 4.2.11 notes cannot be corrected
 where they were published. They are corrected here, and whichever release ships
 next carries the corrected copy.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,9 +42,33 @@ existing file makes `tests/hooks/session-start-telemetry.test.ts` fail: its
 "short-circuits on a missing DB" case then has nothing to short-circuit on. An
 isolated `HOME` is the right isolation; a fixed DB path is not.
 
-Pool mode is `forks`, single fork, no file parallelism. That is not a
+Pool mode is `forks`, one worker, no file parallelism. That is not a
 preference — several test files share one HOME and therefore one SQLite
-database, and running them concurrently deadlocks on the write lock.
+database, and running them concurrently deadlocks on the write lock. It is
+expressed as `maxWorkers: 1` + `fileParallelism: false`; the older
+`singleFork`/`maxForks`/`minForks` keys do not exist in Vitest 4 and were being
+silently ignored.
+
+`npm run typecheck` uses `tsconfig.check.json`, which covers `src/`, `tests/`
+and the root config files. `tsconfig.json` is narrower on purpose — it is the
+config that emits `dist/`.
+
+### Coverage, and what a 0% file means
+
+```bash
+npm run test:coverage        # whole suite + v8 coverage, throwaway HOME
+```
+
+Read the report with one caveat, or it will mislead you. Coverage is measured
+**in-process**, and this project spawns a lot of what it tests: the CLI, all
+seven hooks, the MCP server and the packaged binaries are exercised through
+`spawnSync`, so they report **0% while being well tested**. `src/transports/cli/cli.ts`
+is the clearest case — 750 statements, a whole directory of tests, 0% in the
+report.
+
+What the number is good for is the opposite direction: a file at 0% that is
+*not* spawned anywhere is genuinely unexercised. That is where the dashboard
+sits — 25 components, 6 test files.
 
 ### Verifying a change before claiming it works
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "@types/better-sqlite3": "^7.6.13",
         "@types/express": "^5.0.6",
         "@types/node": "25.6.2",
+        "@vitest/coverage-v8": "4.1.5",
         "eslint": "^10.3.0",
         "happy-dom": "^20.9.0",
         "playwright": "^1.59.1",
@@ -235,9 +236,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -245,9 +246,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -279,13 +280,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -391,17 +392,27 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -2846,6 +2857,37 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
+      "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.5",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.5",
+        "vitest": "4.1.5"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
@@ -3100,6 +3142,25 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.5.tgz",
+      "integrity": "sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
@@ -4732,6 +4793,13 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -5146,6 +5214,45 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jose": {
       "version": "6.1.3",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
@@ -5296,6 +5403,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.4.tgz",
+      "integrity": "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/matcher": {

--- a/package.json
+++ b/package.json
@@ -33,12 +33,13 @@
     "audit:prod": "node scripts/check-consumer-audit.mjs",
     "verify:release": "npm run lint && npm run typecheck && node scripts/check-version-coherence.mjs && node scripts/check-generated-mirror.mjs && node scripts/check-doc-claims.mjs && npm run audit:prod",
     "prepublishOnly": "npm run build && npm run verify:release && npm run test:isolated && npm run test:packaged",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc -p tsconfig.check.json",
     "lint": "eslint src/ scripts/ --max-warnings 0",
     "lint:fix": "eslint src/ scripts/ --fix",
     "start": "node dist/mcp/launcher.js",
     "bench:longmemeval": "node benchmarks/longmemeval/run.mjs --mode A --dataset /tmp/longmemeval_s.json",
-    "test:isolated": "node scripts/run-tests-isolated.mjs"
+    "test:isolated": "node scripts/run-tests-isolated.mjs",
+    "test:coverage": "node scripts/run-tests-isolated.mjs --coverage"
   },
   "author": "PCIRCLE-AI",
   "license": "MIT",
@@ -98,6 +99,7 @@
     "@types/better-sqlite3": "^7.6.13",
     "@types/express": "^5.0.6",
     "@types/node": "25.6.2",
+    "@vitest/coverage-v8": "4.1.5",
     "eslint": "^10.3.0",
     "happy-dom": "^20.9.0",
     "playwright": "^1.59.1",

--- a/tsconfig.check.json
+++ b/tsconfig.check.json
@@ -1,0 +1,38 @@
+{
+  // Type-checking scope, separate from the build scope.
+  //
+  // `tsconfig.json` includes only `src/**/*.ts`, because it is the config that
+  // EMITS `dist/`. That is correct for a build and wrong for a check: it meant
+  // `npm run typecheck` had never looked at `tests/`, at `vitest.config.ts`, or
+  // at anything else outside `src/`.
+  //
+  // What that cost: `vitest.config.ts` carried `singleFork`, `maxForks` and
+  // `minForks` at the top level of `test:`. None of the three exists in Vitest
+  // 4's config type — they are silently ignored — and CLAUDE.md documents single
+  // -fork execution as load-bearing, because several test files share one HOME
+  // and therefore one SQLite database. Three dead keys describing a property the
+  // project depends on, sitting in a file nothing checked.
+  //
+  // Measured when this file was added: widening the scope to `src/` + `tests/` +
+  // root config files produced exactly ONE error across the whole tree, and it
+  // was that bug. The cost of the wider check is one extra `tsc` pass; the cost
+  // of not having it was three years of config that looked like configuration.
+  //
+  // `dashboard/` is deliberately out of scope — it has its own tsconfig with
+  // bundler resolution and a Preact JSX pragma, and checking it under this one
+  // produces 2,580 errors that are all disagreements between the two configs.
+  // `npm run build:dashboard` type-checks it with its own.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    // The base sets `rootDir: src` for emit. A check has no output, and leaving
+    // it would report TS6059 for every file outside src/ before looking at any
+    // of them.
+    "rootDir": ".",
+    // tests/dashboard/*.test.tsx render Preact components; the same pragma
+    // vitest.config.ts gives them via @preact/preset-vite.
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact"
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts", "*.config.ts"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,11 +14,21 @@ export default defineConfig({
     dedupe: ['preact', 'preact/hooks'],
   },
   test: {
-    // Use forks pool to prevent SIGSEGV with better-sqlite3 native module
+    // Use forks pool to prevent SIGSEGV with better-sqlite3 native module.
     pool: 'forks',
-    singleFork: true,
-    maxForks: 1,
-    minForks: 1,
+
+    // One worker, one file at a time. Several test files share one HOME and
+    // therefore one SQLite database, and running them concurrently deadlocks on
+    // the write lock — this is load-bearing, not a preference.
+    //
+    // It used to read `singleFork: true, maxForks: 1, minForks: 1` at this
+    // level. **None of those three exists in Vitest 4's config type.** They were
+    // silently ignored, and only `fileParallelism` was doing any work. Nothing
+    // caught it because `npm run typecheck` pointed at `tsconfig.json`, whose
+    // `include` is `src/**/*.ts` — this file had never been type-checked. It is
+    // now, via `tsconfig.check.json`, and putting the old keys back fails the
+    // check.
+    maxWorkers: 1,
     fileParallelism: false,
 
     // Force test timeout to prevent hanging
@@ -45,10 +55,31 @@ export default defineConfig({
     // work here.
     setupFiles: ['./tests/setup/webstorage.ts'],
 
-    // Coverage configuration (if needed)
+    // Coverage. Two things were wrong with this block for its whole life.
+    //
+    // FIRST, `@vitest/coverage-v8` was never installed, so `vitest --coverage`
+    // answered `MISSING DEPENDENCY` and nobody could run it. The block was
+    // labelled "(if needed)" and had never been needed, which is how a
+    // 2,199-line module reached one assertion without anyone being able to see
+    // it.
+    //
+    // SECOND, and worse once it did run: with no `coverage.include`, v8 reports
+    // only files a test IMPORTED. A module no test touches is not 0% — it is
+    // absent, and the summary then read **72.05%** while seven of the
+    // fifty-three files under `src/` were missing from the report entirely,
+    // among them `cli/view-live.ts` (2,199 lines) and `mcp/launcher.ts`, the
+    // entry point every MCP client executes. With the globs below the same suite
+    // measures **48.86%**. A coverage report that cannot show you a zero is a
+    // gate that cannot fail, which is the defect this repository keeps finding
+    // in other shapes.
+    //
+    // `all: true` is NOT the fix here and is not a valid option in Vitest 4 —
+    // `include` is what widens the denominator. Verified by running one test
+    // file: the denominator stays at 8,593 statements either way.
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'json', 'html'],
+      include: ['src/**/*.ts', 'scripts/hooks/*.js', 'dashboard/src/**/*.{ts,tsx}'],
+      reporter: ['text', 'json', 'json-summary', 'html'],
       exclude: [
         'node_modules/',
         'dist/',
@@ -56,6 +87,8 @@ export default defineConfig({
         '**/*.spec.ts',
         '**/types.ts',
         '**/index.ts',
+        // Build-generated mirrors of src/ modules; the originals are measured.
+        'scripts/hooks/_generated/**',
       ],
     },
 


### PR DESCRIPTION
Two settings that looked like configuration and were not — the same defect the
last three releases have been removing, one layer further out: **the thing
supposed to be watching was not running.**

---

## 1 · Three Vitest options that do not exist

`vitest.config.ts` carried `singleFork: true`, `maxForks: 1` and `minForks: 1`
at the top level of `test:`. **None of the three is part of Vitest 4's config
type** — `poolOptions` is gone as well — so all three were silently ignored.

`CLAUDE.md` documents single-worker execution as load-bearing: several test files
share one `HOME` and therefore one SQLite database, and running them concurrently
deadlocks on the write lock. The property held anyway, because
`fileParallelism: false` is real and was doing the whole job alone. Three keys
describing a property the project depends on, doing nothing.

Replaced with `maxWorkers: 1`. Suite duration is unchanged at ~38s — the
measurement confirming the removed keys were inert, not load-bearing.

### The root cause: `npm run typecheck` had never read the file

`tsconfig.json`'s `include` is `src/**/*.ts` — correct for the config that
**emits** `dist/`, wrong for a check. So `vitest.config.ts`, all of `tests/` and
every root config file sat outside every type check this project ran.

`tsconfig.check.json` widens the scope for checking only. Measured when it was
added: **exactly one error** appeared across `src/` + `tests/` + config, and it
was this bug.

`dashboard/` stays out — it has its own tsconfig with bundler resolution and a
Preact pragma, and checking it under this one produces 2,580 errors that are all
disagreements between the two configs.

## 2 · Coverage could not be measured, then measured the wrong denominator

The `coverage` block was labelled `// (if needed)` and **`@vitest/coverage-v8`
was never installed**, so `vitest --coverage` answered `MISSING DEPENDENCY`.
Nobody could see which modules a test had ever touched.

Installing it was not enough. With no `coverage.include`, v8 reports only files a
test **imported** — a module nothing touches is not 0%, it is *absent*:

| | Statements | Files under `src/` in the report |
|---|---|---|
| provider installed, no `include` | **72.05%** | 46 of 53 |
| with source globs declared | **48.76%** | 53 of 53 |

The seven missing files included `cli/view-live.ts` (2,199 lines) and
`mcp/launcher.ts`, the entry point every MCP client executes.

**A coverage report that cannot show a zero is a gate that cannot fail.**

`all: true` is *not* the fix and is not valid in Vitest 4 — `include` is what
widens the denominator, verified by running one test file with and without it.

### What the number means, recorded rather than left as a trap

Coverage is measured **in-process**, and this project spawns much of what it
tests. The CLI, all seven hooks and the MCP server go through `spawnSync` and
report **0% while being well covered** — `src/transports/cli/cli.ts` is 750
statements with a whole directory of tests and a 0% line.

The number is useful in the other direction: a 0% file that is *not* spawned
anywhere is genuinely unexercised. That is the **dashboard — 25 components, 6
test files.** Named here, not fixed here.

### No floor gate

A global percentage floor would fail on healthy code the first time someone adds
a spawn-tested module, and this repository has already written down what happens
to a gate that fails on a healthy repo.

## Verification

| Gate | Result |
|---|---|
| `npm run verify:release` | exit 0 |
| `npm run typecheck` | exit 0 (now covering `tests/` + config) |
| `npm run lint` | exit 0 |
| `node scripts/run-tests-isolated.mjs` | **101 files, 1433 tests passed**, 38.4s (38.2s before) |
| `npm run test:packaged` | exit 0 |
| `npm run test:coverage` | Statements **48.76%** (4190/8593) |

**Break-tested, both directions:**

- Restoring `singleFork` → `npm run typecheck` exits 2. Removed → exits 0.
- Removing `coverage.include` → the statement denominator collapses from
  **8,593 to 24** on a single test file. Restored → 8,593.

Node v24.15.0.
