### PR TITLE
test(dreamer): stop the chunk-boundary test from racing the 30s timeout on Windows

### DIFF
--- a/tests/core/dreamer-semantic-clustering.test.ts
+++ b/tests/core/dreamer-semantic-clustering.test.ts
@@ -307,20 +307,35 @@ describe('more candidates than fit in one vector-lookup chunk', () => {
     const total = CHUNK + 100;
     const db = getDatabase();
     const day = daysAgo(3);
-    for (let i = 0; i < total; i++) {
-      const name = `bulk-${i}`;
-      db.prepare("INSERT INTO entities (name, type, created_at, metadata) VALUES (?, 'commit', ?, ?)")
-        .run(name, `${day}T12:00:00.000Z`, JSON.stringify({ signal_score: 0.5 }));
-      const id = (db.prepare('SELECT id FROM entities WHERE name = ?').get(name) as { id: number }).id;
-      db.prepare("INSERT INTO tags (entity_id, tag) VALUES (?, 'project:demo')").run(id);
-      db.prepare('INSERT INTO observations (entity_id, content) VALUES (?, ?)').run(id, `work ${i}`);
-      // All on one axis, so they form a single cluster and every one of them
-      // must have been read for the count below to come out right.
-      const v = new Float32Array(DIM);
-      v[3] = 1;
-      v[4] = (i % 10) * 0.001;
-      db.prepare('INSERT INTO entities_vec (rowid, embedding) VALUES (?, ?)')
-        .run(BigInt(id), Buffer.from(v.buffer));
+    // One transaction, statements prepared once. 600 autocommit inserts ×4
+    // statements each re-prepared per row put this test at 30s — the default
+    // testTimeout — on the windows-latest runner (367ms for the whole file on
+    // an M-series Mac), and it failed CI on timing alone. The seeding shape is
+    // not what this test asserts; the chunk arithmetic below is.
+    const insertEntity = db.prepare("INSERT INTO entities (name, type, created_at, metadata) VALUES (?, 'commit', ?, ?)");
+    const selectId = db.prepare('SELECT id FROM entities WHERE name = ?');
+    const insertTag = db.prepare("INSERT INTO tags (entity_id, tag) VALUES (?, 'project:demo')");
+    const insertObs = db.prepare('INSERT INTO observations (entity_id, content) VALUES (?, ?)');
+    const insertVec = db.prepare('INSERT INTO entities_vec (rowid, embedding) VALUES (?, ?)');
+    db.exec('BEGIN');
+    try {
+      for (let i = 0; i < total; i++) {
+        const name = `bulk-${i}`;
+        insertEntity.run(name, `${day}T12:00:00.000Z`, JSON.stringify({ signal_score: 0.5 }));
+        const id = (selectId.get(name) as { id: number }).id;
+        insertTag.run(id);
+        insertObs.run(id, `work ${i}`);
+        // All on one axis, so they form a single cluster and every one of them
+        // must have been read for the count below to come out right.
+        const v = new Float32Array(DIM);
+        v[3] = 1;
+        v[4] = (i % 10) * 0.001;
+        insertVec.run(BigInt(id), Buffer.from(v.buffer));
+      }
+      db.exec('COMMIT');
+    } catch (e) {
+      db.exec('ROLLBACK');
+      throw e;
     }
 
     const result = await dreamPass();


### PR DESCRIPTION
## What this is

`tests/core/dreamer-semantic-clustering.test.ts > loads every vector across chunk boundaries` failed a PR #143 CI round on **windows-latest / Node 22** with `Test timed out in 30000ms`, then passed on rerun — a timing-edge flake, not a code defect. The whole file runs in ~367ms on an M-series Mac; the Windows leg is ~6× slower overall and this test's fixture was doing 600 autocommit insert rounds of four statements each, every statement re-prepared per row.

The fixture now prepares each statement once and wraps the seeding loop in `BEGIN`/`COMMIT`. Nothing the test asserts changed — it pins the vector-lookup chunk arithmetic, not the seeding shape. File runtime locally after the change: 241ms for all 14 tests.

## Verified in this session

- `node scripts/run-tests-isolated.mjs tests/core/dreamer-semantic-clustering.test.ts` — 14 passed (14), exit 0.
- **Killing power unchanged**: mutating the chunk loop in `src/core/dreamer.ts` to `ids.slice(start, VECTOR_LOOKUP_CHUNK)` (only ever reads the first chunk) turns exactly this test red — 1 failed | 13 passed, exit 1 — and restoring turns it green.

## Gates

| Gate | Result |
|---|---|
| `node scripts/run-tests-isolated.mjs` | exit 0 — Test Files 127 passed (127), Tests 1921 passed (1921) |
| `npm run typecheck` | exit 0 |
| `npm run lint` | exit 0 |
| `npm run verify:release` | exit 0 |