### PR TITLE
fix(docs): bring German/Traditional Chinese READMEs back in sync with English

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -413,7 +413,7 @@ Wenn npm eine installierte Version als veraltet kennzeichnet (typischerweise ein
 
 **🔄 Wissensentwicklung** — Entscheidungen ändern sich. `forget` archiviert alte Memories (löscht nie). `supersedes`-Relationen verbinden alt → neu. Ihr KI sieht immer die aktuelle Version.
 
-**⚠️ Konflikterkennung** — Wenn Sie zwei Memories haben, die sich widersprechen, warnt Sie MeMesh.
+**⚠️ Konflikterkennung** — `memesh dream conflicts` lässt das LLM Ihre semantisch nächstliegenden Memory-Paare auf Widerspruch, Supersession oder Duplikat prüfen und legt die Treffer als Vorschläge ab. Nichts wird von selbst übernommen: Sie prüfen mit `dream list` / `dream show`, und erst ein akzeptierter Vorschlag erstellt die Relation — danach trägt jedes `recall`, das eine der beiden Memories betrifft, die Warnung. Kausalität wird nie aus Zeitstempeln abgeleitet; die Urteile beruhen darauf, was die Memories tatsächlich aussagen.
 
 **🕸️ Wissensgraph-Konnektivität** — `memesh kg backfill-relations --all-rules` verknüpft verwaiste Entitäten über Tag-Kookurrenz, Projekt-Clustering, Sitzungskontext und Namensähnlichkeit — ohne LLM.
 
@@ -432,6 +432,45 @@ Importierte Bundles bleiben durchsuchbar, aber MeMesh injiziert importierte Memo
 
 > "Das Dashboard zeigte mir, dass 90 % meiner Memories automatisch generierte Session-Logs waren. Ich begann, `remember` bewusst für Architekturentscheidungen zu nutzen. Ein Spielwechsel."
 > — **Entwickler, der das Analytics-Panel entdeckte**
+
+---
+
+## Rezepte
+
+### Einen Widerspruch erkennen, bevor er zum Problem wird
+
+Zwei Entscheidungen, Wochen auseinander getroffen, die nicht beide wahr sein können — genau das Fehlerbild, das eine Memory-Schicht abfangen soll:
+
+```bash
+memesh remember --name retry-policy --type decision \
+  --obs "Alle HTTP-Clients wiederholen fehlgeschlagene Requests bis zu 5-mal mit exponentiellem Backoff."
+# ...Wochen später entscheidet jemand das Gegenteil...
+memesh remember --name retry-policy-v2 --type decision \
+  --obs "HTTP-Clients dürfen niemals automatisch wiederholen — sofort fehlschlagen und den Fehler melden."
+
+memesh dream conflicts        # markiert das Paar, mit Begründung
+memesh dream show 1           # Urteil, Auszüge und Folgen der Annahme lesen
+memesh dream accept 1         # SIE entscheiden — nichts wird je automatisch verknüpft
+memesh recall "retry policy"  # → Warnung: Konflikte erkannt
+```
+
+Ab dann wird jedem Assistenten, der eine der beiden Entscheidungen abruft, gesagt, dass sie im Widerspruch stehen — statt selbstbewusst die zuerst gefundene zu zitieren.
+
+### Eine Erinnerung, drei Assistenten
+
+MeMesh ist ein MCP-Server, daher bedient dieselbe SQLite-Datei jeden MCP-Client auf der Maschine. Einmal pro Tool registrieren (die genauen Befehle stehen oben unter „In 60 Sekunden starten") — und eine in Claude Code gespeicherte Entscheidung wird mitten in der Session von Codex oder Gemini CLI abgerufen: kein erneutes Erklären, kein Kontext zwischen Anbietern hin- und herkopieren.
+
+### Entscheidungen so festhalten, dass sie auffindbar bleiben
+
+Auto-Capture hält die Session-Historie fest, aber die Erinnerungen, die sich wirklich auszahlen, sind die bewusst gespeicherten:
+
+```bash
+memesh remember --name auth-approach --type decision \
+  --obs "JWT mit RS256; PKCE statt Implicit Flow, weil der Client öffentlich ist." \
+  --tags "project:myapp" "topic:auth"
+```
+
+Verknüpfen Sie dann Folgen mit ihren Ursachen, sobald sie eintreten — von jedem MCP-Client aus, in normalen Worten: „diesen Vorfall als Lektion speichern, beeinflusst von auth-approach". Das `remember`-Tool nimmt frei formulierte Relationen entgegen, und `caused` / `influenced` sind das dokumentierte Kausal-Vokabular (Ursache → Wirkung, explizit angegeben — MeMesh leitet Kausalität nie aus Zeitstempeln ab). Wochen später liefert `memesh recall "warum haben wir uns für PKCE entschieden"` die Entscheidung samt der aufgezeichneten Folgen — nachvollziehbare Begründung, nicht nur zufällig passender Text.
 
 ---
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -421,7 +421,7 @@ MeMesh 的檢索引擎**只用 FTS5**（熱路徑上不使用 LLM、不使用嵌
 
 **🔄 知識演進** — 決策會改變。`forget` 歸檔舊記憶（永不刪除）。`supersedes` 關係連結舊 → 新。你的 AI 總是看到最新版本。
 
-**⚠️ 衝突偵測** — 如果你有兩個互相矛盾的記憶，MeMesh 會警告你。
+**⚠️ 衝突偵測** — `memesh dream conflicts` 會讓 LLM 判定語意上最接近的記憶配對，找出矛盾、汰換或重複，並把結果暫存成提案。沒有東西會自動套用：你用 `dream list` / `dream show` 檢視，只有被接受的提案才會建立關係 —— 之後每次 `recall` 碰到其中任一筆記憶都會帶上警告。因果關係從不從時間戳推論；判決依據的是記憶內容本身怎麼說。
 
 **🕸️ 知識圖連通性** — `memesh kg backfill-relations --all-rules` 使用標籤共現、專案叢集、會話上下文和名稱相似度連結孤立實體 — 無需 LLM。
 
@@ -440,6 +440,45 @@ MeMesh 的檢索引擎**只用 FTS5**（熱路徑上不使用 LLM、不使用嵌
 
 > 「儀表板顯示我 90% 的記憶是自動生成的對話日誌。我開始有意使用 `remember` 來記錄架構決策。改變了遊戲規則。」
 > — **發現分析面板的開發者**
+
+---
+
+## 食譜
+
+### 在矛盾咬你之前先抓到它
+
+兩個決策，隔了好幾週做的，卻不可能同時為真 — 這正是記憶層存在的目的，就是要抓到這種失敗模式：
+
+```bash
+memesh remember --name retry-policy --type decision \
+  --obs "所有 HTTP client 在請求失敗時都用指數退避重試，最多 5 次。"
+# ...幾週後，有人做了完全相反的決定...
+memesh remember --name retry-policy-v2 --type decision \
+  --obs "HTTP client 絕對不能自動重試 — 立刻失敗並把錯誤丟出來。"
+
+memesh dream conflicts        # 判定器標出這一對，附上判斷理由
+memesh dream show 1           # 看完整的判決、引用的段落，接受後會建立什麼
+memesh dream accept 1         # 由你決定 — 沒有東西會自動連起來
+memesh recall "retry policy"  # → 警告：偵測到衝突
+```
+
+從此之後，任何回憶到這兩個決策之一的代理都會被告知它們互相矛盾 — 而不是自信地引用剛好先找到的那一個。
+
+### 一份記憶，三個代理
+
+MeMesh 是一個 MCP server，所以同一個 SQLite 檔案能服務機器上的每一個 MCP 用戶端。每個工具只要註冊一次（確切指令見上方「60 秒快速開始」），在 Claude Code 記錄的決策，session 進行到一半時就能被 Codex 或 Gemini CLI 回憶起來 — 不用重新解釋，不用在不同廠商之間複製貼上 context。
+
+### 記錄決策讓它們保持可被找到
+
+自動擷取會保留 session 歷史，但真正划算的是那些刻意記下的記憶：
+
+```bash
+memesh remember --name auth-approach --type decision \
+  --obs "JWT 搭配 RS256；選 PKCE 而不是 implicit flow，因為 client 是公開的。" \
+  --tags "project:myapp" "topic:auth"
+```
+
+事情發生時，用平常講話的方式把結果連回原因 — 從任何 MCP 用戶端都行，像是：「把這次事故記成一個教訓，受 auth-approach 影響」。`remember` 工具接受自由格式的關係，`caused`／`influenced` 是文件裡定義的因果詞彙（因 → 果，要明確說出來 — MeMesh 從不從時間戳推論因果關係）。幾週後，`memesh recall "為什麼選 PKCE"` 會回傳那個決策，連同它記錄下來的後續影響一起 — 是可以追溯的推理，不只是剛好比對到的文字。
 
 ---
 
@@ -557,7 +596,7 @@ Session 開始時，有新版本可下載時會跳一行 banner（每版本每 2
 ```bash
 git clone https://github.com/PCIRCLE-AI/memesh
 cd memesh && npm install && npm run build
-npm test             # 630 項測試
+npm test
 npm run test:e2e-dashboard
 ```
 

--- a/scripts/check-doc-claims.mjs
+++ b/scripts/check-doc-claims.mjs
@@ -308,9 +308,17 @@ else ok(`server.ts and ARCHITECTURE.md agree on ${routesInCode} HTTP endpoints`)
 // All eleven said "630 tests" while the suite had grown past 1400. The fix is
 // not a checker for eleven copies of a number — it is to stop writing the number
 // down. `npm test` prints the current one.
+//
+// The English pattern alone missed a live case: README.zh-TW.md carried "630
+// 項測試" (630, counter word, "tests") next to a plain `npm test` in the other
+// two READMEs — same stale claim, phrased so the English-only regex never saw
+// it. README.de.md's own word for the same claim ("Tests") is already an
+// English loanword the case-insensitive flag catches; 項測試 needed its own
+// branch because it shares no substring with "tests" at all.
 const readmes = fs.readdirSync(repoRoot).filter(f => /^README(\.[a-zA-Z-]+)?\.md$/.test(f));
 if (readmes.length === 0) fail('no README*.md found — this check stopped looking at anything');
-const withCounts = readmes.filter(f => /\b\d[\d,]*\s*(tests|test cases)\b/i.test(read(f)));
+const testCountRe = /\b\d[\d,]*\s*(tests|test cases)\b|\d[\d,]*\s*項測試/i;
+const withCounts = readmes.filter(f => testCountRe.test(read(f)));
 if (withCounts.length) fail(`README(s) state a hardcoded test count: ${withCounts.join(', ')}`);
 else ok(`${readmes.length} READMEs state no hardcoded test count`);
 


### PR DESCRIPTION
## Summary

Requested review of "the READMEs" turned up real drift between README.md and its two translations, found by reading all three side by side (check-doc-claims.mjs checks facts against code, not translation parity against the English source — this class of gap is outside what it looks for):

- **Missing section**: README.zh-TW.md and README.de.md were both missing the entire "Recipes" section (three worked examples — catching a contradiction, one memory across three assistants, recording decisions with causal links) that exists in README.md. Added, translated to match each file's own established terminology and register (informal 你 in zh-TW per the rest of the file; formal Sie in de, matching the closest analogous walkthrough section).
- **Silently reduced content**: both translations' "⚠️ Conflict Detection" Smart Feature bullet was a single generic sentence ("if you have two contradicting memories, MeMesh warns you"), while English carries three sentences of real detail — the actual command, the review workflow (`dream list`/`dream show`, nothing auto-applies), and the causality guarantee. Expanded both to match.
- **Stale hardcoded number**: README.zh-TW.md's Contributing section had `npm test  # 630 項測試` — the exact "stale test count next to npm test" problem `check-doc-claims.mjs`'s own check #5 exists to prevent (its comment cites an earlier incident: "all eleven said 630 tests while the suite had grown past 1400"). It slipped through because that check's regex only matches the English words "tests"/"test cases" — "630 項測試" is the same claim in Chinese. Removed the stale count and widened the regex to also catch the CJK phrasing, so this doesn't silently recur.

## Test plan
- [x] `node scripts/check-doc-claims.mjs` — all 32 checks pass, including the now-widened "READMEs state no hardcoded test count" check
- [x] Code-fence balance verified in both edited files (60/60, even) — a stray fence would silently break every section after it
- [x] Heading structure now matches across all three files: Example Usage → Recipes (3 subsections) → Unlock Smart Mode
- [x] Every local link/path referenced already resolves in git (verified separately while auditing README.md itself)