### PR TITLE
fix(test): widen Windows cleanup retry window in citation-rule-self-heal

### DIFF
--- a/tests/hooks/citation-rule-self-heal.test.ts
+++ b/tests/hooks/citation-rule-self-heal.test.ts
@@ -37,7 +37,13 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  for (const d of [home, project]) fs.rmSync(d, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+  // maxRetries/retryDelay here are wider than this repo's usual 5/100ms:
+  // this is the one test file that has actually shown Windows CI's
+  // ENOTEMPTY race (rmSync racing the OS's handle release after the child
+  // process spawned by runHook() exits) — twice, in the same CI run, both
+  // legs. 5/100ms (500ms worst case) was not always enough; 10/200ms (2s
+  // worst case) only costs time on the runs that were already retrying.
+  for (const d of [home, project]) fs.rmSync(d, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 });
 });
 
 function writeMarker(scope: 'user' | 'project'): void {


### PR DESCRIPTION
## Summary
- `citation-rule-self-heal.test.ts`'s `afterEach` failed on `windows-latest` with `ENOTEMPTY` on `rmSync`, twice in the same CI run (PR #203, both Node 22 and Node 24 legs) — the temp dir's OS-level handle from the child process `runHook()` spawns had not been released yet when cleanup ran.
- This repo's usual `maxRetries: 5, retryDelay: 100` (500ms worst case) was not always enough under CI load. Widened to `10/200` (2s worst case) for this file only — that cost is paid only on the runs that are already retrying.
- Not applied to the ~106 other test files sharing the same `5/100` literal: this is the only file with observed CI failures, so the fix is scoped to it rather than applied speculatively everywhere.

## Test plan
- [x] `npx vitest run tests/hooks/citation-rule-self-heal.test.ts` — 6 passed locally (macOS)
- [ ] Windows CI on this PR — the actual verification ground, since the race does not reproduce on macOS/Linux