### PR TITLE
fix(hooks): Codex rejects the hook output we ship — v4.7.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "memesh",
       "source": "./",
       "description": "MeMesh \u2014 agentic memory for coding agents. Captured from the agent's real work via hooks, recalled when it acts. One SQLite file, zero cloud required.",
-      "version": "4.7.2",
+      "version": "4.7.3",
       "author": {
         "name": "PCIRCLE AI"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -4,7 +4,7 @@
   "author": {
     "name": "PCIRCLE AI"
   },
-  "version": "4.7.2",
+  "version": "4.7.3",
   "homepage": "https://github.com/PCIRCLE-AI/memesh",
   "repository": "https://github.com/PCIRCLE-AI/memesh",
   "license": "MIT",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to MeMesh are documented here.
 
+## [4.7.3] — 2026-08-24
+
+### Fixed
+
+- **Two hooks errored on every Bash call and every turn under Codex CLI.**
+  `post-commit` (PostToolUse) and `session-summary` (Stop) each ended by
+  printing `{"suppressOutput": true}`. That is valid Claude Code hook output.
+  Codex validates hook output per event against its own schema and rejects the
+  field, so a Codex user saw `PostToolUse hook returned unsupported
+  suppressOutput` after every Bash command and `hook returned invalid stop hook
+  JSON output` at the end of every turn — while the capture itself had already
+  succeeded. The memory was written and the error appeared anyway.
+
+  Both hooks now print nothing. The field was never doing any work: neither
+  writes anything else to stdout, so there was no output to suppress. Empty
+  stdout with exit 0 is the "no opinion" signal in both contracts.
+
+  Affects 4.7.1 and 4.7.2 for anyone running MeMesh as a Codex plugin. Claude
+  Code behaviour is unchanged — a hook that prints nothing and one that asks
+  for its output to be hidden look identical to the user.
+
 ## [4.7.2] — 2026-08-24
 
 ### Fixed

--- a/dist/skills-manifest.json
+++ b/dist/skills-manifest.json
@@ -3,7 +3,7 @@
   "entries": [
     {
       "path": ".claude-plugin/plugin.json",
-      "sha256": "1a03a56bfb2e7d2fd3a2a04692604027d9dbfaed63f4c1d7afc6a35ff6dfafac",
+      "sha256": "773e152af2cbcfe41135dfb8e4535682257f3575ab30139bd09e2e2017c455bd",
       "bytes": 527
     },
     {
@@ -83,8 +83,8 @@
     },
     {
       "path": "scripts/hooks/post-commit.js",
-      "sha256": "6f7e4e66dcbf731aaa01074ec7e27fbf06945c0333e34671468efdc50f3fe711",
-      "bytes": 9537
+      "sha256": "987dd817a6f6310039aa97a7ea2798bca6097a9c7a943ae5c6ea1a9fb00c4264",
+      "bytes": 10309
     },
     {
       "path": "scripts/hooks/pre-compact.js",
@@ -103,8 +103,8 @@
     },
     {
       "path": "scripts/hooks/session-summary.js",
-      "sha256": "12d28e2524bb13b6cb709fe3510264058728d6299bd43a2c1dc5723d658a7806",
-      "bytes": 46696
+      "sha256": "2c13205539a0424ceeb11a7aed79dc8c0504e56e7a9e21661b007f2a504f5554",
+      "bytes": 47387
     },
     {
       "path": "scripts/hooks/user-prompt-intent.js",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # MeMesh Plugin Architecture
 
-**Version**: 4.7.2
+**Version**: 4.7.3
 
 > Looking for "which file do I change for X?" — see [CODEMAP.md](../CODEMAP.md).
 

--- a/docs/api/API_REFERENCE.md
+++ b/docs/api/API_REFERENCE.md
@@ -1,7 +1,7 @@
 # MeMesh Plugin -- API Reference
 
 **Protocol**: Model Context Protocol (MCP) over stdio
-**Version**: 4.7.2
+**Version**: 4.7.3
 **Compatibility**: Works with Claude Code plugins, Claude Managed Agents (via MCP connector), and any MCP-compatible client.
 
 **Native Integrations**: Beyond MCP, MeMesh integrates as a native memory provider for Hermes Agent (Python `MemoryProvider` plugin) and OpenClaw (TypeScript memory-capability plugin) — same tier as their built-in backends, not HTTP bridges. See [docs/platforms/](../platforms/) for platform-specific guides.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pcircle/memesh",
-  "version": "4.7.2",
+  "version": "4.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pcircle/memesh",
-      "version": "4.7.2",
+      "version": "4.7.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcircle/memesh",
-  "version": "4.7.2",
+  "version": "4.7.3",
   "description": "MeMesh — agentic memory for coding agents. Captured from the agent's real work via hooks, recalled when it acts. One SQLite file, zero cloud required.",
   "main": "dist/index.js",
   "type": "module",

--- a/scripts/hooks/post-commit.js
+++ b/scripts/hooks/post-commit.js
@@ -188,7 +188,19 @@ process.stdin.on('end', () => {
     // Never crash Claude Code — but leave a trace for debugging
     try { process.stderr.write(`[memesh post-commit] ${err?.message || err}\n`); } catch {}
   }
-  console.log(JSON.stringify({ suppressOutput: true }));
+  // Emit NOTHING on success — not `{"suppressOutput": true}`.
+  //
+  // That field is valid Claude Code hook output, and it was doing no work:
+  // this hook writes nothing else to stdout, so there was never any output
+  // to suppress. But Codex CLI validates hook output per event against its
+  // own schema, and rejects the field on PostToolUse — reported from a live
+  // Codex session as "PostToolUse hook returned unsupported suppressOutput",
+  // once per Bash tool call, with the capture itself having already succeeded.
+  //
+  // Empty stdout with exit 0 is the "no opinion" signal in BOTH contracts,
+  // and it is what `validateHookOutput` already classifies as `kind: 'empty'`.
+  // So the portable answer is silence, and the field's only remaining effect
+  // was to fail one host for no benefit on the other.
   exit0();
 });
 

--- a/scripts/hooks/session-summary.js
+++ b/scripts/hooks/session-summary.js
@@ -652,8 +652,19 @@ process.stdin.on('end', async () => {
   // so npm install -g doesn't overwrite dist/ while peer hooks are reading it.
   await runAutoUpdateAtStop();
 
-  // Silent output — don't clutter Claude's response
-  console.log(JSON.stringify({ suppressOutput: true }));
+  // Emit NOTHING on success — not `{"suppressOutput": true}`.
+  //
+  // That field is valid Claude Code hook output, and it was doing no work:
+  // this hook writes nothing else to stdout, so there was never any output
+  // to suppress. But Codex CLI validates hook output per event against its
+  // own schema, and rejects the field on Stop — reported from a live
+  // Codex session as "hook returned invalid stop hook JSON output",
+  // once per turn, with the capture itself having already succeeded.
+  //
+  // Empty stdout with exit 0 is the "no opinion" signal in BOTH contracts,
+  // and it is what `validateHookOutput` already classifies as `kind: 'empty'`.
+  // So the portable answer is silence, and the field's only remaining effect
+  // was to fail one host for no benefit on the other.
   exit0();
 });
 

--- a/tests/hooks/cross-host-output-contract.test.ts
+++ b/tests/hooks/cross-host-output-contract.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Hook output that two hosts must both accept.
+ *
+ * `hook-output-contract.test.ts` next door asks "is this valid Claude Code
+ * hook output". That is a different question from "will every host we
+ * document support accept it", and the gap between them shipped: both
+ * `post-commit.js` and `session-summary.js` ended with
+ * `console.log(JSON.stringify({ suppressOutput: true }))`, which is
+ * unimpeachable Claude Code output and which Codex CLI rejects per event.
+ * Reported from a live Codex session in 4.7.1 and 4.7.2:
+ *
+ *   PostToolUse hook returned unsupported suppressOutput
+ *   hook returned invalid post-tool-use JSON output
+ *   hook returned invalid stop hook JSON output
+ *
+ * Once per Bash call and once per turn, with the capture itself having
+ * already succeeded — so the memory was written and the user got an error
+ * about it anyway.
+ *
+ * The field was never doing any work. Neither hook writes anything else to
+ * stdout, so there was no output to suppress; it only announced an intent
+ * that silence already expresses. Empty stdout with exit 0 is the "no
+ * opinion" signal in both contracts.
+ *
+ * This file pins the portable answer: these two hooks say nothing at all.
+ * The neighbouring contract test would pass either way — it accepts
+ * `kind: 'empty'` AND a well-formed envelope — which is exactly why the
+ * regression needs its own assertion rather than relying on that one.
+ */
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { removeTempDir } from '../helpers/temp-dir.js';
+
+function runHook(file: string, payload: object, home: string): { stdout: string; status: number } {
+  const hookPath = path.resolve('scripts/hooks', file);
+  try {
+    const stdout = execFileSync('node', [hookPath], {
+      input: JSON.stringify(payload),
+      env: { ...process.env, HOME: home, USERPROFILE: home },
+      encoding: 'utf8',
+      timeout: 20_000,
+    });
+    return { stdout, status: 0 };
+  } catch (err) {
+    const e = err as { stdout?: string; status?: number };
+    return { stdout: e.stdout ?? '', status: e.status ?? 1 };
+  }
+}
+
+const git = (cwd: string, ...args: string[]) =>
+  execFileSync('git', ['-C', cwd, ...args], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+
+describe('hooks that must be silent on success', () => {
+  it('post-commit.js writes nothing after a REAL commit it accepts', () => {
+    // The path that matters, and the only one the shipped bug was on. Every
+    // early return in this hook already exited silently, so a synthetic
+    // payload proves nothing: it is turned away at one of six gates before
+    // reaching the line that used to print. This builds a real repository and
+    // a real commit, and feeds the hook the hash git actually produced —
+    // otherwise `git cat-file -e <hash>^{commit}` rejects it and the test
+    // passes for the wrong reason.
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'memesh-crosshost-'));
+    fs.mkdirSync(path.join(home, '.memesh'), { recursive: true });
+    const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'memesh-crosshost-repo-'));
+    try {
+      git(repo, 'init', '-q');
+      git(repo, 'config', 'user.email', 'test@example.invalid');
+      git(repo, 'config', 'user.name', 'Test');
+      fs.writeFileSync(path.join(repo, 'a.txt'), 'hello\n');
+      git(repo, 'add', 'a.txt');
+      const commitOut = git(repo, 'commit', '-m', 'add a.txt');
+
+      // Guard the guard: if git's output stopped matching the hook's own
+      // regex, the hook would bail early and this test would go quiet.
+      expect(commitOut, "git's commit line no longer matches what the hook parses")
+        .toMatch(/\[[\w/.-]+(?: \([\w -]+\))? [a-f0-9]{7,}\]/);
+
+      const { stdout, status } = runHook('post-commit.js', {
+        session_id: 'cross-host-1',
+        cwd: repo,
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Bash',
+        tool_input: { command: 'git commit -m "add a.txt"' },
+        tool_response: { stdout: commitOut },
+      }, home);
+
+      expect(status, 'post-commit.js exited non-zero on a real commit').toBe(0);
+      expect(
+        stdout.trim(),
+        'post-commit.js wrote to stdout. Codex validates hook output per event and rejects '
+        + 'fields Claude Code accepts — `suppressOutput` is the one that shipped in 4.7.1/4.7.2 '
+        + 'and errored on every Bash call. Silence is what both hosts accept.',
+      ).toBe('');
+
+      // And the capture still happened — silence must not mean "did nothing".
+      const dbPath = path.join(home, '.memesh', 'knowledge-graph.db');
+      expect(fs.existsSync(dbPath), 'the hook went silent AND stopped capturing').toBe(true);
+    } finally {
+      removeTempDir(home, repo);
+    }
+  });
+
+  it('session-summary.js writes nothing on a Stop it declines to act on', () => {
+    // Weaker than the case above and labelled so: with an empty transcript this
+    // takes an early return rather than the full path. It still pins that the
+    // early returns stay silent; the source scan below is what covers the
+    // completed path for this hook.
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'memesh-crosshost-'));
+    fs.mkdirSync(path.join(home, '.memesh'), { recursive: true });
+    try {
+      const { stdout, status } = runHook('session-summary.js', {
+        session_id: 'cross-host-2',
+        cwd: home,
+        hook_event_name: 'Stop',
+        transcript_path: '',
+      }, home);
+
+      expect(status).toBe(0);
+      expect(stdout.trim(), 'session-summary.js wrote to stdout on an early return').toBe('');
+    } finally {
+      removeTempDir(home);
+    }
+  });
+
+  it('no hook still emits suppressOutput from a branch the success path misses', () => {
+    // The runtime assertions above only cover the success path. An early
+    // return that emits the field would slip past them, and the field reads as
+    // harmless enough to be reintroduced by someone tidying up.
+    //
+    // Comments are stripped before scanning, deliberately: the hooks now carry
+    // a comment explaining why the field is absent, and a check that cannot
+    // tell an explanation from an emission would forbid documenting the
+    // decision. Naming the mistake is how it stays fixed.
+    const dir = path.resolve('scripts/hooks');
+    const stripComments = (src: string) => src
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .split('\n')
+      .filter(l => !l.trim().startsWith('//'))
+      .join('\n');
+
+    const offenders = fs.readdirSync(dir)
+      .filter(f => f.endsWith('.js'))
+      .filter(f => /suppressOutput/.test(stripComments(fs.readFileSync(path.join(dir, f), 'utf8'))));
+
+    expect(offenders, `these hooks emit suppressOutput, which Codex rejects per event`)
+      .toEqual([]);
+  });
+});

