### PR TITLE
feat(release): finish a release in one command, not three

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to MeMesh are documented here.
 
 ## [Unreleased]
 
+### Added
+
+- **`npm run release:finish` — the release is one command now.** Merging a
+  release PR leaves `main` declaring a version nobody can install, and the gate
+  that catches it (`scripts/lib/published-version.mjs`) could only shout about
+  the window, never shorten it: the remedy it named was prose in an error
+  string, and the three commands that prose described were typed by hand.
+  v4.2.11 spent five days between the first and the last. `release:finish`
+  refuses unless it is on `main`, the tree is clean, `HEAD` matches
+  `origin/main`, the tag is free both locally and on `origin`, `gh` is
+  authenticated, and `CHANGELOG.md` has a section to publish — and otherwise
+  creates the tag and the GitHub Release in a single `gh release create` call.
+  One call, because the hand-typed sequence had a worse failure mode than the
+  one being fixed: a pushed tag with no release publishes nothing, while the
+  coherence gate now sees the tag and reports ok.
+
+
 ## [4.6.1] — 2026-08-23
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,8 +62,9 @@ rather than the first item.
 
 Pick the release body deliberately. With no `--notes-file` it publishes the
 whole `## [X.Y.Z]` CHANGELOG section — complete, and long: 4.6.1's was 26,355
-characters. The bodies actually published for 4.6.0 and 4.6.1 were about 3.5KB
-of curated highlights written by hand and passed with `--notes-file <path>`.
+characters. The bodies actually published for 4.6.1 and 4.6.0 were 2,790 and
+1,949 characters of curated highlights, written by hand and passed with
+`--notes-file <path>`.
 Either is a reasonable release; the command prints the first lines of whichever
 it resolved before it acts, and after the call it is too late to look.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,57 @@ Documentation is part of the change, not follow-up work. The CI's `Version coher
 - If your change affects the published artifact, mention that `npm run test:packaged` passed.
 - If your change touches `scripts/hooks/*.js` or any hook payload consumer, follow the hook-change protocol: real-payload fixture (capture from a live Claude Code transcript), default-allow on optional fields, stderr-trace every silent exit, end-to-end install test in a real Claude Code session, `memesh doctor` hook-activity green post-install.
 
+## Cutting a Release
+
+A release is one operation, not three commands:
+
+```bash
+git checkout main && git pull        # the release PR is already merged
+npm run release:finish -- --dry-run  # what it would do, or every reason it refuses
+npm run release:finish
+```
+
+`npm run release:finish` (`scripts/finish-release.mjs`) creates the tag and the
+GitHub Release in a single `gh release create` call, and that release — not a
+bare tag push — is what triggers `.github/workflows/publish-npm.yml`. It refuses
+unless it is on `main`, the tree is clean, local `HEAD` matches `origin/main`,
+`vX.Y.Z` is not already taken locally or on `origin`, `gh` is authenticated, and
+`CHANGELOG.md` has a `## [X.Y.Z]` section to publish as the release body. Every
+reason it refuses is printed at once, so a `--dry-run` tells you the whole list
+rather than the first item.
+
+Pick the release body deliberately. With no `--notes-file` it publishes the
+whole `## [X.Y.Z]` CHANGELOG section — complete, and long: 4.6.1's was 26,355
+characters. The bodies actually published for 4.6.0 and 4.6.1 were about 3.5KB
+of curated highlights written by hand and passed with `--notes-file <path>`.
+Either is a reasonable release; the command prints the first lines of whichever
+it resolved before it acts, and after the call it is too late to look.
+
+The tag it creates is lightweight rather than annotated. Nothing in this
+repository reads the difference — there is no `git describe` anywhere, and
+`git tag --list`, `git ls-remote --tags` and CI's `fetch-tags: true` treat both
+alike. No ruleset needs pausing either: `Protect release and benchmark tags`
+covers `refs/tags/v*` with `deletion` and `non_fast_forward` rules only, so tag
+*creation* is not what it blocks.
+
+Why it is one call rather than `git tag` + `git push` + `gh release create`: the
+middle of that sequence leaves a pushed tag with no release. Nothing publishes,
+because `publish-npm.yml` fires on `release: published` — and the version
+coherence gate now sees the tag and reports ok, so `main` would look released
+while npm did not have it, with nothing left looking.
+
+Between merging the release PR and creating the release, `main` declares a
+version nobody can install, and `npm run verify:release` on `main` FAILS by
+design with "main declares X.Y.Z and no vX.Y.Z tag exists". That failure is
+`scripts/lib/published-version.mjs` working, not a bug to investigate — v4.2.11
+sat in that state for five days. Finish the release; do not go looking into the
+red.
+
+Then watch the workflow run it prints. npm's registry lags a green publish by
+minutes: `npm view` still answering with the previous version is the registry
+catching up, not a failed publish, and a following `npm install` failing with
+`ETARGET` is npm's local metadata cache, which `--prefer-online` gets past.
+
 ## Security
 
 Do not open public issues for vulnerabilities. Use the private reporting process in [SECURITY.md](SECURITY.md).

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test:packaged": "node scripts/smoke-packed-artifact.mjs",
     "audit:prod": "node scripts/check-consumer-audit.mjs",
     "verify:release": "npm run lint && npm run typecheck && node scripts/check-version-coherence.mjs && node scripts/check-generated-mirror.mjs && node scripts/check-doc-claims.mjs && node scripts/audit/verification-audit.mjs && npm run audit:prod",
+    "release:finish": "node scripts/finish-release.mjs",
     "prepublishOnly": "npm run build && npm run verify:release && npm run test:isolated && npm run test:packaged",
     "typecheck": "tsc -p tsconfig.check.json && tsc -p tsconfig.check-dashboard.json",
     "lint": "eslint src/ scripts/ tests/ dashboard/src/ --max-warnings 0",

