### PR TITLE
chore(release): 4.4.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "memesh",
       "source": "./",
       "description": "MeMesh — Local memory for Claude Code and MCP coding agents. One SQLite file, zero cloud required.",
-      "version": "4.3.0",
+      "version": "4.4.0",
       "author": {
         "name": "PCIRCLE AI"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -4,7 +4,7 @@
   "author": {
     "name": "PCIRCLE AI"
   },
-  "version": "4.3.0",
+  "version": "4.4.0",
   "homepage": "https://pcircle.com/memesh-llm-memory",
   "repository": "https://github.com/PCIRCLE-AI/memesh-llm-memory",
   "license": "MIT",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to MeMesh are documented here.
 
 ## [Unreleased]
 
+## [4.4.0] — 2026-08-04
+
 ### Changed
 
 - **Bare `memesh` prints help instead of starting a server.** Running the
@@ -33,10 +35,13 @@ All notable changes to MeMesh are documented here.
   (500 chars + a count; storage and `--json` untouched) — a 324KB note used
   to flood the terminal on every hit.
 
-- **`memesh remember "text" --name x --type y` silently discarded the
-  text** — it reported `Stored (0 observations)`: success, with the user's
-  content gone. Positional text now becomes an observation in the flag form
-  too, which is the only thing that invocation can mean.
+- **`memesh remember` dropped positional text in BOTH mixed forms** — the
+  flag form (`remember "text" --name x --type y`) reported
+  `Stored (0 observations)`: success, with the user's content gone; and the
+  quick-capture form (`remember "text" --obs "note"`, no `--name`/`--type`)
+  discarded the text while *naming the entity after it*, so the entity
+  claimed content it never stored. Positional text is now always an
+  observation, which is the only thing those invocations can mean.
 
 - **The model-download notice fired on a warm cache** when
   `MEMESH_MODEL_CACHE_DIR` was set: the cached-check read a different root

--- a/dist/skills-manifest.json
+++ b/dist/skills-manifest.json
@@ -3,7 +3,7 @@
   "entries": [
     {
       "path": ".claude-plugin/plugin.json",
-      "sha256": "b2d1ad5bdbc3f9f9019d08a3fb0200c3d1eb687b25b2a37ee5f40aa578b2ab64",
+      "sha256": "2fac1ce92cfd2c14333fee20124247c4cdfe223a0ce613134886252821d4f723",
       "bytes": 442
     },
     {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # MeMesh Plugin Architecture
 
-**Version**: 4.3.0
+**Version**: 4.4.0
 
 > Looking for "which file do I change for X?" — see [CODEMAP.md](../CODEMAP.md).
 

--- a/docs/api/API_REFERENCE.md
+++ b/docs/api/API_REFERENCE.md
@@ -1,7 +1,7 @@
 # MeMesh Plugin -- API Reference
 
 **Protocol**: Model Context Protocol (MCP) over stdio
-**Version**: 4.3.0
+**Version**: 4.4.0
 **Compatibility**: Works with Claude Code plugins, Claude Managed Agents (via MCP connector), and any MCP-compatible client.
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pcircle/memesh",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pcircle/memesh",
-      "version": "4.3.0",
+      "version": "4.4.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcircle/memesh",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "description": "MeMesh — Local memory for Claude Code and MCP coding agents. One SQLite file, zero cloud required.",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
Release 4.4.0 — ships PR #115 (first-use audit fixes), #116 (recall provenance root cause + demo relations + pcircle.com sweep + both remember text-drop branches) and #117 (bare `memesh` prints help).

## Gates (all run locally on this commit)

- `npm run verify:release` → exit=0 (version chain: **all eight anchors agree on 4.4.0**, incl. both package-lock spots; audit gate; doc-claims; dist freshness)
- `scripts/release-verify.sh` → **8 gates passed, 0 failed** ("Safe to tag + npm publish")
- Isolated suite on the merged content: 107 files / 1640 tests, exit=0 (run pre-merge on #116/#117 heads; release commit only touches version anchors + CHANGELOG cut)

## After merge (one breath, no gap)

merge → `gh release create v4.4.0` (triggers publish-npm.yml) → post-publish install-back + `memesh doctor` → confirm plugin-marketplace channel dist matches this commit.