### PR TITLE
chore: release v4.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to MeMesh are documented here.
 
 ## [Unreleased]
 
+## [4.6.0] — 2026-08-16
+
 ### Added
 
 - **`memesh upgrade-plugin` — the CLI front door to the plugin upgrade script (P6).**
@@ -426,8 +428,6 @@ All notable changes to MeMesh are documented here.
   dashboard — every dashboard change was potentially a three-place edit, and
   the HTTP server never used it. `memesh serve` is the dashboard;
   `view-live.ts` remains as its no-build fallback.
-
-## [4.6.0] - 2026-08-15
 
 ### Changed
 


### PR DESCRIPTION
Folds [Unreleased] into one `## [4.6.0] — 2026-08-16` section (merging yesterday's never-published 4.6.0 half). All anchors already agree on 4.6.0; `verify:release` exit=0, isolated suite 138 files / 2086 tests exit=0 on this branch.