### PR TITLE
ci: raise the matrix job timeout to cover measured Windows runner variance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,18 @@ jobs:
   build-and-test:
     name: Build & Test (${{ matrix.os }}, Node ${{ matrix.node }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
+    # 40, not 15 — measured, twice (2026-08-13, runs 31697660004 and
+    # 31711750310, attempt 1 of each). A degraded windows-latest runner ran
+    # the suite at ~5× its usual pace: steady per-file progress right up to
+    # the kill, no hang — 51/127 and 48/127 test files done when the
+    # 15-minute cap cancelled the job — which projects to ~34 minutes
+    # end-to-end. A healthy Windows leg takes 6–10 minutes and ubuntu ~2, so
+    # this cap costs nothing when runners are healthy; it exists so
+    # runner-lottery slowness self-recovers as a slow green instead of a
+    # cancelled leg a human has to notice and re-run. The suite is fully
+    # serial (shared SQLite HOME) and spawn-heavy, which is why Windows
+    # magnifies runner variance this much.
+    timeout-minutes: 40
     strategy:
       fail-fast: false
       # Which runtimes this matrix covers, and why each is here.

--- a/scripts/audit/baseline.json
+++ b/scripts/audit/baseline.json
@@ -266,15 +266,15 @@
       "reason": "group-by identity or truthful zero-rows display",
       "triaged": "2026-08-09 (re-keyed: the node:sqlite driver swap shifted these lines; same statements, same classification)"
     },
-    "C4 .github/workflows/ci.yml:228": {
+    "C4 .github/workflows/ci.yml:239": {
       "class": "SAFE",
       "reason": "secondary greps run after the exit-code gate has already read DOCTOR_EXIT",
-      "triaged": "2026-08-09 (re-keyed: review fixes — busy_timeout, vector-index guards and the .mcp.json entry check — shifted these lines; same statements, same classification)"
+      "triaged": "2026-08-09 (re-keyed: review fixes — busy_timeout, vector-index guards and the .mcp.json entry check — shifted these lines; same statements, same classification); re-keyed 2026-08-14 228->239 (the timeout-minutes evidence comment above shifted +11; same statement — verified)"
     },
-    "C4 .github/workflows/ci.yml:222": {
+    "C4 .github/workflows/ci.yml:233": {
       "class": "SAFE",
       "reason": "secondary greps run after the exit-code gate has already read DOCTOR_EXIT",
-      "triaged": "2026-08-09 (re-keyed: review fixes — busy_timeout, vector-index guards and the .mcp.json entry check — shifted these lines; same statements, same classification)"
+      "triaged": "2026-08-09 (re-keyed: review fixes — busy_timeout, vector-index guards and the .mcp.json entry check — shifted these lines; same statements, same classification); re-keyed 2026-08-14 222->233 (the timeout-minutes evidence comment above shifted +11; same statement — verified)"
     },
     "C5 src/core/operations.ts:119": {
       "class": "SAFE-ACCUMULATOR",


### PR DESCRIPTION
## What

`build-and-test` job timeout: 15 → 40 minutes. One line plus the evidence comment.

## Why — measured, not guessed

Two Windows legs were cancelled at the 15-minute cap on 2026-08-13 (run 31697660004 windows/Node 22, run 31711750310 windows/Node 24 — attempt 1 of each). The partial logs of both cancelled attempts show the same shape:

- **No hang.** Tests progressed steadily right up to the kill — the last three ✓ lines land within 4 seconds of the cancellation.
- **A degraded runner at ~5× the usual pace.** 51/127 and 48/127 test files completed after ~11 minutes of the Run-tests step; projected end-to-end ≈ 34 minutes. Healthy Windows legs finish the whole job in 6–10 minutes (ubuntu ~2).
- Different Node versions on the two incidents rule out a version-specific cause; the suite being fully serial (shared SQLite HOME) and spawn-heavy is why Windows magnifies runner variance this much.

A job timeout only caps — healthy legs are unaffected. At 40, the runner-lottery case self-recovers as a slow green instead of a cancelled leg a human has to notice and re-run (which is exactly what happened twice yesterday).

## Verification

`gh api .../runs/<id>/attempts/1/logs`: run 31711750310's `7_Run tests.txt` shows `✓ tests/dashboard-design-tokens.test.ts` at 15:01:06 followed by `##[error]The operation was canceled.` at 15:01:10 (step started 14:49:31); run 31697660004 shows the same progressing-then-cancelled shape (51 files, 11:59:37 → 12:10:39).