--- a/scripts/audit/baseline.json
+++ b/scripts/audit/baseline.json
@@ -623,7 +623,7 @@
     },
     "C6 tests/release-preconditions.test.ts": {
       "class": "WIRING-PIN",
-      "reason": "The decision itself is behavioural: checkReleasePreconditions is a pure function and 20 tests in the same file drive both directions through it. What is read as text is scripts/finish-release.mjs, and only to pin four wiring properties whose happy path cannot be run — cutting the release creates a public GitHub Release and publishes to npm. The regression guarded is someone splitting the single `gh release create --target` back into `git tag` + `git push` + `gh release create`, whose middle leaves a pushed tag with no release: nothing publishes, and the coherence gate now sees the tag and reports ok. Break-tested 2026-08-23: 5/5 mutants killed, including both directions of this pin.",
+      "reason": "The decision itself is behavioural: checkReleasePreconditions is a pure function and 21 tests in the same file drive both directions through it. What is read as text is scripts/finish-release.mjs, and only to pin five wiring properties whose happy path cannot be run — cutting the release creates a public GitHub Release and publishes to npm. The regression guarded is someone splitting the single `gh release create --target` back into `git tag` + `git push` + `gh release create`, whose middle leaves a pushed tag with no release: nothing publishes, and the coherence gate now sees the tag and reports ok. Break-tested 2026-08-23: 7/7 mutants killed, including both directions of this pin.",
       "triaged": "2026-08-23"
     }
   }

--- a/scripts/audit/baseline.json
+++ b/scripts/audit/baseline.json
@@ -620,6 +620,11 @@
       "class": "SAFE-DATA-EXTRACTION",
       "reason": "One test reads src/db.ts and asserts that markReindexOwed() is NOT inside the once-only notice brace. That is a structural pin chosen ON PURPOSE: the behavioural scenario (a fresh open while the notice flag is already set) is unreachable in one process — openDatabase returns the existing singleton, and the only reopen path (closeDatabase) resets the flag. Two behavioural tests were written first and both passed for the wrong reason; the review's brace-move mutant survived them. The text IS the property here.",
       "triaged": "2026-08-23"
+    },
+    "C6 tests/release-preconditions.test.ts": {
+      "class": "WIRING-PIN",
+      "reason": "The decision itself is behavioural: checkReleasePreconditions is a pure function and 20 tests in the same file drive both directions through it. What is read as text is scripts/finish-release.mjs, and only to pin four wiring properties whose happy path cannot be run — cutting the release creates a public GitHub Release and publishes to npm. The regression guarded is someone splitting the single `gh release create --target` back into `git tag` + `git push` + `gh release create`, whose middle leaves a pushed tag with no release: nothing publishes, and the coherence gate now sees the tag and reports ok. Break-tested 2026-08-23: 5/5 mutants killed, including both directions of this pin.",
+      "triaged": "2026-08-23"
     }
   }
 }

