### PR TITLE
docs(agents): what an agent must never invent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,18 @@ host is recallable from all of them. Not installed yet? Follow
   `observation` parameter removes just that fact and keeps the entity active.
   Prefer it over archiving the whole entity.
 
+## What you must never invent
+
+- If MeMesh is unavailable or a recall returns nothing, **say so and work
+  without it** — never fabricate a memory, and never cite a `[mem:id]`
+  handle that was not actually shown to you. A wrong "remembered" fact is
+  worse than no memory: it arrives wearing the authority of the graph.
+- Recall windows are bounded (the `limit` parameter, 30 by default), so do
+  not infer graph-wide counts or "there is no memory about X" from the
+  number of hits one query returns. Absence of results is absence of
+  results, not evidence of absence — vary the wording or narrow by tag
+  before concluding anything.
+
 ## What Claude Code already does — do not double-write
 
 Under Claude Code with the MeMesh plugin, hooks capture automatically:

--- a/dist/skills-manifest.json
+++ b/dist/skills-manifest.json
@@ -113,8 +113,8 @@
     },
     {
       "path": "skills/memesh/SKILL.md",
-      "sha256": "ad76b477c74434f533cc786838fdd6645d734623475c917d5a24326b8c5c83e7",
-      "bytes": 9092
+      "sha256": "04dacfaeab1cb0af2ebe041a8825a44d2ffcae4e192a158217eabdc585721b2e",
+      "bytes": 9498
     }
   ]
 }

--- a/skills/memesh/SKILL.md
+++ b/skills/memesh/SKILL.md
@@ -56,6 +56,13 @@ clear it.
 Run `memesh briefing` (or `--project <name>`) and answer from it. For specific
 follow-up questions, use `recall`.
 
+**MEMESH UNAVAILABLE or RECALL EMPTY → say so, never invent.** Report that
+memory is unavailable (or found nothing) and continue without it. Never
+fabricate a memory or cite a `[mem:id]` that was not actually returned.
+Recall is bounded by `limit` — a small hit count is not a graph-wide count,
+and an empty result is not proof nothing was stored: vary the wording or
+narrow by tag before concluding.
+
 ## What's Already Automatic (Claude Code Plugin Hooks)
 
 If MeMesh is installed as a Claude Code plugin, these happen **without any action from you**:


### PR DESCRIPTION
Two negative instructions for agent-facing docs (AGENTS.md and the /memesh skill), prompted by studying ctx's agent skill — whose anti-hallucination clauses are the best-written part of that doc:

1. **Unavailable or empty ≠ license to improvise.** If MeMesh is unreachable or a recall returns nothing, say so and work without it — never fabricate a memory, and never cite a `[mem:id]` handle that was not actually returned. A wrong "remembered" fact is worse than no memory: it arrives wearing the authority of the graph.
2. **Bounded windows ≠ graph-wide counts.** Recall is capped by `limit`; a hit count is not a corpus count, and an empty result is not proof nothing was stored — vary the wording or narrow by tag before concluding.

One wording lesson the doc-claims gate taught while writing this: lowercase `memesh <word>` in agent docs is reserved for CLI-subcommand claims (the gate verifies each against registered commands), so product-name prose uses **MeMesh**.

## Verification

- `node scripts/run-tests-isolated.mjs` → exit 0, 142 files / 2126 tests.
- `npm run verify:release` → exit 0 (incl. the agent-docs subcommand gate and the AGENTS.md tool-table parity gate).