### PR TITLE
fix: the clock-dependent fixture that stopped the 4.7.0 publish, and release 4.7.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "memesh",
       "source": "./",
       "description": "MeMesh — agentic memory for coding agents. Captured from the agent's real work via hooks, recalled when it acts. One SQLite file, zero cloud required.",
-      "version": "4.7.0",
+      "version": "4.7.1",
       "author": {
         "name": "PCIRCLE AI"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -4,7 +4,7 @@
   "author": {
     "name": "PCIRCLE AI"
   },
-  "version": "4.7.0",
+  "version": "4.7.1",
   "homepage": "https://github.com/PCIRCLE-AI/memesh",
   "repository": "https://github.com/PCIRCLE-AI/memesh",
   "license": "MIT",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to MeMesh are documented here.
 
+## [4.7.1] — 2026-08-24
+
+### Fixed
+
+- **A test fixture whose verdict depended on the time of day.**
+  `tests/core/timestamp-format-comparisons.test.ts` built a "just past the
+  cutoff" timestamp as `cutoff - 1 hour` and then asserted it fell on the
+  cutoff's calendar day — which is false for any run between 00:00 and 01:00
+  UTC, because the cutoff carries the current time of day. It cost 4.7.0: the
+  local suite, the release gate and all thirteen CI legs ran green at other
+  hours, and the npm publish job — which started at 00:06 UTC — went red on
+  it. The stamp is clamped to midnight of the cutoff's own UTC day, which is
+  inside the window at every hour, and a second fixture guard in the same file
+  now compares at the second resolution the product actually works at instead
+  of a stricter millisecond one.
+
+  No shipped behaviour changes. **4.7.0 was tagged and released on GitHub but
+  never reached npm**, because this is the test that stopped the publish. Its
+  entire contents ship here, in 4.7.1 — the `[4.7.0]` section below is the
+  right place to read what changed.
+
 ## [4.7.0] — 2026-08-24
 
 ### Removed

--- a/dist/skills-manifest.json
+++ b/dist/skills-manifest.json
@@ -3,7 +3,7 @@
   "entries": [
     {
       "path": ".claude-plugin/plugin.json",
-      "sha256": "415d337a4df08d3a8ce9e3a28f0d342fca195fe1fd44b7b7db0fd8909164f0aa",
+      "sha256": "66dd902ddfe00d4aca6d87e3b7b6559e8e2b77b59dafdff4cb6140533b726c75",
       "bytes": 524
     },
     {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # MeMesh Plugin Architecture
 
-**Version**: 4.7.0
+**Version**: 4.7.1
 
 > Looking for "which file do I change for X?" — see [CODEMAP.md](../CODEMAP.md).
 

--- a/docs/api/API_REFERENCE.md
+++ b/docs/api/API_REFERENCE.md
@@ -1,7 +1,7 @@
 # MeMesh Plugin -- API Reference
 
 **Protocol**: Model Context Protocol (MCP) over stdio
-**Version**: 4.7.0
+**Version**: 4.7.1
 **Compatibility**: Works with Claude Code plugins, Claude Managed Agents (via MCP connector), and any MCP-compatible client.
 
 **Native Integrations**: Beyond MCP, MeMesh integrates as a native memory provider for Hermes Agent (Python `MemoryProvider` plugin) and OpenClaw (TypeScript memory-capability plugin) — same tier as their built-in backends, not HTTP bridges. See [docs/platforms/](../platforms/) for platform-specific guides.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pcircle/memesh",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pcircle/memesh",
-      "version": "4.7.0",
+      "version": "4.7.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcircle/memesh",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "description": "MeMesh \u2014 agentic memory for coding agents. Captured from the agent's real work via hooks, recalled when it acts. One SQLite file, zero cloud required.",
   "main": "dist/index.js",
   "type": "module",

--- a/tests/core/timestamp-format-comparisons.test.ts
+++ b/tests/core/timestamp-format-comparisons.test.ts
@@ -106,7 +106,15 @@ describe('pruning telemetry keeps rows newer than the cutoff', () => {
     const boundary = sameDayButNewerThan(cutoff);
     // Fixture: the row really is inside the window AND really does share the
     // cutoff's date. Both have to hold or the test proves nothing.
-    expect(parseSqliteUtcMs(boundary)! > cutoff, 'fixture: the row is not inside the window').toBe(true);
+    // Compared at SECOND resolution, which is the resolution the product
+    // works at: `pruneTelemetry` binds `datetime(?)`, and `datetime()` drops
+    // the milliseconds. A strict `>` against a millisecond-precision cutoff is
+    // stricter than the query it is standing in for, and it has one instant a
+    // day where it is wrong — a run in the last second of a UTC day, where
+    // 23:59:59 IS the newest same-day stamp and is `=` rather than `>`. Same
+    // class as the `cutoff - HOUR` fixture below, which cost a release.
+    const cutoffSecond = Math.floor(cutoff / 1000) * 1000;
+    expect(parseSqliteUtcMs(boundary)! >= cutoffSecond, 'fixture: the row is not inside the window').toBe(true);
     expect(boundary.slice(0, 10), 'fixture: the row is not on the cutoff day')
       .toBe(new Date(cutoff).toISOString().slice(0, 10));
 
@@ -161,11 +169,33 @@ describe('a plan touched on the cutoff day is not stale', () => {
     const { computePmAnalytics } = await import('../../src/core/analytics.js');
     const db = getDatabase();
     db.prepare("INSERT INTO entities (name, type, status) VALUES ('a-plan', 'plan', 'active')").run();
-    // Just OUTSIDE the window, on the same calendar day as the cutoff.
+    // Just OUTSIDE the window, on the same calendar day as the cutoff. The
+    // day has to match or the defect cannot bite: the two formats first differ
+    // at index 10, so the separator only decides the comparison when the date
+    // halves are equal.
+    //
+    // This was `cutoff - HOUR`, and `cutoff` carries the CURRENT time of day —
+    // so between 00:00 and 01:00 UTC one hour earlier is the PREVIOUS day and
+    // the fixture guard failed. It fired in exactly one place: the npm publish
+    // run for v4.7.0, which started at 00:06 UTC. Every local run and all 13
+    // CI legs had passed, at other hours. A test whose verdict depends on the
+    // wall clock is not a test — it is a coin the clock flips.
+    //
+    // Clamped to midnight of the cutoff's own UTC day, which is inside the
+    // window at every hour. (The one instant it cannot express is a cutoff
+    // landing exactly on 00:00:00.000 UTC, where "on the cutoff day AND older
+    // than the cutoff" has no solution at all. One millisecond a day, stated
+    // here rather than left to be rediscovered.)
     const cutoff = cutoffMsFor(30);
-    const justStale = new Date(cutoff - HOUR).toISOString();
+    const cutoffDate = new Date(cutoff);
+    const dayStart = Date.UTC(
+      cutoffDate.getUTCFullYear(), cutoffDate.getUTCMonth(), cutoffDate.getUTCDate(),
+    );
+    const justStale = new Date(Math.max(cutoff - HOUR, dayStart)).toISOString();
     expect(justStale.slice(0, 10), 'fixture: not on the cutoff day')
-      .toBe(new Date(cutoff).toISOString().slice(0, 10));
+      .toBe(cutoffDate.toISOString().slice(0, 10));
+    expect(Date.parse(justStale), 'fixture: not actually older than the cutoff')
+      .toBeLessThan(cutoff);
     db.prepare("UPDATE entities SET last_accessed_at = ? WHERE name = 'a-plan'").run(justStale);
 
     expect(computePmAnalytics(db).staleness.stalePlanCount,


### PR DESCRIPTION
**4.7.0 was tagged and released on GitHub and never reached npm.** The publish
job runs the suite, and the suite went red on a test fixture that only fails
between 00:00 and 01:00 UTC. The job started at 00:06 UTC.

```
FAIL tests/core/timestamp-format-comparisons.test.ts:168
AssertionError: fixture: not on the cutoff day: expected '2026-07-24' to be '2026-07-25'
```

### The fixture

It built a "just past the cutoff" stamp as `cutoff - 1 hour` and asserted it
fell on the cutoff's calendar day. `cutoff` is `Date.now() - 30 days`, so it
carries the *current* time of day — and in the first hour of a UTC day, one
hour earlier is the previous day.

The day has to match or the defect the test pins cannot bite: the two timestamp
formats first differ at index 10, so the separator only decides the comparison
when the date halves are equal. The stamp is clamped to midnight of the
cutoff's own UTC day, which is inside the window at every hour. Checked across
the whole day rather than once — **96 sampled times, 0 out of window; the
expression it replaces, 4 of the same 96.**

The same file's other cutoff-day fixture had a narrower version of the same
hole (millisecond comparison against a product that binds `datetime(?)`, which
drops milliseconds — one second a day). It compares at second resolution now.

No shipped behaviour changes.

### Why 4.7.1 and not a re-publish of 4.7.0

`publish-npm.yml` triggers only on `release: published`, and its
`actions/checkout` takes no `ref` — so the only tree that can ever ship as
4.7.0 is the commit that tag points at, the one with the broken fixture.

- Re-running the failed job rebuilds that tree; it would go green only because
  the hour has moved. That is the clock, not a pass.
- Deleting and recreating the release on the same tag gives the same target
  commit.
- Moving the tag needs the `refs/tags/v*` ruleset paused. Nothing has consumed
  v4.7.0 — npm never served it — so an inert ref is not worth turning
  protection off on a public repo to tidy.

4.7.0's contents ship here unchanged. `[4.7.0]` stays where it is; `[4.7.1]`
states that 4.7.0 exists as a tag and never as a package, so it does not become
a phantom version later — the same thing 4.6.3 nearly was.

### Verification

```
node scripts/run-tests-isolated.mjs -> Test Files 185 passed (185) / Tests 2528 passed (2528), exit=0
npm run verify:release                -> exit=0 (all eight anchors agree at 4.7.1)
break-test: revert datetime(last_accessed_at) in analytics.ts -> 1 of 10 fails; restored, checksum-verified
```

### The finding underneath

The local suite, the release gate and thirteen CI legs all ran this test green,
and it was still broken. They ran at other hours. A fixture assertion derived
from `Date.now()` has to be checked across the whole day, not once.
