### PR TITLE
chore(release): v4.5.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "memesh",
       "source": "./",
       "description": "MeMesh — Local memory for Claude Code and MCP coding agents. One SQLite file, zero cloud required.",
-      "version": "4.5.0",
+      "version": "4.5.1",
       "author": {
         "name": "PCIRCLE AI"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -4,7 +4,7 @@
   "author": {
     "name": "PCIRCLE AI"
   },
-  "version": "4.5.0",
+  "version": "4.5.1",
   "homepage": "https://pcircle.com/memesh-llm-memory",
   "repository": "https://github.com/PCIRCLE-AI/memesh-llm-memory",
   "license": "MIT",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to MeMesh are documented here.
 
-## [Unreleased]
+## [4.5.1] — 2026-08-13
 
 ### Removed
 

--- a/dist/skills-manifest.json
+++ b/dist/skills-manifest.json
@@ -3,7 +3,7 @@
   "entries": [
     {
       "path": ".claude-plugin/plugin.json",
-      "sha256": "678e8e8a8a7e10b41418bcbe059c7ae253fa3db0b63a054f3518b67bc946e355",
+      "sha256": "22aaf782a91873b13ee596ff9529471d45f91b596ed340a5aa19d1079a7e3a0d",
       "bytes": 442
     },
     {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # MeMesh Plugin Architecture
 
-**Version**: 4.5.0
+**Version**: 4.5.1
 
 > Looking for "which file do I change for X?" — see [CODEMAP.md](../CODEMAP.md).
 

--- a/docs/api/API_REFERENCE.md
+++ b/docs/api/API_REFERENCE.md
@@ -1,7 +1,7 @@
 # MeMesh Plugin -- API Reference
 
 **Protocol**: Model Context Protocol (MCP) over stdio
-**Version**: 4.5.0
+**Version**: 4.5.1
 **Compatibility**: Works with Claude Code plugins, Claude Managed Agents (via MCP connector), and any MCP-compatible client.
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pcircle/memesh",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pcircle/memesh",
-      "version": "4.5.0",
+      "version": "4.5.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcircle/memesh",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "description": "MeMesh — Local memory for Claude Code and MCP coding agents. One SQLite file, zero cloud required.",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
Release cut for **v4.5.1** — bumps the 7 version anchors and renames CHANGELOG's `[Unreleased]` to `[4.5.1] — 2026-08-13`. No code changes beyond the regenerated `dist/skills-manifest.json`.

## What ships

- **The capture-floor reliability work** (PR #142, three review rounds): the `hook_runs` heartbeat with precise stamp semantics, doctor's evidence-based hook-liveness verdicts (corroboration, stop-silent, never-ran-legacy, 11 locales), read-only-file open tolerance, the unified 18-pattern credential redactor on both public egresses, and recall surviving unwritable capture targets.
- **The agentic-orchestration removal** (PR #147, `verify_agent_work` included): net ≈ −3,000 lines, with retirement signposts (`memesh verify`/`patterns` exit 1, `POST /v1/verify` → 410), install-hooks pruning of retired entries, doctor's `hook-wiring.script-missing`, and four new doc-claims gates.

## Verification

```
check-version-coherence: exit 0 (7 anchors agree on 4.5.1)
suite:  node scripts/run-tests-isolated.mjs — exit 0, 126 files / 1954+ tests
verify:release: exit 0 post-commit
lockfile: both version fields edited by hand — zero dependency resolution changes (2 lines)
```

After merge: `gh release create v4.5.1` triggers `publish-npm.yml` (a bare tag push does not). Then flip the Gemini MCP registration back to the installed bin:
`gemini mcp remove -s user memesh && gemini mcp add -s user memesh memesh-mcp`