--- a/scripts/finish-release.mjs
+++ b/scripts/finish-release.mjs
@@ -1,0 +1,232 @@
+#!/usr/bin/env node
+
+// Finish a release in one operation: tag, GitHub Release, npm publish.
+//
+//   node scripts/finish-release.mjs --dry-run    # what it would do, and why it would refuse
+//   npm run release:finish
+//
+// WHY THIS IS ONE COMMAND
+//
+// Merging the release PR bumps `main` to a version nobody can install yet.
+// `scripts/lib/published-version.mjs` makes that state loud — `verify:release`
+// on main FAILS with "main declares X and no vX tag exists" — and that failure
+// is the guard working, not a bug to investigate. But the guard only shouts;
+// it cannot shorten the window. Closing it was three hand-typed commands, and
+// v4.2.11 spent five days between the first and the last.
+//
+// So the remedy stops being prose in an error message and becomes this. It
+// either refuses with every reason listed, or it finishes.
+//
+// ONE API CALL, NOT THREE COMMANDS
+//
+// `gh release create` creates the tag itself from `--target`. That matters
+// beyond convenience: `git tag` + `git push origin <tag>` + `gh release create`
+// has a failure mode that is WORSE than the one being fixed — a pushed tag
+// with no release publishes nothing (publish-npm.yml fires on
+// `release: published`; a bare tag push does not trigger it), while
+// `verify:release` now sees the tag and reports ok. Main would look released
+// and npm would not have it, with no gate left looking. One call cannot land
+// half way: either the release and its tag both exist, or neither does.
+//
+// The tag it creates is LIGHTWEIGHT, where `git tag -a` produced an annotated
+// one for some past releases (the repo has both: v4.5.0 and v4.6.1 annotated,
+// v4.5.1 and v4.6.0 not). Nothing here reads the difference — no `git describe`
+// exists in this repository, and `git tag --list`, `git ls-remote --tags` and
+// `fetch-tags: true` treat both alike. The repository's tag ruleset does not
+// object either: "Protect release and benchmark tags" covers `refs/tags/v*`
+// with `deletion` and `non_fast_forward` rules only, so creating a new tag is
+// not what it blocks.
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import {
+  checkReleasePreconditions,
+  extractChangelogSection,
+} from './lib/release-preconditions.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+const args = process.argv.slice(2);
+let dryRun = false;
+let notesFile = null;
+for (let i = 0; i < args.length; i++) {
+  const a = args[i];
+  if (a === '--dry-run') dryRun = true;
+  else if (a === '--notes-file') {
+    notesFile = args[++i];
+    if (!notesFile) {
+      console.error('--notes-file needs a path');
+      process.exit(1);
+    }
+  }
+  else if (a === '-h' || a === '--help') {
+    console.log('Usage: node scripts/finish-release.mjs [--dry-run] [--notes-file <path>]');
+    process.exit(0);
+  } else {
+    console.error(`unknown flag: ${a}`);
+    process.exit(1);
+  }
+}
+
+/** Run a command and return trimmed stdout, or null if it failed for any reason. */
+function capture(cmd, cmdArgs) {
+  try {
+    return execFileSync(cmd, cmdArgs, { cwd: repoRoot, encoding: 'utf8' }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function captureLines(cmd, cmdArgs) {
+  const out = capture(cmd, cmdArgs);
+  if (out === null) return null;
+  return out.split('\n').map(s => s.trim()).filter(Boolean);
+}
+
+const pkgVersion = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8')).version;
+const tag = `v${pkgVersion}`;
+
+// --- gather, read-only ------------------------------------------------------
+//
+// Remote state comes from `git ls-remote`, not from a `git fetch`: nothing
+// should mutate this checkout before the preconditions have passed.
+
+const branch = capture('git', ['rev-parse', '--abbrev-ref', 'HEAD']);
+const statusOut = capture('git', ['status', '--porcelain']);
+const isClean = statusOut === null ? null : statusOut === '';
+const headSha = capture('git', ['rev-parse', 'HEAD']);
+
+const remoteMainLine = capture('git', ['ls-remote', 'origin', 'refs/heads/main']);
+const remoteHeadSha = remoteMainLine ? remoteMainLine.split(/\s+/)[0] : null;
+
+const localTags = captureLines('git', ['tag', '--list', 'v*']);
+const remoteTagLines = captureLines('git', ['ls-remote', '--tags', 'origin']);
+const remoteTags =
+  remoteTagLines === null
+    ? null
+    : remoteTagLines
+        .map(l => l.split(/\s+/)[1] ?? '')
+        // `refs/tags/v4.6.1^{}` is the annotated tag's dereferenced commit —
+        // the same tag listed twice. Strip the suffix; the duplicate is
+        // harmless to both questions asked of this list (is it empty, does it
+        // contain the tag), so it is not worth deduplicating.
+        .map(r => r.replace(/^refs\/tags\//, '').replace(/\^\{\}$/, ''))
+        .filter(r => r.startsWith('v'));
+
+// Naming the repo proves `gh` exists, is authenticated, and can reach it —
+// the three things that must be true before anything is created.
+const repoSlug = capture('gh', ['repo', 'view', '--json', 'nameWithOwner', '-q', '.nameWithOwner']);
+
+let notes = null;
+if (notesFile) {
+  try {
+    notes = fs.readFileSync(path.resolve(repoRoot, notesFile), 'utf8');
+  } catch (e) {
+    console.error(`✗ --notes-file ${notesFile}: ${e.message}`);
+    process.exit(1);
+  }
+} else {
+  const changelog = fs.readFileSync(path.join(repoRoot, 'CHANGELOG.md'), 'utf8');
+  notes = extractChangelogSection(changelog, pkgVersion);
+}
+
+// --- decide -----------------------------------------------------------------
+
+const { ok, blockers } = checkReleasePreconditions({
+  branch,
+  isClean,
+  headSha,
+  remoteHeadSha,
+  pkgVersion,
+  localTags,
+  remoteTags,
+  repoSlug,
+  notes,
+});
+
+console.log(`finish-release: ${tag}`);
+console.log(`  repo:        ${repoSlug ?? '(gh could not say)'}`);
+console.log(`  branch:      ${branch ?? '(undiscoverable)'}`);
+console.log(`  commit:      ${headSha ? headSha.slice(0, 8) : '(unknown)'}`);
+console.log(`  notes:       ${notesFile ?? `CHANGELOG.md [${pkgVersion}]`} (${notes ? notes.length : 0} chars)`);
+
+// Print the head of the body BEFORE acting, in both paths. The default source
+// is the CHANGELOG section, which for 4.6.1 was 26KB — while the release bodies
+// actually published for 4.6.0 and 4.6.1 were ~3.5KB of curated highlights
+// passed with `--notes-file`. Both are legitimate; which one is about to become
+// public should not be a surprise, and after the call it is too late to look.
+if (notes) {
+  const head = notes.trim().split('\n').slice(0, 6);
+  for (const line of head) console.log(`    │ ${line.slice(0, 100)}`);
+  if (notes.trim().split('\n').length > 6) console.log('    │ …');
+}
+
+if (!ok) {
+  console.error(`\n✗ refusing to cut ${tag}:`);
+  for (const b of blockers) console.error(`  - ${b}`);
+  process.exit(1);
+}
+
+if (dryRun) {
+  console.log(`\n✓ preconditions pass. Would run:`);
+  console.log(`    gh release create ${tag} --target ${headSha} --title ${tag} --notes-file <changelog section>`);
+  console.log(`  …which creates the tag, publishes the release, and triggers publish-npm.yml.`);
+  process.exit(0);
+}
+
+// --- act --------------------------------------------------------------------
+
+const notesDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memesh-release-'));
+const notesPath = path.join(notesDir, 'notes.md');
+fs.writeFileSync(notesPath, notes, 'utf8');
+
+let releaseUrl;
+try {
+  releaseUrl = execFileSync(
+    'gh',
+    ['release', 'create', tag, '--target', headSha, '--title', tag, '--notes-file', notesPath],
+    { cwd: repoRoot, encoding: 'utf8' }
+  ).trim();
+} catch (e) {
+  console.error(`\n✗ gh release create failed — nothing was tagged, nothing was published.`);
+  console.error(String(e.stderr || e.message).trim());
+  process.exit(1);
+} finally {
+  fs.rmSync(notesDir, { recursive: true, force: true });
+}
+
+console.log(`\n✓ released: ${releaseUrl}`);
+
+// Bring the tag into this checkout so `verify:release` here stops failing —
+// the check reads `git tag --list`, and until the tag is fetched, main still
+// looks like it declares an untagged version.
+if (capture('git', ['fetch', '--tags', 'origin']) === null) {
+  console.log('  (could not `git fetch --tags origin` — run it to sync this checkout)');
+}
+const nowTagged = (captureLines('git', ['tag', '--list', 'v*']) ?? []).includes(tag);
+console.log(`  local checkout has ${tag}: ${nowTagged ? 'yes' : 'no — run `git fetch --tags origin`'}`);
+
+// Where to look next. The publish is a workflow run, and npm's registry lags
+// that run by minutes: `npm view` answering with the OLD version right after a
+// green publish is the registry catching up, not a failed publish. A following
+// `npm install` failing with ETARGET is npm's LOCAL metadata cache —
+// `--prefer-online` gets past it. Both looked like a silent failure once.
+//
+// Filtered by `headBranch`, which for a `release` event is the tag name. A bare
+// `--limit 1` would print the PREVIOUS release's run for the seconds before
+// this one registers — a URL that resolves, looks right, and is about a
+// different release.
+const runUrl = capture('gh', [
+  'run', 'list', '--workflow', 'publish-npm.yml', '--limit', '10',
+  '--json', 'url,headBranch',
+  '-q', `[.[] | select(.headBranch == "${tag}")][0].url`,
+]);
+console.log(
+  runUrl
+    ? `\n  publish run:  ${runUrl}`
+    : `\n  publish run:  not listed yet — https://github.com/${repoSlug}/actions/workflows/publish-npm.yml`
+);
+console.log(`  then:         npm view @pcircle/memesh version --prefer-online`);

--- a/scripts/finish-release.mjs
+++ b/scripts/finish-release.mjs
@@ -191,8 +191,22 @@ try {
     { cwd: repoRoot, encoding: 'utf8' }
   ).trim();
 } catch (e) {
-  console.error(`\n✗ gh release create failed — nothing was tagged, nothing was published.`);
+  // "gh failed" is not evidence that nothing happened. The release is one
+  // `POST /repos/{owner}/{repo}/releases`, and gh can fail AFTER that POST
+  // succeeded — a read timeout on the response, a 502 on the way back. Then
+  // the tag, the release and the publish run all exist while this printed
+  // "nothing was tagged", the operator retries, and the retry refuses with
+  // "already exists". Two contradictory messages and no way to tell which
+  // lied. Ask GitHub what is actually there instead of asserting it.
+  console.error(`\n✗ gh release create failed:`);
   console.error(String(e.stderr || e.message).trim());
+  const created = capture('gh', ['release', 'view', tag, '--json', 'url', '-q', '.url']);
+  console.error(
+    created
+      ? `\n  BUT ${tag} EXISTS: ${created}\n  The call failed on the way back, not on the way in — the publish may ` +
+          `already be running. Check it before doing anything else; do not re-cut.`
+      : `\n  ${tag} does not exist — nothing was tagged, nothing was published. Safe to re-run.`
+  );
   process.exit(1);
 } finally {
   fs.rmSync(notesDir, { recursive: true, force: true });

--- a/scripts/finish-release.mjs
+++ b/scripts/finish-release.mjs
@@ -154,9 +154,10 @@ console.log(`  commit:      ${headSha ? headSha.slice(0, 8) : '(unknown)'}`);
 console.log(`  notes:       ${notesFile ?? `CHANGELOG.md [${pkgVersion}]`} (${notes ? notes.length : 0} chars)`);
 
 // Print the head of the body BEFORE acting, in both paths. The default source
-// is the CHANGELOG section, which for 4.6.1 was 26KB — while the release bodies
-// actually published for 4.6.0 and 4.6.1 were ~3.5KB of curated highlights
-// passed with `--notes-file`. Both are legitimate; which one is about to become
+// is the CHANGELOG section, which for 4.6.1 was 26,355 characters — while the
+// bodies actually published for 4.6.1 and 4.6.0 were 2,790 and 1,949 characters
+// of curated highlights, passed with `--notes-file`. Both are legitimate; which
+// one is about to become
 // public should not be a surprise, and after the call it is too late to look.
 if (notes) {
   const head = notes.trim().split('\n').slice(0, 6);

--- a/scripts/lib/published-version.mjs
+++ b/scripts/lib/published-version.mjs
@@ -13,6 +13,11 @@
 // declares an uninstallable version is minutes, and this check is what makes
 // those minutes loud instead of silent.
 //
+// Loud is not short, though: this check can only shout, and the remedy it
+// names used to be prose nobody had automated. `scripts/finish-release.mjs`
+// (`npm run release:finish`) is that remedy as one command, so the window is
+// the length of one API call rather than however long the next person takes.
+//
 // Kept as a pure function, separate from the script that runs it, so both
 // directions can be pinned by a test without a repository to mutate. A gate
 // nobody break-tested is the defect class this repository keeps finding.
@@ -57,8 +62,9 @@ export function checkMainDeclaresPublishedVersion({ branch, pkgVersion, tags }) 
     message:
       `main declares ${pkgVersion} and no \`v${pkgVersion}\` tag exists — ` +
       'that version is not installable by anyone. Either finish the release ' +
-      `(tag v${pkgVersion} and \`gh release create\`, which is what triggers ` +
-      'publish-npm.yml — a bare tag push does not), or revert the bump and put ' +
-      'the work back under `## [Unreleased]`.',
+      '(`npm run release:finish` — one call that creates the tag and the ' +
+      'GitHub Release together; the release is what triggers publish-npm.yml, ' +
+      'a bare tag push does not), or revert the bump and put the work back ' +
+      'under `## [Unreleased]`.',
   };
 }

--- a/scripts/lib/published-version.mjs
+++ b/scripts/lib/published-version.mjs
@@ -15,8 +15,10 @@
 //
 // Loud is not short, though: this check can only shout, and the remedy it
 // names used to be prose nobody had automated. `scripts/finish-release.mjs`
-// (`npm run release:finish`) is that remedy as one command, so the window is
-// the length of one API call rather than however long the next person takes.
+// (`npm run release:finish`) is that remedy as one command. It does not make
+// the window short by itself — the window still runs until somebody runs it —
+// but it removes the interruptible MIDDLE: there is no longer a half-finished
+// state to walk away from, only "not started" and "done".
 //
 // Kept as a pure function, separate from the script that runs it, so both
 // directions can be pinned by a test without a repository to mutate. A gate

--- a/scripts/lib/release-preconditions.mjs
+++ b/scripts/lib/release-preconditions.mjs
@@ -80,7 +80,12 @@ export function checkReleasePreconditions({
     );
   }
 
-  if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(String(pkgVersion))) {
+  // No prerelease suffix on purpose. Nothing here handles one: `gh release
+  // create` would mark `4.7.0-rc.1` as latest without `--prerelease`, and
+  // publish-npm.yml runs `npm publish` with no `--tag`, so it would take npm's
+  // `latest` dist-tag too. This project has never shipped a prerelease; when
+  // it does, that is its own change, not a regex that quietly permits it.
+  if (!/^\d+\.\d+\.\d+$/.test(String(pkgVersion))) {
     blockers.push(`package.json version \`${pkgVersion}\` is not a version this can tag`);
   }
 

--- a/scripts/lib/release-preconditions.mjs
+++ b/scripts/lib/release-preconditions.mjs
@@ -1,0 +1,156 @@
+// What must be true before a release is cut — as a pure function, and the
+// release notes extractor that goes with it.
+//
+// `scripts/lib/published-version.mjs` catches the state this file exists to
+// prevent: `main` declaring a version that no tag, and therefore no npm
+// release, backs. Its error message names the way out in prose — "tag
+// vX.Y.Z and `gh release create`" — and prose in an error string is a
+// suggestion, not a gate. Nothing performed those steps, so the release was
+// three hand-typed commands whose middle could be interrupted by a crash, a
+// context switch, or an assistant deciding the session was over. v4.2.11 sat
+// in that middle for five days.
+//
+// The window cannot be closed by documenting it better. It is closed by
+// making the whole release one command that either refuses or completes:
+// `npm run release:finish`.
+//
+// Kept as a pure function, separate from the script that runs it, for the
+// same reason `published-version.mjs` is: the happy path cannot be exercised
+// locally without cutting a real release, so the only way both directions get
+// pinned is to hand the decision its inputs.
+
+/**
+ * Every input is tri-state on purpose: `null` means "could not read it", and
+ * every `null` blocks. Absence is not evidence — a shallow clone reporting no
+ * tags must not read as "the tag is free".
+ *
+ * @param {object} input
+ * @param {string|null}   input.branch        Current branch, or null if undiscoverable.
+ * @param {boolean|null}  input.isClean       Working tree clean? null if `git status` failed.
+ * @param {string|null}   input.headSha       Local HEAD sha.
+ * @param {string|null}   input.remoteHeadSha `origin/main` sha, freshly fetched.
+ * @param {string}        input.pkgVersion    `package.json` version.
+ * @param {string[]|null} input.localTags     Every `v*` tag in the checkout.
+ * @param {string[]|null} input.remoteTags    Every `v*` tag on `origin`.
+ * @param {string|null}   input.repoSlug      `owner/name` as `gh` reports it — proof gh is authenticated.
+ * @param {string|null}   input.notes         Release body, already resolved.
+ * @returns {{ok: boolean, blockers: string[]}}
+ */
+export function checkReleasePreconditions({
+  branch,
+  isClean,
+  headSha,
+  remoteHeadSha,
+  pkgVersion,
+  localTags,
+  remoteTags,
+  repoSlug,
+  notes,
+}) {
+  const blockers = [];
+  const tag = `v${pkgVersion}`;
+
+  if (branch !== 'main') {
+    blockers.push(
+      `not on main (branch: ${branch ?? 'undiscoverable'}) — a release is cut from ` +
+        'main after the release PR is merged, never from the branch that raised it'
+    );
+  }
+
+  if (isClean !== true) {
+    blockers.push(
+      isClean === null
+        ? 'could not read `git status` — refusing to release from a tree whose state is unknown'
+        : 'the working tree has uncommitted changes — the release would advertise a commit that is not what you are looking at'
+    );
+  }
+
+  // A tag pushed to origin drags its commit along. Releasing from a local HEAD
+  // that origin has not seen would put unreviewed commits on `main` through
+  // the tag, bypassing the PR the branch protection exists to require.
+  if (headSha === null || remoteHeadSha === null) {
+    blockers.push(
+      'could not compare local HEAD with `origin/main` — refusing rather than ' +
+        'guessing (`git fetch origin main` first)'
+    );
+  } else if (headSha !== remoteHeadSha) {
+    blockers.push(
+      `local HEAD (${headSha.slice(0, 8)}) is not \`origin/main\` (${remoteHeadSha.slice(0, 8)}) — ` +
+        'push or pull first; a release cut here would carry commits main has never reviewed'
+    );
+  }
+
+  if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(String(pkgVersion))) {
+    blockers.push(`package.json version \`${pkgVersion}\` is not a version this can tag`);
+  }
+
+  // Absence is not evidence, twice over. An empty tag list is what a shallow
+  // clone reports, and reading it as "the tag is not taken" would let this
+  // re-cut a release that already shipped.
+  for (const [label, tags] of [
+    ['the checkout', localTags],
+    ['origin', remoteTags],
+  ]) {
+    if (!Array.isArray(tags) || tags.length === 0) {
+      blockers.push(
+        `no \`v*\` tag is visible in ${label}, so "is ${tag} already taken" could not be ` +
+          'answered. Reporting "not checked" rather than assuming it is free'
+      );
+    } else if (tags.includes(tag)) {
+      blockers.push(
+        `${tag} already exists in ${label} — this release was already cut. If the npm ` +
+          'publish is what is missing, re-run the `Publish to npm` workflow instead of re-tagging'
+      );
+    }
+  }
+
+  // gh does the tagging AND the release in one call, so it has to be working
+  // before anything is created. Discovering a broken `gh` afterwards is
+  // precisely the half-done state this command exists to make impossible.
+  if (!repoSlug) {
+    blockers.push(
+      '`gh` could not name this repository — it is missing, unauthenticated, or ' +
+        'offline. Run `gh auth status`; releasing needs it, and finding that out ' +
+        'after the tag exists is the half-finished release this command replaces'
+    );
+  }
+
+  if (!notes || !notes.trim()) {
+    blockers.push(
+      `no release notes for ${tag} — add a \`## [${pkgVersion}]\` section to CHANGELOG.md, ` +
+        'or pass `--notes-file <path>`'
+    );
+  }
+
+  return { ok: blockers.length === 0, blockers };
+}
+
+/**
+ * The body of `## [X.Y.Z]` in a CHANGELOG, up to the next `## ` heading.
+ *
+ * Returns null when the section is absent OR present but empty — an empty
+ * section is the shape a release gets when the header was renamed from
+ * `[Unreleased]` and the entries were never written, and publishing an empty
+ * release body is not better than refusing.
+ *
+ * @param {string} changelog
+ * @param {string} version
+ * @returns {string|null}
+ */
+export function extractChangelogSection(changelog, version) {
+  if (typeof changelog !== 'string') return null;
+  const escaped = String(version).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  // Same header shape `check-version-coherence.mjs` accepts: `## [4.6.1] — 2026-08-23`.
+  //
+  // `[^\n]*`, not `[\s—-]*.*`: `\s` matches a newline inside a character
+  // class even under `/m`, so the greedy first attempt walked past the blank
+  // line and swallowed the NEXT version's header — asked for `[Unreleased]`,
+  // it returned 4.7.0's entries. The header has to end at the end of its line.
+  const header = new RegExp(`^## \\[${escaped}\\][^\\n]*$`, 'm');
+  const start = changelog.match(header);
+  if (!start) return null;
+  const after = changelog.slice(start.index + start[0].length);
+  const next = after.search(/^## /m);
+  const body = (next === -1 ? after : after.slice(0, next)).trim();
+  return body.length > 0 ? body : null;
+}

--- a/tests/release-preconditions.test.ts
+++ b/tests/release-preconditions.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Pins the command that closes the window `published-version.mjs` shouts about.
+ *
+ * Between merging a release PR and cutting the tag, `main` declares a version
+ * nobody can install. `checkMainDeclaresPublishedVersion` makes that state
+ * loud; it cannot make it short. `scripts/finish-release.mjs` makes it short,
+ * and the only way to pin its happy path without cutting a real release is to
+ * hand the decision its inputs — the same split, and the same reason, as
+ * `tests/main-declares-published-version.test.ts`.
+ *
+ * Every refusal is asserted individually, because a precondition set that can
+ * only pass is the defect this repository keeps finding. The unknown-input
+ * cases matter most: `null` means "could not read it", and reading that as
+ * "nothing was wrong" is how a shallow clone would talk this into re-cutting a
+ * release that already shipped.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import {
+  checkReleasePreconditions,
+  extractChangelogSection,
+} from '../scripts/lib/release-preconditions.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+/** A state where cutting 4.7.0 is exactly the right thing to do. */
+function ready(overrides: Record<string, unknown> = {}) {
+  return {
+    branch: 'main',
+    isClean: true,
+    headSha: 'a'.repeat(40),
+    remoteHeadSha: 'a'.repeat(40),
+    pkgVersion: '4.7.0',
+    localTags: ['v4.6.0', 'v4.6.1'],
+    remoteTags: ['v4.6.0', 'v4.6.1'],
+    repoSlug: 'PCIRCLE-AI/memesh',
+    notes: '### Added\n\n- something',
+    ...overrides,
+  };
+}
+
+describe('release preconditions', () => {
+  it('passes when the release is genuinely ready to cut', () => {
+    const r = checkReleasePreconditions(ready());
+    expect(r.blockers).toEqual([]);
+    expect(r.ok).toBe(true);
+  });
+
+  it('refuses off main', () => {
+    const r = checkReleasePreconditions(ready({ branch: 'chore/release-4.7.0' }));
+    expect(r.ok).toBe(false);
+    expect(r.blockers.join('\n')).toContain('not on main');
+  });
+
+  it('refuses when the branch cannot be discovered', () => {
+    expect(checkReleasePreconditions(ready({ branch: null })).ok).toBe(false);
+  });
+
+  it('refuses on a dirty tree', () => {
+    const r = checkReleasePreconditions(ready({ isClean: false }));
+    expect(r.blockers.join('\n')).toContain('uncommitted changes');
+  });
+
+  it('refuses when `git status` could not be read at all', () => {
+    const r = checkReleasePreconditions(ready({ isClean: null }));
+    expect(r.blockers.join('\n')).toContain('could not read');
+  });
+
+  it('refuses when local HEAD is not origin/main', () => {
+    const r = checkReleasePreconditions(ready({ remoteHeadSha: 'b'.repeat(40) }));
+    // A tag drags its commit to origin, so this is how unreviewed commits would
+    // reach main without a PR.
+    expect(r.blockers.join('\n')).toContain('origin/main');
+  });
+
+  it.each([
+    ['local HEAD unreadable', { headSha: null }],
+    ['origin/main unreadable', { remoteHeadSha: null }],
+  ])('refuses when %s', (_label, override) => {
+    expect(checkReleasePreconditions(ready(override)).ok).toBe(false);
+  });
+
+  it('refuses a version it cannot turn into a tag', () => {
+    const r = checkReleasePreconditions(ready({ pkgVersion: '4.7' }));
+    expect(r.ok).toBe(false);
+  });
+
+  it.each([
+    ['the checkout', 'localTags'],
+    ['origin', 'remoteTags'],
+  ])('refuses when the tag already exists in %s', (where, key) => {
+    const r = checkReleasePreconditions(ready({ [key]: ['v4.6.1', 'v4.7.0'] }));
+    expect(r.ok).toBe(false);
+    expect(r.blockers.join('\n')).toContain(`v4.7.0 already exists in ${where}`);
+  });
+
+  it.each([
+    ['localTags', []],
+    ['localTags', null],
+    ['remoteTags', []],
+    ['remoteTags', null],
+  ])('refuses rather than passes when %s is %s', (key, value) => {
+    // A shallow clone reports no tags. "Found no clash among zero tags" must
+    // never read as "the tag is free".
+    const r = checkReleasePreconditions(ready({ [key]: value }));
+    expect(r.ok).toBe(false);
+    expect(r.blockers.join('\n')).toContain('could not be');
+  });
+
+  it('refuses before creating anything when gh cannot name the repo', () => {
+    // Discovering a broken `gh` after the tag exists is the half-finished
+    // release the command exists to make impossible.
+    const r = checkReleasePreconditions(ready({ repoSlug: null }));
+    expect(r.ok).toBe(false);
+    expect(r.blockers.join('\n')).toContain('gh auth status');
+  });
+
+  it.each([[null], [''], ['   \n  ']])('refuses with no release notes (%j)', notes => {
+    const r = checkReleasePreconditions(ready({ notes }));
+    expect(r.ok).toBe(false);
+    expect(r.blockers.join('\n')).toContain('CHANGELOG.md');
+  });
+
+  it('reports every reason at once, not just the first', () => {
+    const r = checkReleasePreconditions(ready({ branch: 'topic', isClean: false, notes: null }));
+    expect(r.blockers.length).toBeGreaterThanOrEqual(3);
+  });
+});
+
+describe('release notes come from the CHANGELOG section', () => {
+  const doc = [
+    '# Changelog',
+    '',
+    '## [Unreleased]',
+    '',
+    '## [4.7.0] — 2026-09-01',
+    '',
+    '### Added',
+    '',
+    '- a thing',
+    '',
+    '## [4.6.1] — 2026-08-23',
+    '',
+    '- an older thing',
+    '',
+  ].join('\n');
+
+  it('extracts the section body and stops at the next heading', () => {
+    const body = extractChangelogSection(doc, '4.7.0');
+    expect(body).toContain('- a thing');
+    expect(body).not.toContain('older thing');
+    expect(body).not.toContain('## [4.6.1]');
+  });
+
+  it('returns null when the version has no section', () => {
+    expect(extractChangelogSection(doc, '4.8.0')).toBeNull();
+  });
+
+  it('returns null for a header with an empty body', () => {
+    // The shape a release gets when `[Unreleased]` was renamed and the entries
+    // were never written. Publishing an empty release body is not better than
+    // refusing.
+    expect(extractChangelogSection(doc, 'Unreleased')).toBeNull();
+  });
+
+  it('reads the real CHANGELOG for the version this repo declares', () => {
+    const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8'));
+    const changelog = fs.readFileSync(path.join(repoRoot, 'CHANGELOG.md'), 'utf8');
+    expect(extractChangelogSection(changelog, pkg.version)).toBeTruthy();
+  });
+});
+
+describe('finish-release cuts the release in one call', () => {
+  // Structural, and deliberately so: the happy path creates a public GitHub
+  // release and publishes to npm, so it cannot be exercised by a test. The
+  // regression to guard is not "the output changed" — it is someone splitting
+  // this back into `git tag` + `git push origin <tag>` + `gh release create`,
+  // whose middle leaves a pushed tag with NO release: publish-npm.yml never
+  // fires, and `verify:release` now sees the tag and reports ok. Main would
+  // look released while npm did not have it, with no gate left looking.
+  const src = fs.readFileSync(path.join(repoRoot, 'scripts/finish-release.mjs'), 'utf8');
+  const code = src
+    .split('\n')
+    .filter(l => !l.trim().startsWith('//'))
+    .join('\n');
+
+  it('creates the tag through `gh release create --target`', () => {
+    expect(code).toMatch(/'release',\s*'create'/);
+    expect(code).toMatch(/'--target'/);
+  });
+
+  it('never pushes a tag by hand', () => {
+    expect(code).not.toMatch(/'push'/);
+    expect(code).not.toMatch(/'tag',\s*'-a'/);
+  });
+
+  it('refuses before it acts', () => {
+    // The precondition check has to come first in the file, not after the
+    // release call — an order this cheap to get wrong is worth pinning.
+    expect(code.indexOf('checkReleasePreconditions(')).toBeLessThan(code.indexOf("'release', 'create'"));
+  });
+
+  it('is wired to an npm script, so it is the documented way in', () => {
+    const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8'));
+    expect(pkg.scripts['release:finish']).toContain('scripts/finish-release.mjs');
+  });
+});

--- a/tests/release-preconditions.test.ts
+++ b/tests/release-preconditions.test.ts
@@ -87,6 +87,14 @@ describe('release preconditions', () => {
     expect(r.ok).toBe(false);
   });
 
+  it('refuses a prerelease version rather than mis-publishing it', () => {
+    // Deliberate, not an oversight in the regex: `gh release create` would
+    // mark 4.7.0-rc.1 as latest without `--prerelease`, and publish-npm.yml
+    // runs `npm publish` with no `--tag`, so it would take npm's `latest`
+    // dist-tag too. A prerelease flow is its own change.
+    expect(checkReleasePreconditions(ready({ pkgVersion: '4.7.0-rc.1' })).ok).toBe(false);
+  });
+
   it.each([
     ['the checkout', 'localTags'],
     ['origin', 'remoteTags'],
@@ -200,6 +208,13 @@ describe('finish-release cuts the release in one call', () => {
     // The precondition check has to come first in the file, not after the
     // release call — an order this cheap to get wrong is worth pinning.
     expect(code.indexOf('checkReleasePreconditions(')).toBeLessThan(code.indexOf("'release', 'create'"));
+  });
+
+  it('asks GitHub what exists before saying nothing was created', () => {
+    // A failure signal is not evidence that nothing happened: gh can fail
+    // AFTER the release POST succeeded, and "nothing was tagged" would then be
+    // a false sentence a human acts on. The failure path has to look.
+    expect(code).toMatch(/'release',\s*'view'/);
   });
 
   it('is wired to an npm script, so it is the documented way in', () => {


### PR DESCRIPTION
## What

`npm run release:finish` — the release becomes one command instead of three.

Merging a release PR leaves `main` declaring a version nobody can install.
`scripts/lib/published-version.mjs` already makes that state loud (`verify:release`
on main FAILS with "main declares X and no vX tag exists"), but a check can only
shout — it cannot shorten the window. The remedy it named lived as prose inside
an error string, and the steps that prose described were typed by hand. v4.2.11
spent five days between the first and the last.

## How

`scripts/finish-release.mjs` refuses unless **all** of these hold, printing every
reason at once:

- on `main`
- working tree clean
- local `HEAD` == `origin/main` (a tag drags its commit to origin — otherwise a
  release would carry commits `main` never reviewed)
- `vX.Y.Z` free both locally and on `origin`
- `gh` can name the repository (it exists, is authenticated, can reach GitHub)
- `CHANGELOG.md` has a `## [X.Y.Z]` section to publish, or `--notes-file <path>`

Otherwise it makes the release in a **single `gh release create --target <sha>`
call**, which creates the tag too.

One call rather than `git tag` + `git push origin <tag>` + `gh release create`,
because that sequence has a **worse** failure mode than the one being fixed: a
pushed tag with no release publishes nothing (`publish-npm.yml` fires on
`release: published`, not on a tag push) — while the coherence gate now sees the
tag and reports ok. `main` would look released while npm did not have it, with
nothing left looking.

## Verification

```
node scripts/run-tests-isolated.mjs   exit=0   155 files / 2284 tests passed, no "Errors" line
npm run verify:release                exit=0   (final tree, both commits)
```

Break-test, restore verified by sha256 (write the original string back, never
`git checkout`) — **7/7 KILLED**:

| mutation | result |
|---|---|
| drop `--target` from `gh release create` | KILLED |
| push the tag by hand | KILLED |
| stop checking gh auth | KILLED |
| treat an empty tag list as "tag is free" | KILLED |
| stop requiring `main` | KILLED |
| stop rejecting an untaggable version | KILLED |
| stop asking whether the release exists after a failed create | KILLED |

Three assumptions checked against the real artifacts rather than assumed:

- `gh run list --workflow publish-npm.yml --json headBranch` → the five past
  release runs report `headBranch` as the **tag name** (`v4.6.1`, `v4.6.0`, …),
  so the filter that picks out *this* release's run is correct. Without it a
  bare `--limit 1` would print the previous release's URL for the seconds
  before this one registers.
- `grep -rn "git describe"` → **no hits anywhere in the repository**, so the
  switch from an annotated tag to the lightweight one `gh` creates is inert.
  (The repo already has both kinds: v4.5.0/v4.6.1 annotated, v4.5.1/v4.6.0 not.)
- `gh api repos/PCIRCLE-AI/memesh/rulesets/16302364` → `Protect release and
  benchmark tags` covers `refs/tags/v*` with `deletion` and `non_fast_forward`
  rules **only**. Tag *creation* is not what it blocks, so nothing needs pausing.

## Second commit — three findings from reviewing the first

- **A failure signal is not evidence that nothing happened.** The catch around
  `gh release create` asserted "nothing was tagged, nothing was published" on
  any non-zero exit. gh can fail *after* the release POST succeeded (read
  timeout on the response, 502 on the way back) — the operator would be told
  nothing happened while the publish was already running, retry, and get
  "already exists". It now asks GitHub what is actually there and says that.
- **A comment claiming more than the command delivers.** `published-version.mjs`
  said the window becomes "the length of one API call". It does not — the window
  still runs until somebody runs the command. What the command removes is the
  interruptible *middle*: no half-finished state to walk away from, only "not
  started" and "done".
- **A prerelease suffix the regex permitted and nothing handled.** `4.7.0-rc.1`
  passed; `gh release create` would mark it latest without `--prerelease` and
  `npm publish` would take the `latest` dist-tag. Dropped, with a test pinning
  the refusal.

## Stated limitation

**The runner's success path has never executed.** Every `--dry-run` in this
session *refused* — correctly, because `v4.6.1` is already tagged. The
`ok === true` branch (gather → pass → `gh release create`) cannot be exercised
locally: its preconditions only coexist during a real release. That is why the
decision is a pure function with 21 tests driving both directions, and why the
five wiring properties of the runner are pinned structurally and triaged in
`scripts/audit/baseline.json` as `WIRING-PIN` with that reason. The first real
proof will be the next release.

Also new here and worth a reviewer's eye: the CHANGELOG section extractor
matches the header tail with a newline-excluding class rather than `[\s-]*.*`.
`\s` matches a newline inside a character class even under `/m`, so the greedy
first attempt walked past the blank line and returned the **next** version's
entries. Its own test caught it before it shipped.
