### PR TITLE
chore(release): v4.3.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "memesh",
       "source": "./",
       "description": "MeMesh — Local memory for Claude Code and MCP coding agents. One SQLite file, zero cloud required.",
-      "version": "4.2.11",
+      "version": "4.3.0",
       "author": {
         "name": "PCIRCLE AI"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -4,7 +4,7 @@
   "author": {
     "name": "PCIRCLE AI"
   },
-  "version": "4.2.11",
+  "version": "4.3.0",
   "homepage": "https://pcircle.ai/memesh-llm-memory",
   "repository": "https://github.com/PCIRCLE-AI/memesh-llm-memory",
   "license": "MIT",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to MeMesh are documented here.
 
-## [Unreleased]
+## [4.3.0] — 2026-08-04
 
 ### Added
 

--- a/dist/skills-manifest.json
+++ b/dist/skills-manifest.json
@@ -3,8 +3,8 @@
   "entries": [
     {
       "path": ".claude-plugin/plugin.json",
-      "sha256": "513a8710c22d6d5a5cc5b22c74fd47c489c3023aa7bd49682b7fdec2d6bd383e",
-      "bytes": 442
+      "sha256": "d3009a03016f1a724f7cbc7bd1083df017cf7e3e42a268a38093d26dd777b5ab",
+      "bytes": 441
     },
     {
       "path": ".mcp.json",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # MeMesh Plugin Architecture
 
-**Version**: 4.2.11
+**Version**: 4.3.0
 
 > Looking for "which file do I change for X?" — see [CODEMAP.md](../CODEMAP.md).
 

--- a/docs/api/API_REFERENCE.md
+++ b/docs/api/API_REFERENCE.md
@@ -1,7 +1,7 @@
 # MeMesh Plugin -- API Reference
 
 **Protocol**: Model Context Protocol (MCP) over stdio
-**Version**: 4.2.11
+**Version**: 4.3.0
 **Compatibility**: Works with Claude Code plugins, Claude Managed Agents (via MCP connector), and any MCP-compatible client.
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pcircle/memesh",
-  "version": "4.2.11",
+  "version": "4.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pcircle/memesh",
-      "version": "4.2.11",
+      "version": "4.3.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pcircle/memesh",
-  "version": "4.2.11",
-  "description": "MeMesh \u2014 Local memory for Claude Code and MCP coding agents. One SQLite file, zero cloud required.",
+  "version": "4.3.0",
+  "description": "MeMesh — Local memory for Claude Code and MCP coding agents. One SQLite file, zero cloud required.",
   "main": "dist/index.js",
   "type": "module",
   "bin": {

--- a/scripts/audit/baseline.json
+++ b/scripts/audit/baseline.json
@@ -416,20 +416,20 @@
       "reason": "group-by identity or truthful zero-rows display",
       "triaged": "2026-08-04 (re-keyed twice: two warning inserts shifted lines)"
     },
-    "C4 scripts/release-verify.sh:146": {
-      "class": "SAFE",
-      "reason": "set -uo pipefail at file top preserves the left commands verdict",
-      "triaged": "2026-08-04 (re-keyed: the suite-gate evidence fix shifted lines)"
-    },
-    "C4 scripts/release-verify.sh:189": {
-      "class": "SAFE",
-      "reason": "set -uo pipefail at file top preserves the left commands verdict",
-      "triaged": "2026-08-04 (re-keyed: the suite-gate evidence fix shifted lines)"
-    },
-    "C4 scripts/release-verify.sh:104": {
+    "C4 scripts/release-verify.sh:109": {
       "class": "SAFE",
       "reason": "display-only pipe: tail|sed formats the failure log AFTER the gate already returned 1 explicitly; no verdict flows through it",
-      "triaged": "2026-08-04"
+      "triaged": "2026-08-04 (re-keyed: the mktemp-orphan fix shifted lines by five)"
+    },
+    "C4 scripts/release-verify.sh:151": {
+      "class": "SAFE",
+      "reason": "set -uo pipefail at file top preserves the left commands verdict",
+      "triaged": "2026-08-04 (re-keyed: the mktemp-orphan fix shifted lines by five)"
+    },
+    "C4 scripts/release-verify.sh:194": {
+      "class": "SAFE",
+      "reason": "set -uo pipefail at file top preserves the left commands verdict",
+      "triaged": "2026-08-04 (re-keyed: the mktemp-orphan fix shifted lines by five)"
     }
   }
 }

--- a/scripts/audit/baseline.json
+++ b/scripts/audit/baseline.json
@@ -121,16 +121,6 @@
       "reason": "|| true inside an exact-match retry loop — absence retries then fails, never passes",
       "triaged": "2026-08-04"
     },
-    "C4 scripts/release-verify.sh:135": {
-      "class": "SAFE",
-      "reason": "set -uo pipefail at file top preserves the left commands verdict",
-      "triaged": "2026-08-04"
-    },
-    "C4 scripts/release-verify.sh:178": {
-      "class": "SAFE",
-      "reason": "set -uo pipefail at file top preserves the left commands verdict",
-      "triaged": "2026-08-04"
-    },
     "C5 src/core/config.ts:336": {
       "class": "SAFE-GUARDED",
       "reason": "absent key truthfully means no failover; corrupt config caught by doctor inspectConfigParse",
@@ -425,6 +415,21 @@
       "class": "SAFE-ACCUMULATOR/DISPLAY",
       "reason": "group-by identity or truthful zero-rows display",
       "triaged": "2026-08-04 (re-keyed twice: two warning inserts shifted lines)"
+    },
+    "C4 scripts/release-verify.sh:146": {
+      "class": "SAFE",
+      "reason": "set -uo pipefail at file top preserves the left commands verdict",
+      "triaged": "2026-08-04 (re-keyed: the suite-gate evidence fix shifted lines)"
+    },
+    "C4 scripts/release-verify.sh:189": {
+      "class": "SAFE",
+      "reason": "set -uo pipefail at file top preserves the left commands verdict",
+      "triaged": "2026-08-04 (re-keyed: the suite-gate evidence fix shifted lines)"
+    },
+    "C4 scripts/release-verify.sh:104": {
+      "class": "SAFE",
+      "reason": "display-only pipe: tail|sed formats the failure log AFTER the gate already returned 1 explicitly; no verdict flows through it",
+      "triaged": "2026-08-04"
     }
   }
 }

