### PR TITLE
docs(install): the first screen answers "install it", and stops lying about what npm wires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,30 @@ All notable changes to MeMesh are documented here.
 
 ### Changed
 
+- **The README answers "install it" in the first screen, and stops making a
+  false claim.** An install-path audit (all eleven paths, stepped through
+  against the actual code) found the first working command 668 words into the
+  README — inside a warning box — and one sentence that was simply untrue:
+  Option B claimed "the MCP server is registered" when the npm package
+  deliberately runs no install scripts and registers nothing. Now: a compact
+  `## Install` section right under the intro (both paths, with the
+  verification for each — the plugin's verification is the `◉ MeMesh`
+  session-start line, which was previously documented nowhere); the false
+  sentence corrected in all three languages; the Codex/Gemini wiring section
+  added to 繁體中文 and Deutsch (both previously omitted it entirely); the
+  platforms guide table aligned with the root README (it told Claude Code
+  users to hand-edit MCP config and listed Gemini as HTTP-only); and two new
+  subsections — "See what it remembered" (`memesh briefing` as the one-command
+  answer) and "Your data" (one local file, backup = copy it, capture opt-out,
+  delete = remove the directory).
+
+- **CLAUDE.md carries the working policy.** Lightweight vs full-process
+  criteria, findings-first review with `PASS`/`PASS_WITH_CONCERNS`/`FAIL`
+  verdicts, no runtime claims without runtime evidence, disjoint-scope
+  delegation, and internal-notes-stay-local — stated once, in the pointer
+  file assistants actually read.
+
+
 - **The topology assembly has one owner; the review that found it also found
   two real defects.** A four-angle cleanup pass over the A1 arc (reuse /
   simplification / efficiency / altitude) converged on the same seam from

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ So — **read the real documents.** Do not restate them here.
 | What does the product do, how is it installed | [README.md](README.md) |
 | Colour, type, spacing, interaction — before ANY dashboard change | [DESIGN.md](DESIGN.md) |
 | How do I report a vulnerability | [SECURITY.md](SECURITY.md) |
+| What changed, and what is merged but unreleased | [CHANGELOG.md](CHANGELOG.md) (`[Unreleased]`) |
 
 ---
 
@@ -94,6 +95,41 @@ grep -E 'Test Files|Tests |Errors ' /tmp/t.log
 When you fix a bug, **revert the fix and confirm the test goes red.** A green
 suite is not evidence that a fix is protected: three tests in this repository
 have passed while the thing they guarded was removed.
+
+### Working policy
+
+How much process a change deserves is decided by its blast radius, not by
+habit. Two modes:
+
+- **Lightweight** — the change is confined to one module or one clear path,
+  needs no multi-surface verification, and touches nothing security-sensitive
+  or destructive. Do it directly: implement, run the affected tests plus
+  `npm run typecheck`, read your own diff, done. Most fixes are this.
+- **Full** — anything that changes behaviour across surfaces (hook + MCP +
+  CLI + docs move together here), touches persistence, security boundaries,
+  or user-facing contracts. Then: understand → plan → implement with tests →
+  the full gate (`verify:release`) → break-test the guards you added
+  (revert the fix, watch the test go red) → docs in the same PR.
+
+Rules that hold in both modes:
+
+- **Findings first, evidence over warnings.** A review or QA report leads
+  with what is wrong and proves it (file:line, actual output), not with
+  broad concerns. Gate verdicts use the same vocabulary `memesh doctor`
+  uses: `PASS`, `PASS_WITH_CONCERNS`, `FAIL`.
+- **No runtime claim without runtime evidence.** "It works" requires having
+  run it — the verification section above is the how.
+- **Delegating to subagents**: split ownership into disjoint file scopes so
+  two writers never touch one file; isolate file-editing agents in
+  worktrees; the orchestrator reads every diff before it lands. Do not
+  delegate the critical path reflexively — coordination has a cost.
+- **Internal working notes stay local.** Plans, scratch analyses, agent
+  transcripts, private TODOs — never committed, never in commit messages or
+  release notes. The repository carries only what reproduces shipped
+  behaviour: source, tests, schemas, configuration, and the public docs
+  above. (This is also why this file is a pointer.)
+- **Docs move with the change** — a capability the docs do not describe, or
+  describe wrongly, fails `check-doc-claims` and is not done.
 
 ### Git
 

--- a/README.de.md
+++ b/README.de.md
@@ -18,6 +18,26 @@
 
 **MeMesh** — Open-Source-**agentischer Speicher** für Claude Code & MCP-Coding-Agenten: erfasst aus der echten Arbeit des Agenten, injiziert in dem Moment, in dem er handelt, ehrlich gehalten, wenn er sich selbst widerspricht. Eine SQLite-Datei. Keine Cloud.
 
