### PR TITLE
docs: add Hermes Agent native integration guide

### DIFF
--- a/docs/platforms/README.md
+++ b/docs/platforms/README.md
@@ -10,6 +10,7 @@ MeMesh is designed for local coding-agent memory first. The preferred path is MC
 |--------|-----------|-------|-------|
 | **Claude Code / Claude Desktop** | MCP Server | Add `memesh-mcp` to your MCP config | See root [README](../../README.md) |
 | **MCP-compatible coding agents** | MCP Server | Point the client at `memesh-mcp` | See root [README](../../README.md) |
+| **Hermes Agent (NousResearch)** | Native `MemoryProvider` plugin | Drop `plugins/memory/memesh/` into a Hermes Agent checkout; `hermes memory setup memesh` | [hermes-agent.md](./hermes-agent.md) |
 | **Custom apps / scripts** | HTTP API | Run `memesh serve` and call `/v1/*` | [universal.md](./universal.md) |
 | **ChatGPT / Custom GPT experiments** | HTTP API | Use a local connector/proxy that can reach localhost | [chatgpt.md](./chatgpt.md) |
 | **Google Gemini experiments** | HTTP API | Use a local connector/proxy that can reach localhost | [gemini.md](./gemini.md) |
@@ -110,6 +111,7 @@ Use MCP mode when the client supports MCP. Use HTTP mode when you control a loca
 
 ## 📚 Platform-Specific Guides
 
+- **[Hermes Agent (NousResearch)](./hermes-agent.md)** - Native `MemoryProvider` plugin, on par with MCP mode
 - **[ChatGPT / Custom GPTs](./chatgpt.md)** - HTTP API with custom instructions
 - **[Google Gemini](./gemini.md)** - HTTP API with system instructions
 - **[Universal Guide](./universal.md)** - For local tools or bridge-based integrations