--- a/scripts/release-verify.sh
+++ b/scripts/release-verify.sh
@@ -94,10 +94,15 @@ gate_full_test_suite() {
   # Output goes to a log, not /dev/null: this gate failed once during the
   # v4.3.0 release and left NOTHING to diagnose — a verdict without evidence.
   # On failure the tail is printed and the log path named.
-  local log
-  log="$(mktemp -t memesh-release-suite.XXXXXX).log"
+  # mktemp -d, not `mktemp -t X).log`: the first form created the mktemp
+  # file AND wrote to a different concatenated path, orphaning one empty
+  # temp file per run — and a suffix template is GNU-only, while this runs
+  # on macOS too.
+  local logdir log
+  logdir="$(mktemp -d)"
+  log="$logdir/suite.log"
   if with_throwaway_home npx vitest run >"$log" 2>&1; then
-    rm -f "$log"
+    rm -rf "$logdir"
     return 0
   fi
   echo "  suite output tail ($log):"

--- a/scripts/release-verify.sh
+++ b/scripts/release-verify.sh
@@ -91,7 +91,18 @@ with_throwaway_home() {
 }
 
 gate_full_test_suite() {
-  with_throwaway_home npx vitest run >/dev/null 2>&1
+  # Output goes to a log, not /dev/null: this gate failed once during the
+  # v4.3.0 release and left NOTHING to diagnose — a verdict without evidence.
+  # On failure the tail is printed and the log path named.
+  local log
+  log="$(mktemp -t memesh-release-suite.XXXXXX).log"
+  if with_throwaway_home npx vitest run >"$log" 2>&1; then
+    rm -f "$log"
+    return 0
+  fi
+  echo "  suite output tail ($log):"
+  tail -20 "$log" | sed 's/^/    /'
+  return 1
 }
 
 gate_doctor_runs() {


### PR DESCRIPTION
Release PR for v4.3.0 — ships the verification-integrity work from PRs #107–#113 (each of which was individually adversarially reviewed, break-tested in both directions, and merged green this session).

## In this PR (mechanical release delta only)

- All eight version anchors move together: package.json, package-lock.json (both self-version fields — the pair that drifted for four releases once), plugin.json, marketplace.json, the CHANGELOG header, both doc `**Version**:` lines, and the version-stamped `dist/skills-manifest.json`.
- CHANGELOG `[Unreleased]` cut to `[4.3.0] — 2026-08-04`.
- One gate fix caught during this very release: `release-verify.sh`'s suite gate sent output to /dev/null, failed once, and left nothing to diagnose — it now keeps a log and prints the tail on failure.

## Receipts

- `node scripts/check-version-coherence.mjs` → exit=0, all sources agree on 4.3.0.
- `node scripts/run-tests-isolated.mjs` on the release tree → exit=0, Test Files 104 passed (104), Tests 1622 passed (1622).
- `npm run verify:release` (incl. the new verification-audit gate) → exit=0.
- `bash scripts/release-verify.sh` → exit=0, **8/8 gates** (the one transient suite-gate failure was reproduced with output captured — 1622/1622 pass — and the gate now preserves evidence).
- `node scripts/check-generated-mirror.mjs` → exit=0: the committed dist the plugin-marketplace channel installs is this commit's build.

## After merge

Create the GitHub release `v4.3.0` (publish-npm.yml triggers on release-published, gates tag == package.json), then post-publish verification: install from npm and run `memesh doctor`.