--- a/tests/hooks/cross-host-output-contract.test.ts
+++ b/tests/hooks/cross-host-output-contract.test.ts
@@ -141,8 +141,16 @@ describe('hooks that must be silent on success', () => {
       .filter(l => !l.trim().startsWith('//'))
       .join('\n');
 
-    const offenders = fs.readdirSync(dir)
-      .filter(f => f.endsWith('.js'))
+    const hookFiles = fs.readdirSync(dir).filter(f => f.endsWith('.js'));
+
+    // Anti-vacuity pin. `toEqual([])` below passes just as happily when the
+    // scan found NO files — a wrong path, a moved directory — as when it found
+    // them all and none offended. Those are opposite outcomes and the
+    // assertion cannot tell them apart, so the count is pinned first.
+    expect(hookFiles.length, 'scanned no hook files — this check stopped looking at anything')
+      .toBeGreaterThan(5);
+
+    const offenders = hookFiles
       .filter(f => /suppressOutput/.test(stripComments(fs.readFileSync(path.join(dir, f), 'utf8'))));
 
     expect(offenders, `these hooks emit suppressOutput, which Codex rejects per event`)

--- a/tests/hooks/post-commit.test.ts
+++ b/tests/hooks/post-commit.test.ts
@@ -353,7 +353,13 @@ describe('Feature: Post-Commit Hook', () => {
     db.close();
   });
 
-  it('Scenario: Hook output includes suppressOutput flag', () => {
+  it('Scenario: Hook writes nothing to stdout', () => {
+    // Was 'Hook output includes suppressOutput flag', asserting
+    // `{"suppressOutput": true}`. That is valid Claude Code hook output, and
+    // Codex CLI rejects it per event — "PostToolUse hook returned unsupported
+    // suppressOutput", once per Bash call, with the capture already done. The
+    // field suppressed nothing (this hook has no other stdout write), so the
+    // portable answer is silence, which both contracts read as "no opinion".
     const c = commit('fix: something');
     const hookPath = path.resolve('scripts/hooks/post-commit.js');
     const input = {
@@ -368,8 +374,7 @@ describe('Feature: Post-Commit Hook', () => {
       encoding: 'utf8',
       timeout: 15000,
     });
-    const parsed = JSON.parse(result.trim());
-    expect(parsed.suppressOutput).toBe(true);
+    expect(result.trim(), 'stdout must stay empty — see tests/hooks/cross-host-output-contract.test.ts').toBe('');
   });
 
   it('Scenario: Invalid JSON input -> exits cleanly', () => {


### PR DESCRIPTION
Reported from a live Codex session against installed **4.7.1**, and confirmed present in the **v4.7.2 tag** before touching anything.

```
PostToolUse hook returned unsupported suppressOutput
hook returned invalid post-tool-use JSON output
hook returned invalid stop hook JSON output
```

## What happens

`post-commit.js` (PostToolUse/Bash) and `session-summary.js` (Stop) each ended with:

```js
console.log(JSON.stringify({ suppressOutput: true }));
```

That is valid Claude Code hook output. Codex validates hook output **per event** against its own schema and rejects the field — so a Codex user gets an error after **every Bash command** and at the **end of every turn**, with the capture having already succeeded. The memory is written and the error appears anyway.

## The fix

Both hooks now print nothing.

Not a compromise — the field was never doing any work. Neither hook writes anything else to stdout, so there was no output to suppress; it announced an intent that silence already expresses. Empty stdout with exit 0 is the "no opinion" signal in both contracts, and is exactly what this repo's own `validateHookOutput` classifies as `kind: 'empty'`.

Claude Code behaviour is unchanged: a hook that prints nothing and one that asks for its output to be hidden look identical to the user.

## A conclusion of mine this overturns

I had told KT that this class of error was not memesh's, on the strength of a structural proof that `session-summary.js` emits only well-formed JSON. That proof is correct and answers the wrong question. **JSON a host can parse is not JSON a host accepts.** I checked validity and reported compatibility.

## Two bad tests, caught before landing

**The source scan tripped on my own comments.** It searched for the string `suppressOutput`, and the hooks now carry a comment explaining why the field is absent. Comments are stripped before scanning — a check that cannot tell an explanation from an emission would forbid documenting the decision.

**The first runtime test passed with the bug reinstated.** Its payload was synthetic, and this hook turns such a payload away at one of six gates long before the line that used to print — every early return was *already* silent, so the assertion covered nothing. It now builds a real git repository, makes a real commit, and feeds the hook the hash git actually produced, with a guard asserting git's output still matches the hook's own regex. It also asserts the database was written, so silence cannot quietly become "did nothing".

**And the audit caught a third.** C1 flagged `expect(offenders).toEqual([])` as an emptiness assertion with no size pin — correctly: it passes identically whether the scan read every hook and none offended, or read *no* hooks because the path was wrong. The file count is pinned first now.

## Evidence

```
node scripts/run-tests-isolated.mjs     exit=0   189 files, 2595 tests
npm run verify:release                  exit=0   all detectors new=0
npm run build                           exit=0
check-version-coherence                 exit=0   8 anchors at 4.7.3
```

Break-tests, each restored byte-identical:

| Mutation | Result |
|---|---|
| bug reinstated in `post-commit.js` | `exit=1` — 2 failed: the real-commit runtime case **and** the source scan |
| scan path misspelled | `exit=1` — ENOENT on the source-scan case |

## Release

Bumped to **4.7.3** in this PR. 4.7.1 and 4.7.2 are both affected for anyone running MeMesh as a Codex plugin, so this wants shipping rather than waiting.