### PR TITLE
chore(release): 4.5.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "memesh",
       "source": "./",
       "description": "MeMesh — Local memory for Claude Code and MCP coding agents. One SQLite file, zero cloud required.",
-      "version": "4.4.0",
+      "version": "4.5.0",
       "author": {
         "name": "PCIRCLE AI"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -4,7 +4,7 @@
   "author": {
     "name": "PCIRCLE AI"
   },
-  "version": "4.4.0",
+  "version": "4.5.0",
   "homepage": "https://pcircle.com/memesh-llm-memory",
   "repository": "https://github.com/PCIRCLE-AI/memesh-llm-memory",
   "license": "MIT",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to MeMesh are documented here.
 
 ## [Unreleased]
 
+## [4.5.0] — 2026-08-05
+
 ### Added
 
 - **Transcript mining can now run on a schedule (opt-in).** `dream run

--- a/dist/skills-manifest.json
+++ b/dist/skills-manifest.json
@@ -3,7 +3,7 @@
   "entries": [
     {
       "path": ".claude-plugin/plugin.json",
-      "sha256": "2fac1ce92cfd2c14333fee20124247c4cdfe223a0ce613134886252821d4f723",
+      "sha256": "678e8e8a8a7e10b41418bcbe059c7ae253fa3db0b63a054f3518b67bc946e355",
       "bytes": 442
     },
     {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # MeMesh Plugin Architecture
 
-**Version**: 4.4.0
+**Version**: 4.5.0
 
 > Looking for "which file do I change for X?" — see [CODEMAP.md](../CODEMAP.md).
 

--- a/docs/api/API_REFERENCE.md
+++ b/docs/api/API_REFERENCE.md
@@ -1,7 +1,7 @@
 # MeMesh Plugin -- API Reference
 
 **Protocol**: Model Context Protocol (MCP) over stdio
-**Version**: 4.4.0
+**Version**: 4.5.0
 **Compatibility**: Works with Claude Code plugins, Claude Managed Agents (via MCP connector), and any MCP-compatible client.
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pcircle/memesh",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pcircle/memesh",
-      "version": "4.4.0",
+      "version": "4.5.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcircle/memesh",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "description": "MeMesh — Local memory for Claude Code and MCP coding agents. One SQLite file, zero cloud required.",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
Cuts `[Unreleased]` into **`[4.5.0]` — 2026-08-05**. All eight version anchors bumped together (package.json, package-lock.json ×2, plugin.json, marketplace.json, CHANGELOG section, dist/skills-manifest.json, ARCHITECTURE.md, API_REFERENCE.md).

## Highlights since 4.4.0

**Added**
- Opt-in **scheduled transcript mining** (`dream run --from-transcripts --if-due`) — per-project self-throttle, no daemon, doctor INFO row.
- **Fallback LLM providers in the dashboard** — masked keys never re-sent; `keepKeyFrom` identity so reorder/remove/edit keeps each entry its own key.
- **Conversation mining** — `--from-transcripts` reads session JSONL and stages the decisions/lessons/why as proposals (time-ordered, secret-dropping, current-project scoped); vector-deduped against existing memories; `dream show <id>` full preview.
- Output language for generated memory content; stable `errorCode` envelope; empty-DB self-explanation; graph node cap; list-truncation notes; settings model display.

**Removed**
- The **local ONNX embedder** — standardised on ollama with FTS5 keyword degradation when no embedder is configured.

**Fixed**
- Dashboard error surfaces no longer throw raw exceptions; non-English UI no longer falls back to hardcoded English; `dream list` no longer invents "(empty)"; doctor banner speaks the user's language; `serve` fills the update-check cache; falsified benchmark figure removed; rate limiter skips loopback + envelopes 429s; API-key mask never persisted; plural memory types no longer downgraded out of the protected set.

## Verification
- `npm run verify:release` exit=0 — "All version sources agree" (4.5.0 in all eight anchors), doc-claims ✓, verification audit ✓ (every detector non-empty, 0 new), consumer advisories ✓.
- Full isolated suite: 1802 passed. `npm publish` will re-run the `prepublishOnly` gate (build + verify:release + test:isolated + test:packaged) before anything ships.

After merge: tag `v4.5.0` on main and `npm publish`.