### PR TITLE
chore: release 4.6.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "memesh",
       "source": "./",
       "description": "MeMesh — agentic memory for coding agents. Captured from the agent's real work via hooks, recalled when it acts. One SQLite file, zero cloud required.",
-      "version": "4.6.1",
+      "version": "4.6.2",
       "author": {
         "name": "PCIRCLE AI"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -4,7 +4,7 @@
   "author": {
     "name": "PCIRCLE AI"
   },
-  "version": "4.6.1",
+  "version": "4.6.2",
   "homepage": "https://github.com/PCIRCLE-AI/memesh",
   "repository": "https://github.com/PCIRCLE-AI/memesh",
   "license": "MIT",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to MeMesh are documented here.
 
 ## [Unreleased]
 
+## [4.6.2] — 2026-08-23
+
 ### Added
 
 - **`npm run release:finish` — the release is one command now.** Merging a

--- a/dist/skills-manifest.json
+++ b/dist/skills-manifest.json
@@ -3,7 +3,7 @@
   "entries": [
     {
       "path": ".claude-plugin/plugin.json",
-      "sha256": "cf1dd5c9c9d731320712d70a3a117bf0ea57062094daf6b2c17ea12d3361d393",
+      "sha256": "c3476257c0f29f71e65215f06adb86f64cc5e7832e3b6c58859b4bd03bec1cd3",
       "bytes": 524
     },
     {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # MeMesh Plugin Architecture
 
-**Version**: 4.6.1
+**Version**: 4.6.2
 
 > Looking for "which file do I change for X?" — see [CODEMAP.md](../CODEMAP.md).
 

--- a/docs/api/API_REFERENCE.md
+++ b/docs/api/API_REFERENCE.md
@@ -1,7 +1,7 @@
 # MeMesh Plugin -- API Reference
 
 **Protocol**: Model Context Protocol (MCP) over stdio
-**Version**: 4.6.1
+**Version**: 4.6.2
 **Compatibility**: Works with Claude Code plugins, Claude Managed Agents (via MCP connector), and any MCP-compatible client.
 
 **Native Integrations**: Beyond MCP, MeMesh integrates as a native memory provider for Hermes Agent (Python `MemoryProvider` plugin) and OpenClaw (TypeScript memory-capability plugin) — same tier as their built-in backends, not HTTP bridges. See [docs/platforms/](../platforms/) for platform-specific guides.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pcircle/memesh",
-  "version": "4.6.1",
+  "version": "4.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pcircle/memesh",
-      "version": "4.6.1",
+      "version": "4.6.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pcircle/memesh",
-  "version": "4.6.1",
-  "description": "MeMesh — agentic memory for coding agents. Captured from the agent's real work via hooks, recalled when it acts. One SQLite file, zero cloud required.",
+  "version": "4.6.2",
+  "description": "MeMesh \u2014 agentic memory for coding agents. Captured from the agent's real work via hooks, recalled when it acts. One SQLite file, zero cloud required.",
   "main": "dist/index.js",
   "type": "module",
   "bin": {


### PR DESCRIPTION
`npm run release:finish` ships in this release, and this is the release that will use it for the first time.

**Contents**

- **Added** — `npm run release:finish`: tag + GitHub Release in one `gh release create` call, refusing unless main is clean, synced, untagged for this version, `gh` is authenticated and the CHANGELOG has a section. Closes the window where main declares a version nobody can install.
- **Fixed** — three gates that could report success without checking anything, and the two dead command names they found (one of them in the published 4.5.1 notes).

**Verification**

```
node scripts/run-tests-isolated.mjs      exit=0   157 files / 2308 tests, no "Errors" line
MEMESH_RELEASE=1 npm run verify:release  exit=0
node scripts/check-version-coherence.mjs exit=0   all 8 anchors agree on 4.6.2
```

`dist/skills-manifest.json` is in the diff on purpose — the mirror gate caught it missing, because plugin-marketplace installs run `dist/` as committed and never build.
