### PR TITLE
chore: release v4.6.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "memesh",
       "source": "./",
       "description": "MeMesh — agentic memory for coding agents. Captured from the agent's real work via hooks, recalled when it acts. One SQLite file, zero cloud required.",
-      "version": "4.6.0",
+      "version": "4.6.1",
       "author": {
         "name": "PCIRCLE AI"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -4,7 +4,7 @@
   "author": {
     "name": "PCIRCLE AI"
   },
-  "version": "4.6.0",
+  "version": "4.6.1",
   "homepage": "https://github.com/PCIRCLE-AI/memesh",
   "repository": "https://github.com/PCIRCLE-AI/memesh",
   "license": "MIT",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to MeMesh are documented here.
 
 ## [Unreleased]
 
+## [4.6.1] — 2026-08-23
+
 ### Added
 
 - **A reindex no longer deletes anything until the new index is complete.**
@@ -58,7 +60,7 @@ All notable changes to MeMesh are documented here.
   error — the tab shows the full graph and says that it did, instead of
   presenting an almost-empty canvas as the answer.
 
-- **`memesh kg backfill` draws the evidence→work edges (Rule 5, on by
+- **`memesh kg backfill-relations` draws the evidence→work edges (Rule 5, on by
   default).** Commits and session captures get an `evidences` edge to the
   work item they support, matched on an exact session id — the
   `session:*` tag, or `metadata.session_id` for commit entities, which
@@ -320,8 +322,6 @@ All notable changes to MeMesh are documented here.
   corrupt shadow table must not arrive as an empty result. The staging index's
   start time also survives a resume now, instead of being overwritten on every
   attempt.
-
-### Changed
 
 - **Dashboard design system: VIVARIUM supersedes Precision Engineer.** The
   dashboard's visual language is rebuilt around one idea — a second brain

--- a/dist/skills-manifest.json
+++ b/dist/skills-manifest.json
@@ -3,7 +3,7 @@
   "entries": [
     {
       "path": ".claude-plugin/plugin.json",
-      "sha256": "485b5f993aec41ab055f7f2d7ad4a8fb115a9d165dc39fac04cdd7d5e9214837",
+      "sha256": "cf1dd5c9c9d731320712d70a3a117bf0ea57062094daf6b2c17ea12d3361d393",
       "bytes": 524
     },
     {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # MeMesh Plugin Architecture
 
-**Version**: 4.6.0
+**Version**: 4.6.1
 
 > Looking for "which file do I change for X?" — see [CODEMAP.md](../CODEMAP.md).
 

--- a/docs/api/API_REFERENCE.md
+++ b/docs/api/API_REFERENCE.md
@@ -1,7 +1,7 @@
 # MeMesh Plugin -- API Reference
 
 **Protocol**: Model Context Protocol (MCP) over stdio
-**Version**: 4.6.0
+**Version**: 4.6.1
 **Compatibility**: Works with Claude Code plugins, Claude Managed Agents (via MCP connector), and any MCP-compatible client.
 
 **Native Integrations**: Beyond MCP, MeMesh integrates as a native memory provider for Hermes Agent (Python `MemoryProvider` plugin) and OpenClaw (TypeScript memory-capability plugin) — same tier as their built-in backends, not HTTP bridges. See [docs/platforms/](../platforms/) for platform-specific guides.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pcircle/memesh",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pcircle/memesh",
-      "version": "4.6.0",
+      "version": "4.6.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcircle/memesh",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "description": "MeMesh — agentic memory for coding agents. Captured from the agent's real work via hooks, recalled when it acts. One SQLite file, zero cloud required.",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
chore: release v4.6.1

Seven version anchors move together, in one commit, minutes before the tag —
so main never sits declaring a version npm does not have (v4.2.11 did that
for five days). package-lock.json carries the version twice and both are
edited by hand; `npm install --package-lock-only` can also move dependency
resolutions and is not used.

CHANGELOG: `[Unreleased]` becomes `[4.6.1] — 2026-08-23`, with two corrections
made while promoting it. A second `### Changed` heading was a merge leftover
and its bullets now sit under the first. One bullet named `memesh kg backfill`,
a command that does not exist — the command is `kg backfill-relations`;
check-doc-claims scans the agent docs for subcommand names but not the
CHANGELOG, which is how that slipped. A fresh, empty `[Unreleased]` heads the
file for what comes next.

`npm run build` regenerates dist/skills-manifest.json against the new version;
without it `memesh doctor` reports the manifest as tampered.

Verification, this session, throwaway HOME:

  node scripts/check-version-coherence.mjs   exit=0   All version sources agree
  node scripts/run-tests-isolated.mjs        exit=0   154 files / 2254 tests, no "Errors" line
  npm run typecheck                          exit=0
  npm run verify:release                     exit=0 after this commit (the stale-dist check
                                             is the only thing it flagged before it)

main-declares-published-version is skipped on a release branch by design and
runs on main after merge — that is the moment it must be green, not now.