--- a/docs/platforms/hermes-agent.md
+++ b/docs/platforms/hermes-agent.md
@@ -1,0 +1,120 @@
+# MeMesh With Hermes Agent (NousResearch)
+
+Hermes Agent has a **first-party, documented plugin system for external memory
+providers** — `agent.memory_provider.MemoryProvider` (ABC), activated via
+convention-based discovery under `plugins/memory/<name>/`. This is not a
+generic HTTP/CLI bridge situation like ChatGPT or Gemini: Hermes ships seven
+providers this way already (honcho, mem0, hindsight, holographic, retaindb,
+byterover, openviking, supermemory), and MeMesh can be added as an eighth,
+with automatic per-turn recall/write — no core Hermes file needs editing.
+
+This guide is written from a working integration built and verified live
+against Hermes Agent `main` (2026-08-15), MeMesh 4.5.1, on a single-GPU host
+running `memesh serve` as a local systemd service. Treat it as the source
+material for a proper `hermes` entry in the platform table, not a stub.
+
+## Why this is a good fit
+
+- Hermes's `MemoryProvider.prefetch()` / `sync_turn()` hooks map directly
+  onto MeMesh's `POST /v1/recall` / `POST /v1/remember` — no adapter logic
+  needed beyond plain HTTP calls.
+- Hermes's provider discovery (`plugins.memory.discover_memory_providers()`)
+  scans the filesystem at runtime and reads each `plugin.yaml`'s `name` +
+  `description` + `is_available()` — a new provider directory is enough;
+  nothing in Hermes core needs to know MeMesh exists in advance.
+- MeMesh's loopback-only auth model (no bearer token required for
+  `localhost`) matches Hermes's local-first deployment pattern with zero
+  secret management.
+
+## The provider shape
+
+```
+plugins/memory/memesh/
+├── __init__.py      # MemeshProvider(MemoryProvider) + register(ctx)
+├── plugin.yaml       # name, version, description, hooks
+└── README.md
+```
+
+Minimum viable methods (all required by the ABC, see Hermes's own
+`website/docs/developer-guide/memory-provider-plugin.md` for the full
+contract):
+
+| Method | MeMesh call | Notes |
+|---|---|---|
+| `is_available()` | none (no network) | Check `shutil.which("memesh")` **and** a hardcoded `~/.npm-global/bin/memesh` fallback — see Pitfall 2. |
+| `initialize()` | none | Open one `httpx.Client(base_url=..., timeout=5.0)`, reused for the provider's lifetime. |
+| `prefetch(query)` | `POST /v1/recall` | Background-thread pattern: `queue_prefetch()` starts a thread after the previous turn; `prefetch()` consumes the cached result or blocks up to ~3s before giving up and returning `""`. Copy this pattern from `plugins/memory/mem0/__init__.py` — don't reinvent it. |
+| `sync_turn(user, assistant)` | `POST /v1/remember` | **Must** run in a daemon thread — see Threading Contract in the dev guide. Gate on `agent_context == "primary"` (see Pitfall 3). |
+| `get_tool_schemas()` / `handle_tool_call()` | `/v1/remember`, `/v1/recall`, `/v1/forget` | Expose as `memesh_remember` / `memesh_recall` / `memesh_forget` for explicit LLM-directed lookups on top of automatic recall. |
+| `get_config_schema()` / `save_config()` | — | For a local loopback deployment, one optional field (`base_url`, default `http://localhost:3737`) is enough. No secrets needed. |
+
+Activate with `hermes memory setup memesh` (non-interactive: the second
+positional arg skips the picker) — this writes `memory.provider: memesh` to
+`config.yaml`. Verify with `hermes memory status`.
+
+## Pitfalls found the hard way (all reproduced and fixed in a live session)
+
+1. **`POST /v1/recall`'s `data` field is a bare array**, not the
+   `{"entities": [...]}` object MeMesh's own `docs/api/API_REFERENCE.md`
+   documents. Confirmed on 4.5.1, with and without a `query`. Filed upstream:
+   [PCIRCLE-AI/memesh#159](https://github.com/PCIRCLE-AI/memesh/issues/159).
+   **Any HTTP integration must handle both shapes defensively** until this is
+   resolved — don't trust the doc's example verbatim.
+
+2. **PATH, not code, is the usual "provider shows unavailable" cause.**
+   `is_available()`'s `shutil.which("memesh")` depends on the *systemd
+   service's* PATH, not your interactive shell's. `hermes-gateway.service`
+   sets `Environment="PATH=..."` explicitly and narrowly — `npm install -g`
+   under a custom prefix (`~/.npm-global/bin`, needed if the default global
+   npm dir isn't user-writable) won't be on it until you add it to the unit
+   file **and** `daemon-reload`. Symptom: `discover_memory_providers()` shows
+   `is_available: False` even though `memesh --version` works fine over SSH.
+
+3. **The `system_prompt_block()` text can cause a real, undesired side
+   effect: it can make the model rewrite Hermes's own built-in
+   `MEMORY.md`/`USER.md` files, not just use your new provider.** Observed
+   live: an early draft that said "use the memesh_* tools to *explicitly
+   manage memory*" caused the model to also reorganize/rewrite the
+   pre-existing `USER.md` (structured markdown → compact prose) on a query
+   that just said "remember my favorite language" — an unintended cascade
+   into the *built-in* memory tool, not something MeMesh's HTTP calls did.
+   Confirmed by an A/B test: same query with the provider fully disabled did
+   a single clean append via the built-in tool and never touched `USER.md`.
+   **Fix**: keep `system_prompt_block()` minimal and explicitly say recall
+   is automatic and the explicit tools are a narrow backstop, not an
+   invitation to reorganize anything:
+   > "MeMesh auto-recalls relevant memory each turn; you don't need to call
+   > memesh_recall yourself for that. Only call memesh_remember/recall/forget
+   > for a specific, narrow lookup or correction the automatic recall
+   > missed — not as a cue to reorganize or rewrite existing memory files."
+   After this fix, the same "remember this" query completed cleanly with no
+   `USER.md` mutation, in ~51s (built-in memory tool still fired first; when
+   it errored with "file is full," the model fell back to `memesh_remember`
+   as a working backstop — a good emergent behavior *once* the prompt no
+   longer over-encouraged it).
+
+4. **Don't assume a hang is your integration's fault.** A `timeout 150
+   python -m hermes_cli.main -z "..."` run that produced *zero output* and
+   died at the timeout looked exactly like a stuck HTTP connection (a
+   `CLOSE-WAIT`/`FIN-WAIT-2` pair on the MeMesh port was visible via `ss
+   -tp`, which pointed straight at the plugin). It wasn't: `-z` is not a
+   valid non-interactive single-query flag (the correct invocation is
+   `hermes chat -q "..." --cli`), so the process was hanging on something
+   else entirely (an interactive read) before it ever reached the
+   memesh-aware code path. **Always verify the CLI invocation itself against
+   `hermes chat --help` before diagnosing a hang as coming from your
+   provider** — and once using the right invocation, response latency
+   (~16–50s observed, tool-call-count dependent) was identical whether the
+   MeMesh provider was on or off, i.e. MeMesh's prefetch overhead was not
+   the source of the earlier apparent hang at all.
+
+## Recommended platform-table entry
+
+| Client | Best Mode | Setup | Guide |
+|--------|-----------|-------|-------|
+| **Hermes Agent (NousResearch)** | Native `MemoryProvider` plugin | Drop `plugins/memory/memesh/` into a Hermes Agent checkout; `hermes memory setup memesh` | This page |
+
+Unlike the HTTP-only platforms in this directory, Hermes Agent should get
+listed as a **native integration**, same tier as MCP mode for Claude Code —
+the plugin, once written, behaves exactly like Hermes's own first-party
+providers, discoverable and configurable through Hermes's own CLI.


### PR DESCRIPTION
## Summary

First documented **native integration** (not HTTP-only) — Hermes Agent's `MemoryProvider` plugin system.

Written from a live integration session (2026-08-15) against Hermes Agent `main` + MeMesh 4.5.1, deployed as a local systemd service on a single-GPU host.

## What's included

**`docs/platforms/hermes-agent.md`** (121 lines):
- Why Hermes is a good fit (plugin discovery, direct API mapping, loopback auth)
- Complete MemoryProvider method → MeMesh API mapping table
- Provider structure (`plugins/memory/memesh/` layout)
- **4 pitfalls reproduced and fixed live**:
  1. **Recall response shape drift** — `POST /v1/recall` returns bare array, not `{entities: [...]}` (cross-refs #159)
  2. **systemd PATH trap** — `shutil.which("memesh")` depends on service PATH, not interactive shell
  3. **`system_prompt_block()` side effect** — over-encouraging prompt caused model to rewrite Hermes's own `USER.md` (unintended cascade)
  4. **CLI syntax misdiagnosis** — hung on wrong Hermes flag (`-z` vs `chat -q`), blamed integration instead of invocation

**Platform table update** (`docs/platforms/README.md`):
- Adds Hermes as **native integration** tier (same level as MCP mode, not HTTP-only like ChatGPT/Gemini)
- Listed above HTTP-only platforms

## Why this matters

- First integration guide written from real deployment (not theoretical)
- Documents pitfalls other integrators will hit (especially #1 and #3)
- Establishes "native integration" as a tier above HTTP-only
- Cross-validates issue #159 with real-world reproduction

## Testing

Live integration verified:
- `hermes memory setup memesh` + `hermes memory status` ✅
- Auto-recall on each turn ✅
- Explicit `memesh_remember`/`recall`/`forget` tools ✅
- systemd service deployment ✅

[verified: Deployed and tested in live Hermes session]