+## Installation
+
+**In Claude Code** — diese zwei Zeilen im Chat eingeben (Hooks, Memory-Tools und der `/memesh`-Skill werden automatisch verdrahtet):
+
+```
+/plugin marketplace add PCIRCLE-AI/memesh
+/plugin install memesh@pcircle-memesh
+```
+
+Claude Code neu starten. Eine `◉ MeMesh`-Statuszeile am Anfang der nächsten Session bedeutet: es zeichnet auf.
+
+**Im Terminal** — die `memesh`-CLI, das Dashboard und der `memesh-mcp`-Server für Codex / Gemini / Cursor (braucht [Node 22.13+](https://nodejs.org)):
+
+```bash
+npm install -g @pcircle/memesh
+memesh doctor        # prüft diese Installation Ende-zu-Ende
+```
+
+Die meisten Claude-Code-Nutzer wollen am Ende **beides** — gemeinsame Datenbank, kein Konflikt. Details, weitere Agenten, Upgrades: siehe „In 60 Sekunden starten" unten.
+
 ## Das Problem
 
 Ihr Coding-Agent vergisst nicht nur Fakten zwischen Sessions — er **wiederholt Arbeit**. Er schlägt erneut den Ansatz vor, den Sie letzten Monat abgelehnt haben, stolpert über denselben fehlschlagenden Test, entdeckt die Constraint wieder, die im März die Produktion kaputt gemacht hat, und bittet Sie, die Architektur erneut zu erklären, die er selbst mitentworfen hat.
@@ -105,6 +125,8 @@ Wenn Sie Claude Code nutzen, installieren Sie MeMesh als Plugin direkt in der CL
 
 Claude Code verdrahtet Hooks, Skills und den MCP-Server automatisch. Sie erhalten Auto-Capture in der Session, proaktives Recall, den `/memesh`-Skill in der Unterhaltung und `remember` / `recall` / `forget` / `learn` als MCP-Tools für den Agenten.
 
+**Prüfen:** Claude Code neu starten und eine beliebige Session beginnen. Eine Statuszeile wie `◉ MeMesh ready · no memories for "your-project" yet` erscheint oben — diese Zeile IST das funktionierende Plugin; kein separater Befehl nötig. (Mit vorhandenen Memories zeigt sie stattdessen Zähler.)
+
 ### Option B — npm global (optionale Optimierung)
 
 Wenn Sie das Binary direkt im `PATH` möchten (damit `memesh` in jedem Terminal ohne `npx`-Verzögerung läuft) oder `memesh-mcp` als stdio-Befehl mit festem Pfad für MCP-Clients außerhalb von Claude Code (Cursor, Cline) bereitstellen wollen:
@@ -115,7 +137,7 @@ npm install -g @pcircle/memesh
 
 ### Schritt 1.5: MeMesh in Claude Code einbinden (empfohlen, einmalig)
 
-`npm install -g` legt die CLI in den PATH und registriert den MCP-Server, aber MeMeshs Claude-Code-Session-Hooks werden **nicht** automatisch verdrahtet. Ohne diese Hooks können Sie `memesh remember` / `recall` manuell verwenden, aber die **Auto-Capture-Schleife** (Session → Lektionen → proaktive Erinnerung in der nächsten Session) bleibt stumm.
+`npm install -g` legt die CLI in den PATH — aber nichts ist damit in Claude Code eingebunden: Das npm-Paket führt bewusst keine Install-Skripte aus; MCP-Server und Hooks in Claude Code registriert das Plugin (Option A). Was der npm-Pfad selbst verdrahten kann, sind die Session-Hooks. Ohne diese Hooks können Sie `memesh remember` / `recall` manuell verwenden, aber die **Auto-Capture-Schleife** (Session → Lektionen → proaktive Erinnerung in der nächsten Session) bleibt stumm.
 
 ```bash
 memesh install-hooks         # fügt memesh-Hooks zu ~/.claude/settings.json hinzu
@@ -123,6 +145,27 @@ memesh doctor                # bestätigt, dass „Hooks wired into Claude Code"
 ```
 
 Die Hooks existieren neben Ihren bestehenden Custom-Hooks unter `~/.claude/hooks/` — `install-hooks` schreibt additiv und überschreibt nie Ihre Einträge. Zum Entfernen: `memesh uninstall-hooks`.
+
+### Dieselben Memories aus Codex CLI und Gemini CLI
+
+`memesh-mcp` ist ein gewöhnlicher stdio-MCP-Server — jeder MCP-fähige Host kann ihn nutzen, nicht nur Claude Code. Mit installierter Option B (`memesh-mcp` im `PATH`) einmal pro Host registrieren:
+
+```bash
+# OpenAI Codex CLI — schreibt [mcp_servers.memesh] in ~/.codex/config.toml
+codex mcp add memesh -- memesh-mcp
+
+# Google Gemini CLI — User-Scope, funktioniert in jedem Ordner
+gemini mcp add -s user memesh memesh-mcp
+```
+
+Jeder Host liest und schreibt dieselbe `~/.memesh/knowledge-graph.db` — eine in Claude Code gespeicherte Memory ist aus Codex oder Gemini abrufbar, und umgekehrt. Prüfen:
+
+```bash
+codex mcp list       # memesh sollte als enabled gelistet sein
+gemini mcp list      # memesh sollte "Connected" zeigen
+```
+
+> **Als konfigurierten Befehl `memesh-mcp` verwenden, NICHT `npx -p @pcircle/memesh`.** `npx -p` löst zum *lokalen* Paket auf, sobald das Arbeitsverzeichnis des Hosts in einem Checkout dieses Repositories liegt — und führt dann stillschweigend dessen aktuellen Stand statt des installierten Release aus.
 
 ### Native Integration: Hermes Agent
 
@@ -180,6 +223,32 @@ memesh serve
 <p align="center">
   <img src="docs/images/dashboard-graph.png" alt="MeMesh Graph — interactive knowledge graph with type filters and ego mode" width="100%" />
 </p>
+
+### Sehen, was es sich gemerkt hat
+
+Ein Befehl zeigt jederzeit, was Ihr Agent über das aktuelle Projekt weiß — wo die Arbeit stand, Entscheidungen, Lektionen, jüngste Aktivität (verpackt als Referenzdaten):
+
+```bash
+memesh briefing
+```
+
+```text
+Where "your-project" was left off (today):
+- Goal: Ship the payment retry logic
+- Next: Open the PR once CI is green
+
+Decisions and direction for "your-project":
+- [decision] Use FTS5 as the retrieval baseline
+```
+
+Denselben Block erhält Claude Code automatisch beim Session-Start, und jeder andere MCP-Client über das `briefing`-Tool — der Agent startet orientiert, statt das Repository neu zu lesen, und Sie erklären letzte Woche nicht noch einmal. Das Dashboard (`memesh serve`) ist die vollständige visuelle Ansicht.
+
+### Ihre Daten
+
+- **Eine lokale Datei.** Alles liegt in `~/.memesh/knowledge-graph.db` — SQLite, auf Ihrer Festplatte. Kein Cloud-Konto; nichts verlässt Ihren Rechner, außer Sie konfigurieren selbst einen Cloud-Embedder oder ein LLM.
+- **Backup = diese eine Datei kopieren.** Wiederherstellen = zurückkopieren.
+- **Aufzeichnung jederzeit pausieren**: `export MEMESH_AUTO_CAPTURE=false`.
+- **Alles löschen**: `~/.memesh/` entfernen.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,26 @@
 
 **MeMesh** — open-source **agentic memory** for Claude Code & MCP coding agents: captured from the agent's real work, injected at the moment it acts, kept honest when it contradicts itself. One SQLite file. No cloud.
 
+## Install
+
+**In Claude Code** — type these in the chat (hooks, memory tools and the `/memesh` skill are wired automatically):
+
+```
+/plugin marketplace add PCIRCLE-AI/memesh
+/plugin install memesh@pcircle-memesh
+```
+
+Restart Claude Code. A `◉ MeMesh` status line at the top of your next session means it is capturing.
+
+**In a terminal** — the `memesh` CLI, the dashboard, and the `memesh-mcp` server for Codex / Gemini / Cursor (needs [Node 22.13+](https://nodejs.org)):
+
+```bash
+npm install -g @pcircle/memesh
+memesh doctor        # verifies this install end to end
+```
+
+Most Claude Code users eventually want **both** — they share one database and never conflict. Details, other agents, and upgrades: [Get Started](#get-started-in-60-seconds).
+
 ## The Problem
 
 Your coding agent doesn't just forget facts between sessions — it **repeats work**. It re-proposes the approach you rejected last month, trips over the same failing test, re-discovers the constraint that broke production in March, and asks you to re-explain the architecture it helped design.
@@ -103,6 +123,8 @@ If you use Claude Code, install MeMesh as a plugin from inside the CLI:
 
 Claude Code wires hooks, skills, and the MCP server automatically. You get in-session auto-capture, proactive recall, the `/memesh` skill (remember / recall / learn / forget) inside the Claude Code conversation, and `remember` / `recall` / `forget` / `learn` available as MCP tools to the agent.
 
+**Verify it:** restart Claude Code and start any session. A status line like `◉ MeMesh ready · no memories for "your-project" yet` appears at the top — that line IS the plugin working; no separate command needed. (Once you have memories, it shows counts instead.)
+
 The MCP server runs directly from the plugin's bundled compiled output — no `npx` lookup, no build step, and nothing to compile. memesh stores its data through `node:sqlite`, which is part of Node itself (22.13+), so a Node upgrade cannot leave it with a binary built for the wrong runtime.
 
 > **This installs the plugin only.** You can run CLI commands via `npx @pcircle/memesh <command>` if you absolutely don't want a global install, but typing plain `memesh` in a terminal will report `command not found`. To get a real shell `memesh` command, also run **Option B** below — both paths coexist and share the same memory database. The "Install paths at a glance" diagram above covers this.
@@ -123,7 +145,7 @@ npm install -g @pcircle/memesh
 
 If you installed via **Option A** (`/plugin install memesh@pcircle-memesh`), skip this step — Claude Code wires plugin hooks automatically.
 
-If you installed via **Option B** (`npm install -g`), the CLI is on your PATH and the MCP server is registered, but the Claude Code session hooks are not auto-wired. Without them you can still use `memesh remember` / `recall` manually, but the **auto-capture loop** (sessions → lessons → recall on next session) is silent.
+If you installed via **Option B** (`npm install -g`), the CLI is on your PATH — but nothing is wired into Claude Code yet: the npm package deliberately runs no install scripts, and the plugin (Option A) is what registers the MCP server and hooks inside Claude Code. What the npm path can wire by itself is the session hooks. Without them you can still use `memesh remember` / `recall` manually, but the **auto-capture loop** (sessions → lessons → recall on next session) is silent.
 
 ```bash
 memesh install-hooks         # adds memesh's hooks to ~/.claude/settings.json
@@ -211,6 +233,32 @@ memesh serve
 <p align="center">
   <img src="docs/images/dashboard-graph.png" alt="MeMesh Graph — interactive knowledge graph with type filters and ego mode" width="100%" />
 </p>
+
+### See what it remembered
+
+At any moment, one command prints what your agent knows about the current project — where work was left off, decisions, lessons, recent activity (wrapped as reference data):
+
+```bash
+memesh briefing
+```
+
+```text
+Where "your-project" was left off (today):
+- Goal: Ship the payment retry logic
+- Next: Open the PR once CI is green
+
+Decisions and direction for "your-project":
+- [decision] Use FTS5 as the retrieval baseline
+```
+
+This same block is what Claude Code receives automatically at session start, and what any other MCP client gets from the `briefing` tool — the agent starts oriented instead of re-reading the repository, and you stop re-explaining last week. The dashboard (`memesh serve`) is the full visual view.
+
+### Your data
+
+- **One local file.** Everything lives in `~/.memesh/knowledge-graph.db` — SQLite, on your disk. No cloud account; nothing leaves your machine unless you configure a cloud embedder or LLM yourself.
+- **Back up = copy that one file.** Restore = copy it back.
+- **Pause capture anytime**: `export MEMESH_AUTO_CAPTURE=false`.
+- **Delete everything**: remove `~/.memesh/`.
 
 ---
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -18,6 +18,26 @@
 
 **MeMesh** — 給 Claude Code 和 MCP 程式開發代理的開源**代理式記憶**：從代理的實際工作中擷取，在它行動的當下注入，記憶自相矛盾時保持誠實。一個 SQLite 檔案。不需要雲端。
 
+## 安裝
+
+**在 Claude Code 裡** — 在對話框輸入這兩行（hooks、記憶工具和 `/memesh` skill 會自動接好）：
+
+```
+/plugin marketplace add PCIRCLE-AI/memesh
+/plugin install memesh@pcircle-memesh
+```
+
+重開 Claude Code。下一個 session 開頭出現 `◉ MeMesh` 狀態列，就代表它在記了。
+
+**在終端機裡** — `memesh` CLI、儀表板，以及給 Codex / Gemini / Cursor 用的 `memesh-mcp` server（需要 [Node 22.13+](https://nodejs.org)）：
+
+```bash
+npm install -g @pcircle/memesh
+memesh doctor        # 端到端驗證這份安裝
+```
+
+大多數 Claude Code 使用者最後兩種都會裝 — 它們共用同一個資料庫、永不衝突。細節、其他代理、升級方式：見下方「60 秒快速開始」。
+
 ## 問題所在
 
 你的程式開發代理在對話之間不只是忘記事實 — 它會**重複做過的工作**。它會重新提出你上個月否決過的做法，被同一個失敗的測試絆倒，重新發現三月那次弄壞 production 的限制條件，還要你重新解釋那個它自己參與設計的架構。
@@ -103,7 +123,9 @@ npm install -g @pcircle/memesh
 /plugin install memesh@pcircle-memesh
 ```
 
-Claude Code 會自動接好 hooks、skills 和 MCP server。你會獲得對話內自動擷取、主動回憶、可在 Claude Code 對話中使用的 `/memesh` skill（remember / recall / learn / forget），以及代理可呼叫的 `remember` / `recall` / `forget` / `learn` MCP 工具。CLI 與本地儀表板無需任何額外的全域安裝就能完整使用 — `npx @pcircle/memesh <command>` 可執行所有 CLI 指令，`npx @pcircle/memesh` 可在 `localhost:3737` 啟動儀表板。MCP server 直接從外掛內建的編譯產物啟動 — 不需要 `npx` 查找、不需要 `npm install -g`、不需要本地建置步驟。memesh 透過 Node 內建的 `node:sqlite`（22.13+）存放資料，所以升級 Node 不會留下一個為錯誤 runtime 編譯的二進位檔。
+Claude Code 會自動接好 hooks、skills 和 MCP server。你會獲得對話內自動擷取、主動回憶、可在 Claude Code 對話中使用的 `/memesh` skill（remember / recall / learn / forget），以及代理可呼叫的 `remember` / `recall` / `forget` / `learn` MCP 工具。
+
+**驗證方式：**重開 Claude Code、開任何 session。開頭出現像 `◉ MeMesh ready · no memories for "your-project" yet` 的狀態列 — 那一行就是外掛在運作的證明，不需要另外跑指令。（有記憶之後會改顯示數量。）CLI 與本地儀表板無需任何額外的全域安裝就能完整使用 — `npx @pcircle/memesh <command>` 可執行所有 CLI 指令，`npx @pcircle/memesh` 可在 `localhost:3737` 啟動儀表板。MCP server 直接從外掛內建的編譯產物啟動 — 不需要 `npx` 查找、不需要 `npm install -g`、不需要本地建置步驟。memesh 透過 Node 內建的 `node:sqlite`（22.13+）存放資料，所以升級 Node 不會留下一個為錯誤 runtime 編譯的二進位檔。
 
 ### 選項 B — npm 全域安裝（可選最佳化）
 
@@ -121,7 +143,7 @@ npm install -g @pcircle/memesh
 
 如果你透過**選項 A**（`/plugin install memesh@pcircle-memesh`）安裝，請略過此步驟 — Claude Code 會自動接好外掛 hooks。
 
-如果你透過**選項 B**（`npm install -g`）安裝，CLI 已在 PATH 上、MCP server 也已註冊，但 Claude Code session hooks 並未自動接上。沒有這些 hooks 還是可以手動使用 `memesh remember` / `recall`，但**自動擷取迴路**（session → 教訓 → 下次 session 主動回憶）就會靜默不動。
+如果你透過**選項 B**（`npm install -g`）安裝，CLI 已在 PATH 上 — 但**還沒有任何東西接進 Claude Code**：npm 套件刻意不執行安裝腳本，把 MCP server 和 hooks 接進 Claude Code 的是外掛（選項 A）。npm 路徑自己能接的是 session hooks。沒有這些 hooks 還是可以手動使用 `memesh remember` / `recall`，但**自動擷取迴路**（session → 教訓 → 下次 session 主動回憶）就會靜默不動。
 
 ```bash
 memesh install-hooks         # 把 memesh hooks 加進 ~/.claude/settings.json
@@ -129,6 +151,27 @@ memesh doctor                # 確認「Hooks wired into Claude Code」過了
 ```
 
 這些 hooks 會跟你既有的 `~/.claude/hooks/` 自訂 hooks 共存 — `install-hooks` 用追加方式寫入，從不覆寫你的東西。要移除：`memesh uninstall-hooks`。
+
+### 從 Codex CLI 和 Gemini CLI 用同一份記憶
+
+`memesh-mcp` 是標準的 stdio MCP server，任何支援 MCP 的主機都能用 — 不限 Claude Code。裝好選項 B（`memesh-mcp` 在 `PATH` 上）之後，每個主機註冊一次：
+
+```bash
+# OpenAI Codex CLI — 會把 [mcp_servers.memesh] 寫進 ~/.codex/config.toml
+codex mcp add memesh -- memesh-mcp
+
+# Google Gemini CLI — user 範圍，每個資料夾都能用
+gemini mcp add -s user memesh memesh-mcp
+```
+
+每個主機讀寫的都是同一個 `~/.memesh/knowledge-graph.db`，所以在 Claude Code session 存的記憶，Codex 和 Gemini 都回憶得到，反之亦然。驗證：
+
+```bash
+codex mcp list       # memesh 應顯示為 enabled
+gemini mcp list      # memesh 應顯示 "Connected"
+```
+
+> **設定的指令要用 `memesh-mcp`，不要用 `npx -p @pcircle/memesh`。**當主機的工作目錄在這個 repo 的 checkout 裡時，`npx -p` 會解析到*本地*套件，靜默執行工作樹當下的狀態而不是安裝好的正式版。
 
 ### 原生整合：Hermes Agent
 
@@ -188,6 +231,32 @@ memesh serve
 <p align="center">
   <img src="docs/images/dashboard-graph.png" alt="MeMesh 圖表 — 互動式知識圖，具有類型篩選和自我中心模式" width="100%" />
 </p>
+
+### 看看它幫你記了什麼
+
+任何時候一條指令，就能印出你的代理對目前專案知道什麼 — 工作做到哪、決策、教訓、近期活動（以參考資料的形式包好）：
+
+```bash
+memesh briefing
+```
+
+```text
+Where "your-project" was left off (today):
+- Goal: Ship the payment retry logic
+- Next: Open the PR once CI is green
+
+Decisions and direction for "your-project":
+- [decision] Use FTS5 as the retrieval baseline
+```
+
+Claude Code 在 session 開始時自動收到的就是同一個區塊，其他 MCP 用戶端呼叫 `briefing` 工具也拿到同一份 — 代理一開場就有方向，不用重讀整個 repo，你也不用再重講上禮拜的事。儀表板（`memesh serve`）是完整的視覺化版本。
+
+### 你的資料
+
+- **就一個本機檔案。**所有東西都在 `~/.memesh/knowledge-graph.db` — SQLite、在你的硬碟上。沒有雲端帳號；除非你自己設定雲端 embedder 或 LLM，否則什麼都不會離開你的機器。
+- **備份 = 複製那個檔案。**還原 = 複製回去。
+- **隨時暫停擷取**：`export MEMESH_AUTO_CAPTURE=false`。
+- **全部刪除**：移除 `~/.memesh/`。
 
 ---
 

--- a/docs/platforms/README.md
+++ b/docs/platforms/README.md
@@ -8,13 +8,14 @@ MeMesh is designed for local coding-agent memory first. The preferred path is MC
 
 | Client | Best Mode | Setup | Guide |
 |--------|-----------|-------|-------|
-| **Claude Code / Claude Desktop** | MCP Server | Add `memesh-mcp` to your MCP config | See root [README](../../README.md) |
-| **MCP-compatible coding agents** | MCP Server | Point the client at `memesh-mcp` | See root [README](../../README.md) |
+| **Claude Code** | Plugin (hooks + MCP + skills, wired automatically) | `/plugin marketplace add PCIRCLE-AI/memesh` → `/plugin install memesh@pcircle-memesh` | See root [README](../../README.md) |
+| **Codex CLI / Gemini CLI** | MCP Server | `codex mcp add memesh -- memesh-mcp` / `gemini mcp add -s user memesh memesh-mcp` (needs `npm install -g @pcircle/memesh`) | See root [README](../../README.md) |
+| **Other MCP coding agents (Cursor, Cline…)** | MCP Server | Point the client at `memesh-mcp` | See root [README](../../README.md) |
 | **Hermes Agent (NousResearch)** | Native `MemoryProvider` plugin | Drop `plugins/memory/memesh/` into a Hermes Agent checkout; `hermes memory setup memesh` | [hermes-agent.md](./hermes-agent.md) |
 | **OpenClaw** | Native memory plugin | `openclaw plugins install <package>` or drop into OpenClaw checkout; configure `plugins.slots.memory` | [openclaw.md](./openclaw.md) |
 | **Custom apps / scripts** | HTTP API | Run `memesh serve` and call `/v1/*` | [universal.md](./universal.md) |
 | **ChatGPT / Custom GPT experiments** | HTTP API | Use a local connector/proxy that can reach localhost | [chatgpt.md](./chatgpt.md) |
-| **Google Gemini experiments** | HTTP API | Use a local connector/proxy that can reach localhost | [gemini.md](./gemini.md) |
+| **Gemini web / AI Studio experiments** | HTTP API | Use a local connector/proxy that can reach localhost (the Gemini **CLI** uses MCP above instead) | [gemini.md](./gemini.md) |
 
 ---
 

--- a/scripts/audit/baseline.json
+++ b/scripts/audit/baseline.json
@@ -466,35 +466,35 @@
       "reason": "batch-hydrate lookups; confidence bump fails closed",
       "triaged": "2026-08-09 (re-keyed: review fixes — busy_timeout, vector-index guards and the .mcp.json entry check — shifted these lines; same statements, same classification); re-keyed 2026-08-10 (review pass 2: redactUserPaths moved to core/paths, namespace breadcrumb, dreamer retirement); re-keyed 2026-08-14 (UX-1 title column added lines above; same statement — verified against the line content); re-keyed 2026-08-15 631→649 (merge main shifted lines +18; same statement — verified)"
     },
-    "C7 README.md:283": {
+    "C7 README.md:331": {
       "class": "LINKED-MEASUREMENT",
       "reason": "benchmark figure linked to benchmarks/longmemeval/RESULTS.md + REPRODUCE.md; no machine gate by accepted policy",
-      "triaged": "2026-08-04; re-keyed 2026-08-15 21→271 (merge main shifted lines +250; same statement — verified)"
+      "triaged": "2026-08-04; re-keyed 2026-08-15 21→271 (merge main shifted lines +250; same statement — verified); re-keyed 2026-08-16 (+48: Install first-screen section and See-what-it-remembered/Your-data subsections added above; statements byte-identical — verified against HEAD)"
     },
-    "C7 README.md:289": {
+    "C7 README.md:337": {
       "class": "LINKED-MEASUREMENT",
       "reason": "benchmark figure linked to benchmarks/longmemeval/RESULTS.md + REPRODUCE.md; no machine gate by accepted policy",
-      "triaged": "2026-08-04; re-keyed 2026-08-15 27→277 (merge main shifted lines +250; same statement — verified)"
+      "triaged": "2026-08-04; re-keyed 2026-08-15 27→277 (merge main shifted lines +250; same statement — verified); re-keyed 2026-08-16 (+48: Install first-screen section and See-what-it-remembered/Your-data subsections added above; statements byte-identical — verified against HEAD)"
     },
-    "C7 README.md:307": {
+    "C7 README.md:355": {
       "class": "LINKED-MEASUREMENT",
       "reason": "benchmark figure linked to benchmarks/longmemeval/RESULTS.md + REPRODUCE.md; no machine gate by accepted policy",
-      "triaged": "2026-08-04 (re-keyed 273->294: the Codex/Gemini MCP setup section added to Get Started shifted this line down 21; same auto-capture table row verified before re-keying); re-keyed 2026-08-13 (review-fix commit shifted lines; same statement, classification unchanged — verified); re-keyed 2026-08-15 293→295 (merge main shifted lines +2; same statement — verified)"
+      "triaged": "2026-08-04 (re-keyed 273->294: the Codex/Gemini MCP setup section added to Get Started shifted this line down 21; same auto-capture table row verified before re-keying); re-keyed 2026-08-13 (review-fix commit shifted lines; same statement, classification unchanged — verified); re-keyed 2026-08-15 293→295 (merge main shifted lines +2; same statement — verified); re-keyed 2026-08-16 (+48: Install first-screen section and See-what-it-remembered/Your-data subsections added above; statements byte-identical — verified against HEAD)"
     },
-    "C7 README.md:381": {
+    "C7 README.md:429": {
       "class": "LINKED-MEASUREMENT",
       "reason": "benchmark figure linked to benchmarks/longmemeval/RESULTS.md + REPRODUCE.md; no machine gate by accepted policy",
-      "triaged": "2026-08-04 (re-keyed 346->348->369: the Codex/Gemini MCP setup section shifted this line down 21 more; same testimonial figure verified before re-keying); re-keyed 2026-08-13 (agentic-orchestration removal shifted lines up; same statement, classification unchanged); re-keyed 2026-08-13 (review-fix commit shifted lines; same statement, classification unchanged — verified); re-keyed 2026-08-15 367→369 (merge main shifted lines +2; same statement — verified)"
+      "triaged": "2026-08-04 (re-keyed 346->348->369: the Codex/Gemini MCP setup section shifted this line down 21 more; same testimonial figure verified before re-keying); re-keyed 2026-08-13 (agentic-orchestration removal shifted lines up; same statement, classification unchanged); re-keyed 2026-08-13 (review-fix commit shifted lines; same statement, classification unchanged — verified); re-keyed 2026-08-15 367→369 (merge main shifted lines +2; same statement — verified); re-keyed 2026-08-16 (+48: Install first-screen section and See-what-it-remembered/Your-data subsections added above; statements byte-identical — verified against HEAD)"
     },
-    "C7 README.md:440": {
+    "C7 README.md:488": {
       "class": "LINKED-MEASUREMENT",
       "reason": "benchmark figure linked to benchmarks/longmemeval/RESULTS.md + REPRODUCE.md; no machine gate by accepted policy",
-      "triaged": "2026-08-04 (re-keyed 353->355->376: the Codex/Gemini MCP setup section shifted this line down 21 more; same 95.60% R@5 out-of-the-box figure verified before re-keying); re-keyed 2026-08-13 (agentic-orchestration removal shifted lines up; same statement, classification unchanged); re-keyed 2026-08-13 (review-fix commit shifted lines; same statement, classification unchanged — verified); re-keyed 2026-08-14 374->426 (the Recipes section added above; same statement — verified); re-keyed 2026-08-15 426→428 (merge main shifted lines +2; same statement — verified)"
+      "triaged": "2026-08-04 (re-keyed 353->355->376: the Codex/Gemini MCP setup section shifted this line down 21 more; same 95.60% R@5 out-of-the-box figure verified before re-keying); re-keyed 2026-08-13 (agentic-orchestration removal shifted lines up; same statement, classification unchanged); re-keyed 2026-08-13 (review-fix commit shifted lines; same statement, classification unchanged — verified); re-keyed 2026-08-14 374->426 (the Recipes section added above; same statement — verified); re-keyed 2026-08-15 426→428 (merge main shifted lines +2; same statement — verified); re-keyed 2026-08-16 (+48: Install first-screen section and See-what-it-remembered/Your-data subsections added above; statements byte-identical — verified against HEAD)"
     },
-    "C7 README.md:471": {
+    "C7 README.md:519": {
       "class": "LINKED-MEASUREMENT",
       "reason": "benchmark figure linked to benchmarks/longmemeval/RESULTS.md + REPRODUCE.md; no machine gate by accepted policy",
-      "triaged": "2026-08-04 (re-keyed 379->382->386->407: the Codex/Gemini MCP setup section shifted this line down 21 more; same 95.60% R@5 comparison-table figure verified before re-keying); re-keyed 2026-08-13 (agentic-orchestration removal shifted lines up; same statement, classification unchanged); re-keyed 2026-08-13 (review-fix commit shifted lines; same statement, classification unchanged — verified); re-keyed 2026-08-14 405->457 (the Recipes section added above; same statement — verified); re-keyed 2026-08-15 457→459 (merge main shifted lines +2; same statement — verified)"
+      "triaged": "2026-08-04 (re-keyed 379->382->386->407: the Codex/Gemini MCP setup section shifted this line down 21 more; same 95.60% R@5 comparison-table figure verified before re-keying); re-keyed 2026-08-13 (agentic-orchestration removal shifted lines up; same statement, classification unchanged); re-keyed 2026-08-13 (review-fix commit shifted lines; same statement, classification unchanged — verified); re-keyed 2026-08-14 405->457 (the Recipes section added above; same statement — verified); re-keyed 2026-08-15 457→459 (merge main shifted lines +2; same statement — verified); re-keyed 2026-08-16 (+48: Install first-screen section and See-what-it-remembered/Your-data subsections added above; statements byte-identical — verified against HEAD)"
     },
     "C3 scripts/audit/measure-injection-tokens.mjs": {
       "class": "NOT-A-GATE",


### PR DESCRIPTION
P3 of the install-UX plan (from the eleven-path install audit). Human-side documentation fixes only — no code.

## What changed

- **`## Install` in the first screen** (all three languages): both paths with their verification. The plugin path's verification — the `◉ MeMesh` session-start status line — existed in the product but was documented **nowhere**; Option A previously had no verification step at all, and the first working command sat 668 words in, inside a warning box.
- **A false sentence deleted** (×3 languages): Option B claimed "the MCP server is registered." The npm package deliberately runs no install scripts and registers nothing. Corrected to what is true: the plugin registers MCP + hooks; the npm path can wire the session hooks itself.
- **繁體中文 / Deutsch gain the Codex & Gemini wiring section** — both had omitted it entirely (grep count zero). A non-English reader previously had no path to either host.
- **`docs/platforms/README.md` aligned with the root README** — its table told Claude Code users to hand-edit MCP config (no mention of the plugin channel) and listed Gemini as HTTP-only while the root README ships `gemini mcp add`.
- **"See what it remembered"** (`memesh briefing` as the one-command answer) and **"Your data"** (one local file · backup = copy it · `MEMESH_AUTO_CAPTURE=false` · delete = remove `~/.memesh/`) — new subsections, all three languages.
- **CLAUDE.md working policy**: lightweight vs full-process criteria, findings-first review with `PASS`/`PASS_WITH_CONCERNS`/`FAIL` verdicts, no runtime claims without runtime evidence, disjoint-scope delegation, internal notes stay local.

## Verification

```
node scripts/run-tests-isolated.mjs → exit=0   (134 files / 2057 tests)
node scripts/check-doc-claims.mjs   → exit=0
npm run verify:release              → exit=0
```

Audit baseline: 6 C7 entries re-keyed (+48 uniform shift; statements verified byte-identical against HEAD). H2 parity between the three READMEs unchanged (each +1).
