### PR TITLE
chore: release 4.7.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "memesh",
       "source": "./",
       "description": "MeMesh — agentic memory for coding agents. Captured from the agent's real work via hooks, recalled when it acts. One SQLite file, zero cloud required.",
-      "version": "4.6.2",
+      "version": "4.7.0",
       "author": {
         "name": "PCIRCLE AI"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -4,7 +4,7 @@
   "author": {
     "name": "PCIRCLE AI"
   },
-  "version": "4.6.2",
+  "version": "4.7.0",
   "homepage": "https://github.com/PCIRCLE-AI/memesh",
   "repository": "https://github.com/PCIRCLE-AI/memesh",
   "license": "MIT",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to MeMesh are documented here.
 
-## [Unreleased]
+## [4.7.0] — 2026-08-24
 
 ### Removed
 

--- a/dist/skills-manifest.json
+++ b/dist/skills-manifest.json
@@ -3,7 +3,7 @@
   "entries": [
     {
       "path": ".claude-plugin/plugin.json",
-      "sha256": "c3476257c0f29f71e65215f06adb86f64cc5e7832e3b6c58859b4bd03bec1cd3",
+      "sha256": "415d337a4df08d3a8ce9e3a28f0d342fca195fe1fd44b7b7db0fd8909164f0aa",
       "bytes": 524
     },
     {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # MeMesh Plugin Architecture
 
-**Version**: 4.6.2
+**Version**: 4.7.0
 
 > Looking for "which file do I change for X?" — see [CODEMAP.md](../CODEMAP.md).
 

--- a/docs/api/API_REFERENCE.md
+++ b/docs/api/API_REFERENCE.md
@@ -1,7 +1,7 @@
 # MeMesh Plugin -- API Reference
 
 **Protocol**: Model Context Protocol (MCP) over stdio
-**Version**: 4.6.2
+**Version**: 4.7.0
 **Compatibility**: Works with Claude Code plugins, Claude Managed Agents (via MCP connector), and any MCP-compatible client.
 
 **Native Integrations**: Beyond MCP, MeMesh integrates as a native memory provider for Hermes Agent (Python `MemoryProvider` plugin) and OpenClaw (TypeScript memory-capability plugin) — same tier as their built-in backends, not HTTP bridges. See [docs/platforms/](../platforms/) for platform-specific guides.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pcircle/memesh",
-  "version": "4.6.2",
+  "version": "4.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pcircle/memesh",
-      "version": "4.6.2",
+      "version": "4.7.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcircle/memesh",
-  "version": "4.6.2",
+  "version": "4.7.0",
   "description": "MeMesh \u2014 agentic memory for coding agents. Captured from the agent's real work via hooks, recalled when it acts. One SQLite file, zero cloud required.",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
Cuts **4.7.0** from `main`. Version bump and changelog only — no code changes.

`4.6.3` was never published, and nothing in the repository claims otherwise:
there is no `[4.6.3]` section and no `v4.6.3` tag. So 4.7.0 follows 4.6.2 with
no gap to explain.

### Why a minor, not a patch

Three user-visible contract changes ship here, each under its own changelog
heading:

- `user_patterns` no longer returns `toolPreferences` or
  `workflow.avgSessionMinutes` (both were permanently empty — parsed from a
  text format nothing has ever written).
- `DEFAULT_SIGNAL_THRESHOLD` is gone; it described a dashboard filter that does
  not exist.
- **`memesh import` no longer exits 1** for a relation whose target is not in
  the bundle. Those relations are still reported — by name, in a new
  `skipped_relations` field — but every bundle narrowed by `--tag`,
  `--namespace` or `--limit` has them, so counting them as errors made
  `memesh export > b.json && memesh import b.json` a failing command on a
  correct restore. Scripts that check the exit code are affected.

### The eight anchors

`package.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`,
both `package-lock.json` entries, `docs/ARCHITECTURE.md`,
`docs/api/API_REFERENCE.md`, and `[Unreleased]` → `[4.7.0]`.
`dist/skills-manifest.json` is the eighth: it carries a sha256 of
`plugin.json`, so a bump that does not rebuild leaves it pointing at the
previous file. `scripts/check-version-coherence.mjs` verifies all of them.

### Verification

```
node scripts/run-tests-isolated.mjs -> Test Files 185 passed (185) / Tests 2528 passed (2528), exit=0
npm run verify:release                -> exit=0 (all eight anchors agree at 4.7.0)
CI on e2a179c5 (the head this release contains) -> 13/13 pass
```

After merge, `npm run release:finish` from `main` creates the tag and the
GitHub Release in one API call, which is what triggers the npm publish.
Between the merge and that call, `verify:release` on `main` will FAIL with
"main declares 4.7.0 and no v4.7.0 tag exists" — that is the guard working.
