### PR TITLE
fix: close two open CodeQL alerts

### DIFF
--- a/scripts/lib/npm-bin.mjs
+++ b/scripts/lib/npm-bin.mjs
@@ -90,8 +90,8 @@ export function assertSafeShellArg(value, what) {
  */
 function runSync(bin, args, opts) {
   if (!isWindows) return execFileSync(bin, args, opts);
-  args.forEach((arg, i) => assertSafeShellArg(arg, `${bin} argument ${i} (${arg})`));
-  return execSync([bin, ...args].join(' '), opts);
+  const safeArgs = args.map((arg, i) => assertSafeShellArg(arg, `${bin} argument ${i} (${arg})`));
+  return execSync([bin, ...safeArgs].join(' '), opts);
 }
 
 /** `npm <args>`, spawned correctly for the platform. */

--- a/tests/core/fallback-chain-is-wired.test.ts
+++ b/tests/core/fallback-chain-is-wired.test.ts
@@ -32,9 +32,9 @@ const FALLBACK: LLMConfig = { provider: 'ollama', model: 'llama3.2' };
 function stubChain(body: string): { hosts: string[] } {
   const hosts: string[] = [];
   vi.spyOn(globalThis, 'fetch').mockImplementation((async (input: RequestInfo | URL) => {
-    const url = String(input);
-    hosts.push(new URL(url).host);
-    if (url.includes('api.anthropic.com')) {
+    const host = new URL(String(input)).host;
+    hosts.push(host);
+    if (host === 'api.anthropic.com') {
       return new Response('upstream is having a bad day', { status: 500 });
     }
     // Ollama's shape: { response: "..." }


### PR DESCRIPTION
## Summary
- #128 `js/incomplete-url-substring-sanitization` (high) — a test's fetch stub matched the request host with `url.includes('api.anthropic.com')`, which a crafted URL like `http://evil.com/api.anthropic.com` would also satisfy. Reuses the already-parsed `URL().host` for an exact match instead.
- #127 `js/shell-command-injection-from-environment` (medium) — `assertSafeShellArg` validated each Windows shell arg inside a `forEach` side effect, so CodeQL's data-flow analysis can't trace that the value reaching `execSync` is the checked one (the original `args` array is unchanged by a `forEach`). Switching to `.map()` makes the validated return value the one actually joined into the command string — same allow-list, same runtime behavior, but the sanitizer is now in the traceable data flow.

Neither alert reflected real exploitability in this codebase (test-only mock in the first case; the allow-list was already correctly enforced before use in the second, just not in a shape CodeQL's static analysis could confirm) — both are fixed anyway since the fix is free and closes the alert cleanly.

## Test plan
- [x] `npx vitest run tests/consumer-audit-gate.test.ts tests/core/fallback-chain-is-wired.test.ts tests/typecheck-scope.test.ts` — 11 passed
- [x] `npm run typecheck` — exit 0
- [ ] Confirm both CodeQL alerts auto-close after this merges to `main` and the next scan runs