### PR TITLE
test(e2e): pin the dashboard smoke's environment isolation against ambient provider state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,18 @@ All notable changes to MeMesh are documented here.
   `OLLAMA_HOST` is unchanged. The dashboard global-filter test builds its
   cross-tab event as `new Event('storage')` to clear CodeQL #138.
 
+- **The packaged Dashboard E2E smoke now pins its environment isolation.**
+  `scripts/dashboard-e2e-smoke.mjs` builds the child runtime's environment in
+  an exported pure function (`buildIsolatedRuntimeEnv`) and only runs the smoke
+  when invoked directly. `tests/release-scripts-safety.test.ts` calls that
+  function with a deliberately polluted maintainer environment and asserts,
+  key by key, that the test-owned HOME/MEMESH_DIR/database win, that
+  `MEMESH_AUTO_DETECT_LLM` is off, and that every provider variable
+  `detectFromEnv()` reads is gone — the list is derived from `config.ts`
+  itself, so a provider added there without updating the smoke fails the test.
+  Recorded under a shell that really had `OPENAI_API_KEY` set: the packaged
+  server still started at Level 0 and the smoke exited 0 (#271).
+
 ### Added
 
 - **Repeatable owner-run live delivery checks.** `npm run qa:live-journey -- --host codex|claude`

--- a/scripts/dashboard-e2e-smoke.mjs
+++ b/scripts/dashboard-e2e-smoke.mjs
@@ -6,6 +6,7 @@ import os from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
 import { setTimeout as delay } from 'node:timers/promises';
+import { pathToFileURL } from 'node:url';
 import { chromium } from 'playwright';
 import { npmSync } from './lib/npm-bin.mjs';
 
@@ -106,15 +107,26 @@ function cleanupDir(dirPath) {
   fs.rmSync(dirPath, { recursive: true, force: true });
 }
 
-async function main() {
-  cleanupDir(smokeDir);
-  fs.mkdirSync(smokeDir, { recursive: true });
-  const runtimeHome = path.join(smokeDir, 'runtime-home');
-  const memeshDir = path.join(runtimeHome, '.memesh');
-  const dbPath = path.join(memeshDir, 'knowledge-graph.db');
-  fs.mkdirSync(memeshDir, { recursive: true });
+/**
+ * Build the environment the packaged runtime spawns under: a test-owned
+ * HOME/USERPROFILE/MEMESH_DIR/MEMESH_DB_PATH, provider auto-detection turned
+ * off, and every provider credential/endpoint variable that could turn it
+ * back on stripped from what would otherwise be a full `...baseEnv` spread.
+ *
+ * Pure and side-effect-free on purpose — `tests/release-scripts-safety.test.ts`
+ * imports it directly and calls it with a deliberately polluted `baseEnv` to
+ * pin this isolation as a regression test, without spawning `npm pack`,
+ * installing a tarball, or launching a browser.
+ *
+ * The stripped names are exactly what `src/core/config.ts`'s `detectFromEnv`
+ * reads (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `OLLAMA_HOST`) plus
+ * `MEMESH_AUTO_DETECT_LLM` itself. Keeping the two lists in lockstep is the
+ * point: a name added to one without the other is exactly the gap GitHub
+ * issue #271 found.
+ */
+export function buildIsolatedRuntimeEnv(baseEnv, { runtimeHome, memeshDir, dbPath }) {
   const isolatedEnv = {
-    ...process.env,
+    ...baseEnv,
     HOME: runtimeHome,
     USERPROFILE: runtimeHome,
     MEMESH_DIR: memeshDir,
@@ -124,6 +136,17 @@ async function main() {
   delete isolatedEnv.ANTHROPIC_API_KEY;
   delete isolatedEnv.OPENAI_API_KEY;
   delete isolatedEnv.OLLAMA_HOST;
+  return isolatedEnv;
+}
+
+async function main() {
+  cleanupDir(smokeDir);
+  fs.mkdirSync(smokeDir, { recursive: true });
+  const runtimeHome = path.join(smokeDir, 'runtime-home');
+  const memeshDir = path.join(runtimeHome, '.memesh');
+  const dbPath = path.join(memeshDir, 'knowledge-graph.db');
+  fs.mkdirSync(memeshDir, { recursive: true });
+  const isolatedEnv = buildIsolatedRuntimeEnv(process.env, { runtimeHome, memeshDir, dbPath });
 
   const packJson = npmSync(
     ['pack', '--json', '--pack-destination', smokeDir],
@@ -374,7 +397,19 @@ async function onceExit(child) {
   });
 }
 
-main().catch((error) => {
-  console.error(error.stack || error.message);
-  process.exit(1);
-});
+// Guard so importing this module (the regression test in
+// tests/release-scripts-safety.test.ts imports buildIsolatedRuntimeEnv above)
+// does not also run the smoke. Matches the idiom already used in
+// scripts/hooks/auto-update-runner.mjs — realpathSync + pathToFileURL rather
+// than `new URL(import.meta.url).pathname`, which
+// tests/release-scripts-safety.test.ts's "resolves module paths with
+// fileURLToPath" gate forbids repo-wide (it breaks on Windows drive paths).
+const invokedPath = process.argv[1]
+  ? pathToFileURL(fs.realpathSync(process.argv[1])).href
+  : null;
+if (invokedPath === import.meta.url) {
+  main().catch((error) => {
+    console.error(error.stack || error.message);
+    process.exit(1);
+  });
+}

--- a/tests/release-scripts-safety.test.ts
+++ b/tests/release-scripts-safety.test.ts
@@ -17,12 +17,13 @@
  *
  * Recorded as unpinned during the mutation sweep of this release, then pinned.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import os from 'node:os';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { spawnSync } from 'child_process';
+import { buildIsolatedRuntimeEnv } from '../scripts/dashboard-e2e-smoke.mjs';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -470,5 +471,93 @@ describe('Feature: release scripts never edit the real ~/.memesh', () => {
     for (const value of Object.values(sentinels)) {
       expect(output).not.toContain(value);
     }
+  });
+
+  it('the dashboard e2e smoke isolates the runtime env and strips provider variables', () => {
+    // GitHub issue #271: the packaged Dashboard E2E gave the child runtime
+    // an isolated MEMESH_DB_PATH but otherwise spread the maintainer's real
+    // process.env, so a shell with a configured provider made the "isolated"
+    // server start in Smart Mode against a real LLM. buildIsolatedRuntimeEnv
+    // is the fix, extracted into a pure function so this test can call it
+    // directly instead of running the full smoke (npm pack + install +
+    // Playwright).
+
+    // Derive the provider variable list from detectFromEnv() itself, rather
+    // than re-typing it here, so a provider added to config.ts without
+    // updating the smoke script's delete list fails this test instead of
+    // leaking silently. Falls back to nothing if the function is ever
+    // rewritten in a way the regex can't follow — the assertions right
+    // after this catch that case loudly instead of the loop passing
+    // vacuously over an empty list.
+    const configSource = read('src/core/config.ts');
+    const detectFromEnvBody = configSource.match(/function detectFromEnv\(\)[^{]*\{([\s\S]*?)\n\}/)?.[1] ?? '';
+    const providerKeys = [...new Set(
+      [...detectFromEnvBody.matchAll(/process\.env\.([A-Z0-9_]+)/g)].map((m) => m[1])
+    )];
+    expect(providerKeys.length).toBeGreaterThan(0);
+    expect(providerKeys).toEqual(expect.arrayContaining(['ANTHROPIC_API_KEY', 'OPENAI_API_KEY', 'OLLAMA_HOST']));
+
+    const smokeSource = read('scripts/dashboard-e2e-smoke.mjs');
+    for (const key of providerKeys) {
+      expect(smokeSource).toContain(`delete isolatedEnv.${key}`);
+    }
+
+    // A base env standing in for a maintainer's shell: real PATH (so the
+    // "unrelated ambient state still passes through" assertion below means
+    // something), plus a sentinel for every value the isolation must
+    // remove or override. GEMINI_API_KEY is deliberately NOT included —
+    // grepped repo-wide, it is not read anywhere in this codebase, so a
+    // sentinel for it would assert nothing and just be dead weight.
+    const paths = {
+      runtimeHome: '/test-owned/runtime-home',
+      memeshDir: '/test-owned/runtime-home/.memesh',
+      dbPath: '/test-owned/runtime-home/.memesh/knowledge-graph.db',
+    };
+    const pollutedBaseEnv: Record<string, string> = {
+      PATH: process.env.PATH ?? '',
+      HOME: '/ambient/maintainer-home-sentinel',
+      USERPROFILE: 'C:\\ambient\\maintainer-home-sentinel',
+      MEMESH_DIR: '/ambient/maintainer-memesh-sentinel',
+      MEMESH_DB_PATH: '/ambient/maintainer-db-sentinel.db',
+      OLLAMA_HOST: 'http://ambient-ollama.invalid',
+      OPENAI_API_KEY: 'ambient-openai-sentinel',
+      ANTHROPIC_API_KEY: 'ambient-anthropic-sentinel',
+      MEMESH_AUTO_DETECT_LLM: '1',
+    };
+
+    // Nothing about building this env should print anything — the isolated
+    // values (and, on a real machine, real credentials in the base env)
+    // must never reach a log.
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    let env: Record<string, string | undefined>;
+    try {
+      env = buildIsolatedRuntimeEnv(pollutedBaseEnv, paths);
+    } finally {
+      logSpy.mockRestore();
+      errorSpy.mockRestore();
+    }
+    expect(logSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+
+    // Test-owned paths win over whatever the ambient shell had.
+    expect(env.HOME).toBe(paths.runtimeHome);
+    expect(env.USERPROFILE).toBe(paths.runtimeHome);
+    expect(env.MEMESH_DIR).toBe(paths.memeshDir);
+    expect(env.MEMESH_DB_PATH).toBe(paths.dbPath);
+    expect(env.MEMESH_AUTO_DETECT_LLM).toBe('0');
+
+    // Every provider variable detectFromEnv() reads is gone, not merely
+    // overwritten. Asserted key by key (never the whole `env` object) so a
+    // failure here can never print a sentinel — or, on a real machine, a
+    // real credential — into the test log.
+    for (const key of providerKeys) {
+      expect(env[key]).toBeUndefined();
+    }
+
+    // This isolates the provider surface, not the whole environment —
+    // unrelated ambient state (PATH, needed to spawn npm/node at all)
+    // still passes through.
+    expect(env.PATH).toBe(pollutedBaseEnv.PATH);
   });
 });


### PR DESCRIPTION
## Summary

Closes the last open box on #271: an ambient-state regression pin for `scripts/dashboard-e2e-smoke.mjs`, plus a recorded run from a shell that really has provider state.

- The child-runtime environment is built by an exported pure function, `buildIsolatedRuntimeEnv(baseEnv, paths)`; the smoke only runs when the script is invoked directly.
- `tests/release-scripts-safety.test.ts` derives the provider-variable list from `detectFromEnv()` in `src/core/config.ts` (so a new provider that is not stripped fails the test), asserts the smoke deletes each, and calls the function with a polluted maintainer env — asserting key by key that test-owned HOME/MEMESH_DIR/db win, `MEMESH_AUTO_DETECT_LLM` is `'0'`, every provider variable is gone, PATH passes through, and nothing is printed.

## Type of change

- [x] Test only (`test`)

## Docs synced

- [x] `CHANGELOG.md` `[Unreleased]`

## Verification (worktree at the PR head)

- `node scripts/run-tests-isolated.mjs tests/release-scripts-safety.test.ts` → exit 0, 20/20
- Mutation: drop `delete isolatedEnv.OPENAI_API_KEY` → 1 failed / 19 passed; drop `delete isolatedEnv.OLLAMA_HOST` → 1 failed / 19 passed; restored → 20/20
- Recorded ambient run: shell had `OPENAI_API_KEY` and `ANTHROPIC_MODEL` set (names only); `npm run build` exit 0; `npm run test:e2e-dashboard` exit 0 with the packaged server logging `Level 0 (Core)`; real `~/.memesh` database mtime unchanged
- `npm run typecheck` 0, `npm run lint` 0, `npm run verify:release` 0

## Test plan

- CI on this head. After merge, #271 can be closed: the remaining two boxes (regression pin, ambient-state run) are now in the repo and on record.


## Evidence Gates (`eg` 0.4.18) — ledger in the PR worktree, base `f53c31e0`
```
PASS contract=sha256:9a2aaa6d4194… rev=f7a3304f changed=3
risk declared=legacy_strict effective=legacy_strict budget=7
upstream refs/remotes/origin/main
- e2e-ambient-isolation: source_library required=CODE_COMPLETE observed=CODE_COMPLETE
    LIMITATION: fallback added, unproven: tests/release-scripts-safety.test.ts:493 falls back with ?? -- const detectFromEnvBody = configSource.match(/function detec
    LIMITATION: fallback added, unproven: tests/release-scripts-safety.test.ts:517 falls back with ?? -- PATH: process.env.PATH ?? '',
```
`eg status`: implementation verified; review / runtime / deployment-effect / human-authorization / protected-CI remain **unverified** — eg does not accept Claude Code reviewers (evidence-gates#17) and the CI gate needs its own attestation. The contract was frozen after implementation (post-hoc) at the merge base, so the changed set is exactly this PR; disclosed, not a validator PASS.
