### PR TITLE
feat(qa): add repeatable owner-run live delivery checks for Codex and Claude sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,23 @@ All notable changes to MeMesh are documented here.
   `OLLAMA_HOST` is unchanged. The dashboard global-filter test builds its
   cross-tab event as `new Event('storage')` to clear CodeQL #138.
 
+### Added
+
+- **Repeatable owner-run live delivery checks.** `npm run qa:live-journey -- --host codex|claude`
+  (`scripts/qa/live-journey.mjs`) starts this checkout's router in a throwaway
+  `MEMESH_DIR`, registers one real host session, sends one exact-session
+  envelope, and passes only on model-visible proof: the Codex path requires the
+  model to quote the envelope's `message_id` and `delivery_id` back on its next
+  turn; the Claude path requires an `intake` receipt written by the interactive
+  session the operator launched with the printed command. Both then stop the
+  session and require `recipient_unavailable` while the durable row stays
+  fetchable and the router still answers `discover`. It refuses to run against
+  `$HOME/.memesh`, reads no auth files, never runs in CI, and records its
+  limitations in the JSON report — including that the Codex registration is
+  harness-driven because `codex exec --ignore-user-config` bypasses the plugin
+  `SessionStart` hook, and that print-mode Claude is unsupported (#275).
+  Closes the "repeatable check in the repository" box on #270 and #272.
+
 ## [4.8.3] — 2026-08-31
 
 ### Fixed

--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -142,4 +142,7 @@ The same `operations.ts` memory functions run identically from all three transpo
 
 - Tests: `tests/` mirrors `src/`. Run `npm test -- --run` (pool: forks, not threads — native modules).
   Cross-hook contract gate: `tests/hooks/hook-output-contract.test.ts` (validates every hook's stdout against the real Claude Code contract).
+- Owner-run live checks (never CI): `scripts/qa/live-journey.mjs` — `npm run qa:live-journey -- --host codex|claude`
+  drives a real Codex thread or an interactive Claude channel session and requires model-visible proof.
+  Its pure half is pinned by `tests/qa/live-journey.test.ts`; the contract is in `docs/platforms/agent-messaging.md`.
 - Version anchors that must agree on a bump: `package.json`, both root entries in `package-lock.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `herdr-plugin.toml`, `CHANGELOG.md`, `CODEMAP.md`, `docs/ARCHITECTURE.md`, and `docs/api/API_REFERENCE.md`. Run `npm run build` after to regenerate `dist/skills-manifest.json`.

--- a/docs/platforms/agent-messaging.md
+++ b/docs/platforms/agent-messaging.md
@@ -203,6 +203,81 @@ for active Codex-session delivery.
 - `intake`, `ack`, `disposition`, and `activation` are explicit, separate, idempotent receipt facts. Inbox/MCP ACK is valid without a host-native acceptance; host-native ACK remains bound to its `host_accept`. `receipts` returns one ordered projection and identifies each underlying fact source. For example, `manual_resume_required` does not imply ACK, acceptance, rejection, cancellation, or completion.
 - The transport, rather than model-provided payload data, records sender-host provenance.
 
+## Repeatable owner-run live checks
+
+Everything above is checked by the test suite against stubs and fakes. That
+proves the plumbing and nothing about a live model: a queue admission or a
+`host_accept` is a statement about a frame, not about cognition. Two checks
+close that gap by requiring evidence that could only have come out of a running
+model.
+
+```bash
+npm run qa:live-journey -- --host codex  --out codex-report.json
+npm run qa:live-journey -- --host claude --out claude-report.json
+```
+
+`scripts/qa/live-journey.mjs` is owner-run and never runs in CI, because
+neither check can run unattended: one needs the owner's Codex login, the other
+needs a person at an interactive Claude session. Its argument parsing, its
+refusals, and every assertion it makes are unit-tested in
+`tests/qa/live-journey.test.ts`, which does run in CI against recorded fixtures.
+
+Both checks run entirely inside a fresh `mktemp` MEMESH_DIR that is deleted on
+exit (`--keep` retains it), against this repository's own `dist/`. The script
+refuses to start if `MEMESH_DIR` or `MEMESH_DB_PATH` resolves inside
+`$HOME/.memesh`, or if `dist/` has not been built. It reads no authentication
+file and writes no host configuration outside its temporary directory.
+
+**`--host codex`** starts the router, runs `memesh agent setup codex-session`,
+creates one real Codex CLI thread with `codex exec`, registers that thread,
+sends one exact-session message, and then resumes the thread with a fixed
+prompt that names neither the sentinel nor any identifier. The reply must quote
+the envelope's `message_id` and `delivery_id` back. Neither id exists anywhere
+in the prompt, so a reply carrying them is proof the envelope reached the
+model. The check then stops the companion and requires the next send to return
+`recipient_unavailable` while `message fetch` still returns the payload.
+
+**`--host claude`** starts the router, runs `memesh agent setup claude`, writes
+a temporary MCP config, and prints the exact interactive launch command. The
+operator runs it and types nothing. The check waits for the session to appear
+in `message discover`, sends one exact-session message, and then waits for an
+`intake` receipt on that message whose actor is that session — the model must
+call `intake` itself, which is what makes the proof model-visible rather than
+transport-visible. The operator is then asked to exit the session, and the same
+fail-closed assertion runs.
+
+Print mode (`claude -p`) is **not supported** and is deliberately not
+exercised. A print-mode session does not surface `memesh-channel` notifications
+to the model even when the channel host reports the frame accepted, so it can
+never produce the receipt this check requires.
+
+Each run writes a JSON report: the repository revision, every `message_id` and
+`delivery_id`, the `native_delivery` receipts, the model-visible evidence, and
+a `limitations` list. The exit code is 0 only when every required step passed.
+The limitations these checks always declare:
+
+- The Codex **registration** half is harness-driven. `codex exec
+  --ignore-user-config` structurally prevents the packaged plugin `SessionStart`
+  hook from running, so the check feeds the shipped
+  `src/host-runtime/codex-session.ts` companion the payload that hook would have
+  supplied. Dispatch → `codex queue` → model-visible reply is product-path
+  evidence; the registration step is not.
+- `--host codex` creates one throwaway thread in the owner's Codex rollout
+  store and queues one message into it. That is session state, not
+  configuration; nothing outside the temporary directory is otherwise written.
+- The Claude operator is told to type nothing, but the check cannot observe
+  whether anything was typed. The intake receipt proves the model called
+  `intake` in that session; it does not prove it did so unprompted.
+- The Claude intake receipt is matched on its `actor`, which `intake` sets from
+  the caller's `recipient`. The model must intake under its own session id; an
+  intake recorded against the principal id would not match, and the check would
+  report no model-visible proof.
+- `recipient_unavailable` is a shared failure surface — the same string is
+  returned when the *sender* cannot reach the router. The fail-closed step
+  therefore also records that `message discover` still answered and that
+  `message fetch` still returned the payload. That pairing, not the string, is
+  what attributes the failure to the stopped recipient.
+
 ## Identity and lifecycle
 
 A **principal** is the stable logical recipient. A **session** is one live host connection for that principal. A **generation** changes when that session is replaced. An exact-session target never reroutes. A principal target can deliver only to an eligible active session after its activation checkpoint; it does not replay historical inbox contents into a first session.

--- a/docs/platforms/agent-messaging.md
+++ b/docs/platforms/agent-messaging.md
@@ -212,34 +212,58 @@ close that gap by requiring evidence that could only have come out of a running
 model.
 
 ```bash
-npm run qa:live-journey -- --host codex  --out codex-report.json
-npm run qa:live-journey -- --host claude --out claude-report.json
+TMPDIR=/private/tmp npm run qa:live-journey -- --host codex  --out codex-report.json
+TMPDIR=/private/tmp npm run qa:live-journey -- --host claude --out claude-report.json
 ```
 
-`scripts/qa/live-journey.mjs` is owner-run and never runs in CI, because
-neither check can run unattended: one needs the owner's Codex login, the other
-needs a person at an interactive Claude session. Its argument parsing, its
-refusals, and every assertion it makes are unit-tested in
-`tests/qa/live-journey.test.ts`, which does run in CI against recorded fixtures.
+`TMPDIR` is not decoration on macOS. The router's Unix socket lives beside the
+database inside the temporary directory, and `AF_UNIX` caps a socket path at
+104 bytes; the platform default `os.tmpdir()` spends about half of that before
+the check adds anything. The script measures its own socket path and refuses
+with this hint rather than starting a router that cannot bind.
 
-Both checks run entirely inside a fresh `mktemp` MEMESH_DIR that is deleted on
-exit (`--keep` retains it), against this repository's own `dist/`. The script
-refuses to start if `MEMESH_DIR` or `MEMESH_DB_PATH` resolves inside
-`$HOME/.memesh`, or if `dist/` has not been built. It reads no authentication
-file and writes no host configuration outside its temporary directory.
+`scripts/qa/live-journey.mjs` is owner-run and refuses to start when `CI` is
+set, because neither check can run unattended: one needs the owner's Codex
+login, the other needs a person at an interactive Claude session. Its argument
+parsing, its refusals, and every **pure** assertion it makes are unit-tested in
+`tests/qa/live-journey.test.ts`, which does run in CI against recorded
+fixtures; the orchestration around them is exercised only by a live run.
+
+Everything MeMesh writes goes into a fresh `mktemp` MEMESH_DIR that is deleted
+on exit (`--keep` retains it), against this repository's own `dist/`. The check
+refuses to start if that directory would resolve inside `$HOME/.memesh` — the
+comparison is made on **real** paths, before anything is created, so a
+symlinked `TMPDIR` cannot get past it — or if `dist/` has not been built. It
+reads no authentication file. Where that isolation stops is listed under
+limitations below, and the report records whether the working tree was dirty
+and whether `dist/` predates the newest file under `src/`.
+
+Shutdown order is part of the design rather than an afterthought. A connected
+host that sees the router socket disappear starts a **detached** packaged
+router inheriting its own environment — including this check's `MEMESH_DIR` —
+and the router recreates its data directory on start. The check therefore stops
+the companion, waits for live sessions to disconnect, stops the router, and
+only then removes the directory; if a session is still connected when the wait
+expires it keeps the directory rather than racing that spawn. The same sequence
+runs on failures and on `SIGINT`/`SIGTERM`.
 
 **`--host codex`** starts the router, runs `memesh agent setup codex-session`,
 creates one real Codex CLI thread with `codex exec`, registers that thread,
 sends one exact-session message, and then resumes the thread with a fixed
 prompt that names neither the sentinel nor any identifier. The reply must quote
-the envelope's `message_id` and `delivery_id` back. Neither id exists anywhere
-in the prompt, so a reply carrying them is proof the envelope reached the
-model. The check then stops the companion and requires the next send to return
+the envelope's `message_id` and `delivery_id` back, **and** that turn must have
+produced nothing but an answer. Both halves matter: a `read-only` Codex sandbox
+still permits reads, so a turn that ran one command could have taken the
+identifiers off disk instead of out of the envelope. The Codex workspace is a
+separate temporary tree for the same reason — the database and this run's own
+logs are not one `..` away from it. The check then stops the companion and requires the next send to return
 `recipient_unavailable` while `message fetch` still returns the payload.
 
 **`--host claude`** starts the router, runs `memesh agent setup claude`, writes
-a temporary MCP config, and prints the exact interactive launch command. The
-operator runs it and types nothing. The check waits for the session to appear
+a temporary MCP config, and prints the exact interactive launch command — which
+includes `--setting-sources ""` so that no user, project, or local settings
+file is loaded. The operator runs it, confirms with `/mcp` and `/hooks` that
+only the two servers from `--mcp-config` are present, and then types nothing. The check waits for the session to appear
 in `message discover`, sends one exact-session message, and then waits for an
 `intake` receipt on that message whose actor is that session — the model must
 call `intake` itself, which is what makes the proof model-visible rather than
@@ -256,12 +280,22 @@ Each run writes a JSON report: the repository revision, every `message_id` and
 a `limitations` list. The exit code is 0 only when every required step passed.
 The limitations these checks always declare:
 
-- The Codex **registration** half is harness-driven. `codex exec
-  --ignore-user-config` structurally prevents the packaged plugin `SessionStart`
-  hook from running, so the check feeds the shipped
-  `src/host-runtime/codex-session.ts` companion the payload that hook would have
-  supplied. Dispatch → `codex queue` → model-visible reply is product-path
-  evidence; the registration step is not.
+- The Codex **registration** half is harness-driven: the check drives the
+  shipped `src/host-runtime/codex-session.ts` companion directly with the
+  `SessionStart` payload the packaged plugin hook supplies, because a scripted
+  `codex exec` turn was not observed to register anything on its own. *Why* the
+  plugin hook does not run there is not established — `--ignore-user-config` is
+  documented only as skipping `config.toml`, and on a machine whose
+  `~/.memesh/hosts` has no `codex-session.json` the shipped companion would
+  return early regardless. Dispatch → `codex queue` → model-visible reply is
+  product-path evidence; the registration step is not.
+- The interactive Claude session is **outside** this check's isolation.
+  `--setting-sources ""` is accepted by the CLI (an invalid source name is
+  rejected, an empty list is not), but it is not verified to exclude
+  plugin-provided hooks or MCP servers. A MeMesh plugin hook running in that
+  session inherits no `MEMESH_DIR` and would write the owner's real
+  `~/.memesh`. The operator is told to confirm with `/mcp` and `/hooks` first,
+  and the check cannot observe whether they did.
 - `--host codex` creates one throwaway thread in the owner's Codex rollout
   store and queues one message into it. That is session state, not
   configuration; nothing outside the temporary directory is otherwise written.

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "lint:fix": "eslint src/ scripts/ tests/ dashboard/src/ --fix",
     "start": "node dist/mcp/server.js",
     "bench:longmemeval": "node benchmarks/longmemeval/run.mjs --mode A --dataset /tmp/longmemeval_s.json",
+    "qa:live-journey": "node scripts/qa/live-journey.mjs",
     "test:isolated": "node scripts/run-tests-isolated.mjs",
     "test:coverage": "node scripts/run-tests-isolated.mjs --coverage"
   },

--- a/scripts/qa/live-journey.mjs
+++ b/scripts/qa/live-journey.mjs
@@ -1,0 +1,855 @@
+#!/usr/bin/env node
+
+// Owner-run, repeatable live-journey checks for the two host-native delivery
+// paths: an ordinary Codex CLI thread (issue #270) and a Claude Code session
+// with the memesh-channel development channel admitted (issue #272).
+//
+// WHY THIS EXISTS, AND WHY IT IS NOT A TEST
+//
+// `scripts/smoke-packed-artifact.mjs` proves the installed router and adapter
+// plumbing with a fake `codex` executable and a stubbed `connectRouterHost()`.
+// That is real evidence of the plumbing and no evidence at all that a live
+// model ever saw a message. Both issues asked for the missing half: a check
+// that binds a REAL active session identity, sends one exact-session message,
+// and then requires proof that came out of the model rather than out of the
+// database.
+//
+// The proof shape differs per host, because the two hosts expose different
+// model-visible surfaces:
+//
+//   codex  — the next turn's reply must quote the `message_id` and
+//            `delivery_id` from the injected envelope. Neither id exists
+//            anywhere in the prompt, so a reply containing them cannot have
+//            been produced without reading the envelope.
+//   claude — the session's own model must call `intake` on that message. The
+//            intake receipt is written by the recipient session, not by this
+//            harness, so its presence is model-visible proof.
+//
+// This cannot run in CI. It needs the owner's Codex login, or a human at an
+// interactive Claude session. It is deliberately a script under `scripts/qa/`
+// and NOT a file under `tests/` — a check that cannot run unattended must not
+// sit where an unattended runner will find it. The parts that CAN be checked
+// without a live host (argument parsing, the path refusal, every assertion
+// applied to recorded fixtures) are exported from here and exercised by
+// `tests/qa/live-journey.test.ts`.
+//
+// SAFETY BOUNDARY
+//
+// Everything MeMesh writes goes to a fresh `mktemp` MEMESH_DIR that is deleted
+// on exit. The script refuses to run against `$HOME/.memesh`. It reads no auth
+// files: the Codex precondition is `codex login status`, whose exit code is the
+// answer. It writes no host configuration outside the temp directory.
+//
+// The one thing it touches outside the temp directory is the owner's Codex
+// rollout store: `codex exec` creates one throwaway thread there and
+// `codex queue` appends one message to it. That is the product path under
+// test, it is session state rather than configuration, and it is disclosed in
+// the report's `limitations`.
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { spawn, spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+export const PROJECT = 'memesh-live-journey';
+export const DEFAULT_WAIT_MS = 300_000;
+
+/** dist artefacts this check runs. Missing any of them is a refusal, not a skip. */
+export const REQUIRED_DIST = [
+  'dist/host-runtime/router.js',
+  'dist/transports/cli/cli.js',
+  'dist/host-runtime/codex-session.js',
+  'dist/host-runtime/claude.js',
+  'dist/mcp/server.js',
+];
+
+export function helpText() {
+  return [
+    'memesh qa:live-journey — owner-run live host-native delivery checks',
+    '',
+    'Usage:',
+    '  npm run qa:live-journey -- --host codex  [--out report.json] [--keep] [--wait-ms N]',
+    '  npm run qa:live-journey -- --host claude [--out report.json] [--keep] [--wait-ms N]',
+    '',
+    'Options:',
+    '  --host <codex|claude>  Which live path to exercise. Required.',
+    '  --out <path>           Write the JSON evidence report here (also written on failure).',
+    '  --keep                 Keep the temporary MEMESH_DIR instead of deleting it on exit.',
+    `  --wait-ms <N>          Bound for each wait on the operator or the model, default ${DEFAULT_WAIT_MS}.`,
+    '                         Only --host claude waits on a person; the codex path is unattended.',
+    '  --help                 Print this text.',
+    '',
+    'Preconditions:',
+    '  codex   — `codex` on PATH and `codex login status` reporting a logged-in owner.',
+    '            Costs one or two small Codex turns. Creates one throwaway Codex thread.',
+    '  claude  — `claude` on PATH, and the owner launching one interactive session with',
+    '            the command this script prints. Print mode (`claude -p`) is NOT supported:',
+    '            a print-mode session does not surface memesh-channel notifications to the',
+    '            model even when the channel host reports the frame accepted (issue #275),',
+    '            so it can never produce the model-visible proof this check requires.',
+    '',
+    'This check never runs in CI, never touches $HOME/.memesh, and reads no auth files.',
+  ].join('\n');
+}
+
+/**
+ * @param {string[]} argv arguments after the script path
+ * @returns {{help: boolean, host: string|null, out: string|null, keep: boolean, waitMs: number}}
+ */
+export function parseArgs(argv) {
+  const parsed = { help: false, host: null, out: null, keep: false, waitMs: DEFAULT_WAIT_MS };
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    const value = () => {
+      const next = argv[index + 1];
+      if (next === undefined || next.startsWith('--')) throw new Error(`${flag} requires a value.`);
+      index += 1;
+      return next;
+    };
+    if (flag === '--help' || flag === '-h') parsed.help = true;
+    else if (flag === '--keep') parsed.keep = true;
+    else if (flag === '--host') parsed.host = value();
+    else if (flag === '--out') parsed.out = value();
+    else if (flag === '--wait-ms') {
+      const raw = Number(value());
+      if (!Number.isSafeInteger(raw) || raw < 1_000 || raw > 3_600_000) {
+        throw new Error('--wait-ms must be a whole number of milliseconds between 1000 and 3600000.');
+      }
+      parsed.waitMs = raw;
+    } else throw new Error(`Unknown argument ${flag}. Run with --help.`);
+  }
+  if (parsed.help) return parsed;
+  if (parsed.host === null) throw new Error('--host is required (codex | claude). Run with --help.');
+  if (parsed.host !== 'codex' && parsed.host !== 'claude') {
+    throw new Error(`--host must be codex or claude, not ${parsed.host}.`);
+  }
+  return parsed;
+}
+
+/**
+ * Refuse to run against the owner's real knowledge graph. A live check writes
+ * messages, registers hosts and then deletes its whole data directory; pointed
+ * at `~/.memesh` that is data loss, not a check.
+ *
+ * @param {{memeshDir: string, dbPath: string, home: string}} input
+ */
+export function assertSafeMemeshPaths(input) {
+  const home = path.resolve(input.home);
+  const forbidden = path.join(home, '.memesh');
+  for (const [label, candidate] of [['MEMESH_DIR', input.memeshDir], ['MEMESH_DB_PATH', input.dbPath]]) {
+    const resolved = path.resolve(candidate);
+    if (resolved === forbidden || resolved.startsWith(`${forbidden}${path.sep}`)) {
+      throw new Error(
+        `Refusing to run: ${label} resolves to ${resolved}, inside the owner's ${forbidden}. `
+        + 'This check creates and deletes its own data directory and must never be pointed at real memory.',
+      );
+    }
+  }
+}
+
+/**
+ * @param {string} repoRoot
+ * @param {(file: string) => boolean} [exists] injectable for tests
+ */
+export function assertDistPresent(repoRoot, exists = (file) => fs.existsSync(file)) {
+  const missing = REQUIRED_DIST.filter((relative) => !exists(path.join(repoRoot, relative)));
+  if (missing.length > 0) {
+    throw new Error(
+      `Refusing to run: this repository has no built dist/ for ${missing.join(', ')}. Run \`npm run build\` first.`,
+    );
+  }
+}
+
+/** @param {string} text JSONL as emitted by `codex exec --json` */
+export function parseJsonl(text) {
+  const events = [];
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith('{')) continue;
+    try {
+      events.push(JSON.parse(trimmed));
+    } catch {
+      // A partial or interleaved line is not evidence of anything; the
+      // assertions below fail closed when the event they need is absent.
+    }
+  }
+  return events;
+}
+
+/** @param {string} text @returns {string} the thread id Codex printed */
+export function parseCodexThreadId(text) {
+  for (const event of parseJsonl(text)) {
+    if (event?.type === 'thread.started' && typeof event.thread_id === 'string' && event.thread_id.length > 0) {
+      return event.thread_id;
+    }
+  }
+  throw new Error('Codex emitted no `thread.started` event, so there is no thread to register.');
+}
+
+/** @param {string} text @returns {string[]} every agent_message this turn produced */
+export function collectCodexAgentMessages(text) {
+  const messages = [];
+  for (const event of parseJsonl(text)) {
+    const item = event?.item;
+    if (event?.type === 'item.completed' && item?.type === 'agent_message' && typeof item.text === 'string') {
+      messages.push(item.text);
+    }
+  }
+  return messages;
+}
+
+/**
+ * The model-visible half of the Codex claim.
+ *
+ * The prompt that produced this reply names neither the sentinel nor either id
+ * — it only says "substitute the values from that envelope". So a reply
+ * carrying the exact `message_id` is proof the envelope reached the model. The
+ * sentinel alone is not: it is the only one of the three a model could in
+ * principle guess from context, which is why `message_id` is required too.
+ *
+ * @param {{jsonl: string, sentinel: string, messageId: string, deliveryId: string}} input
+ */
+export function assertCodexReply(input) {
+  const messages = collectCodexAgentMessages(input.jsonl);
+  if (messages.length === 0) throw new Error('Codex produced no agent message on the resume turn.');
+  const joined = messages.join('\n');
+  if (/\bNO_ENVELOPE\b/.test(joined)) {
+    throw new Error('Codex replied NO_ENVELOPE: the queued envelope was not visible to the model.');
+  }
+  const token = `CODEX_RECEIVED_${input.sentinel}`;
+  if (!joined.includes(token)) {
+    throw new Error(`Codex reply does not contain ${token}. Reply was: ${joined}`);
+  }
+  if (!joined.includes(input.messageId)) {
+    throw new Error(
+      `Codex reply does not quote message_id ${input.messageId}; without it the sentinel proves nothing. Reply was: ${joined}`,
+    );
+  }
+  if (!joined.includes(input.deliveryId)) {
+    throw new Error(`Codex reply does not quote delivery_id ${input.deliveryId}. Reply was: ${joined}`);
+  }
+  return joined;
+}
+
+/**
+ * `send` returning a message row is NOT delivery. Only
+ * `native_delivery.status === "native_accepted"` means a host took the frame.
+ *
+ * @param {unknown} result parsed `message send` stdout
+ * @param {string} expectedAdapterKind
+ */
+export function assertNativeAccepted(result, expectedAdapterKind) {
+  if (result === null || typeof result !== 'object') throw new Error('message send returned no JSON object.');
+  const record = /** @type {Record<string, unknown>} */ (result);
+  const native = record.native_delivery;
+  if (native === null || typeof native !== 'object') {
+    throw new Error('message send returned no native_delivery block, so nothing proves a host accepted it.');
+  }
+  const nativeRecord = /** @type {Record<string, unknown>} */ (native);
+  if (nativeRecord.status !== 'native_accepted') {
+    throw new Error(`native_delivery.status is ${JSON.stringify(nativeRecord.status)}, not "native_accepted".`);
+  }
+  if (nativeRecord.adapter_kind !== expectedAdapterKind) {
+    throw new Error(
+      `native_delivery.adapter_kind is ${JSON.stringify(nativeRecord.adapter_kind)}, not ${JSON.stringify(expectedAdapterKind)}.`,
+    );
+  }
+  if (typeof record.message_id !== 'string' || typeof record.delivery_id !== 'string') {
+    throw new Error('message send returned no message_id/delivery_id pair.');
+  }
+  return { messageId: record.message_id, deliveryId: record.delivery_id, native: nativeRecord };
+}
+
+/**
+ * The failure path. `recipient_unavailable` is a SHARED failure surface: the
+ * same string comes back when the sender cannot reach the router at all. So
+ * the caller must pair this with proof that the router is still answering and
+ * the durable row survived — see `runCodex`/`runClaude`, which assert both.
+ *
+ * @param {{status: number|null, stderr: string}} outcome
+ */
+export function assertRecipientUnavailable(outcome) {
+  if (outcome.status === 0) {
+    throw new Error('Sending to the stopped session succeeded; the exact-session target did not fail closed.');
+  }
+  if (!/recipient_unavailable/.test(outcome.stderr)) {
+    throw new Error(`Expected recipient_unavailable on stderr, got: ${outcome.stderr.trim() || '<empty>'}`);
+  }
+}
+
+/**
+ * @param {unknown} receipts parsed `message receipts` stdout
+ * @param {{messageId: string, actor: string}} expected
+ */
+export function findIntakeReceipt(receipts, expected) {
+  if (!Array.isArray(receipts)) return null;
+  return receipts.find((fact) => (
+    fact !== null && typeof fact === 'object'
+    && fact.receipt_kind === 'intake'
+    && fact.message_id === expected.messageId
+    && fact.actor === expected.actor
+  )) ?? null;
+}
+
+/**
+ * @param {unknown} receipts
+ * @param {{messageId: string, actor: string}} expected
+ */
+export function assertIntakeReceipt(receipts, expected) {
+  const found = findIntakeReceipt(receipts, expected);
+  if (!found) {
+    throw new Error(
+      `No intake receipt written by ${expected.actor} for message ${expected.messageId}. `
+      + 'host_accept alone proves the channel took the frame, not that the model read it.',
+    );
+  }
+  return found;
+}
+
+/**
+ * @param {unknown} discovered parsed `message discover` stdout
+ * @param {{hostKind?: string, sessionId?: string}} filter
+ */
+export function findLiveCards(discovered, filter = {}) {
+  const cards = discovered !== null && typeof discovered === 'object'
+    ? /** @type {Record<string, unknown>} */ (discovered).cards
+    : undefined;
+  if (!Array.isArray(cards)) return [];
+  return cards.filter((card) => (
+    card !== null && typeof card === 'object'
+    && (filter.hostKind === undefined || card.host_kind === filter.hostKind)
+    && (filter.sessionId === undefined || card.session_id === filter.sessionId)
+  ));
+}
+
+// ---------------------------------------------------------------------------
+// Everything below performs I/O and is exercised by the live run, not by tests.
+// ---------------------------------------------------------------------------
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+function dist(relative) {
+  return path.join(repoRoot, relative);
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    encoding: 'utf8',
+    maxBuffer: 16 * 1024 * 1024,
+    ...options,
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? (result.error ? String(result.error.message) : ''),
+  };
+}
+
+/** One live-journey run: owns the temp directory, the child processes and the report. */
+class Journey {
+  constructor(options) {
+    this.options = options;
+    this.steps = [];
+    this.limitations = [];
+    this.children = [];
+    this.dir = fs.mkdtempSync(path.join(os.tmpdir(), 'memesh-live-journey-'));
+    this.memeshDir = path.join(this.dir, 'memesh');
+    this.dbPath = path.join(this.memeshDir, 'knowledge-graph.db');
+    assertSafeMemeshPaths({ memeshDir: this.memeshDir, dbPath: this.dbPath, home: os.homedir() });
+    fs.mkdirSync(this.memeshDir, { recursive: true, mode: 0o700 });
+    this.env = { ...process.env, MEMESH_DIR: this.memeshDir, MEMESH_DB_PATH: this.dbPath };
+    this.socketPath = path.join(this.memeshDir, 'agent-router.sock');
+    /** Set by the accepted send; the fail-closed step fetches this exact row back. */
+    this.lastDurableMessageId = null;
+  }
+
+  step(name, evidence) {
+    this.steps.push({ step: this.steps.length + 1, name, status: 'PASS', at: new Date().toISOString(), ...evidence });
+    process.stdout.write(`  ok   ${name}\n`);
+  }
+
+  note(text) {
+    this.limitations.push(text);
+  }
+
+  say(text) {
+    process.stdout.write(`${text}\n`);
+  }
+
+  cli(args, options = {}) {
+    return run(process.execPath, [dist('dist/transports/cli/cli.js'), ...args], { env: this.env, ...options });
+  }
+
+  cliJson(args, options = {}) {
+    const outcome = this.cli(args, options);
+    if (outcome.status !== 0) {
+      throw new Error(`memesh ${args.join(' ')} exited ${outcome.status}: ${outcome.stderr.trim() || outcome.stdout.trim()}`);
+    }
+    try {
+      return JSON.parse(outcome.stdout);
+    } catch {
+      throw new Error(`memesh ${args.join(' ')} did not print JSON: ${outcome.stdout.slice(0, 400)}`);
+    }
+  }
+
+  discover() {
+    return this.cliJson(['message', 'discover', '--project', PROJECT]);
+  }
+
+  startRouter() {
+    const log = fs.openSync(path.join(this.dir, 'router.log'), 'a');
+    const child = spawn(process.execPath, [dist('dist/host-runtime/router.js')], {
+      env: this.env,
+      stdio: ['ignore', log, log],
+    });
+    this.children.push({ name: 'router', child });
+    return child;
+  }
+
+  async waitForRouterSocket(timeoutMs = 15_000) {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      if (fs.existsSync(this.socketPath)) return;
+      await sleep(200);
+    }
+    throw new Error(`The router did not create ${this.socketPath} within ${timeoutMs} ms.`);
+  }
+
+  /**
+   * Poll a predicate until it holds or the bound expires. `describe` is what
+   * the failure says, so it must name the thing that did not happen — never a
+   * generic timeout.
+   */
+  async until(describe, predicate, timeoutMs) {
+    const deadline = Date.now() + timeoutMs;
+    let last;
+    while (Date.now() < deadline) {
+      last = await predicate();
+      if (last) return last;
+      await sleep(1_000);
+    }
+    throw new Error(`${describe} (waited ${Math.round(timeoutMs / 1000)} s)`);
+  }
+
+  send(recipient, sentinel, idempotencyKey) {
+    const payload = JSON.stringify({
+      qa_sentinel: sentinel,
+      instruction: 'No action required. MeMesh owner-run live journey check; run no commands.',
+    });
+    return this.cli([
+      'message', 'send',
+      '--project', PROJECT,
+      '--sender', 'memesh-live-journey-harness',
+      '--recipient', recipient,
+      '--target-kind', 'session',
+      '--idempotency-key', idempotencyKey,
+      '--payload-stdin',
+      '--content-type', 'application/json',
+      '--privacy', 'private',
+    ], { input: payload });
+  }
+
+  sendAccepted(recipient, sentinel, idempotencyKey, adapterKind) {
+    const outcome = this.send(recipient, sentinel, idempotencyKey);
+    if (outcome.status !== 0) {
+      throw new Error(`message send exited ${outcome.status}: ${outcome.stderr.trim()}`);
+    }
+    return assertNativeAccepted(JSON.parse(outcome.stdout), adapterKind);
+  }
+
+  /**
+   * The fail-closed half. `recipient_unavailable` is returned both when the
+   * recipient session is gone AND when the sender cannot reach the router, so
+   * proving the intended cause needs two more facts in the same breath: the
+   * router still answers `discover`, and the durable payload is still fetchable.
+   */
+  provesFailClosed(recipient, sentinel) {
+    const outcome = this.send(recipient, sentinel, `${sentinel}-after-stop`);
+    assertRecipientUnavailable(outcome);
+    // Both of these are part of the same assertion, not decoration. Without
+    // them a dead router produces the identical `recipient_unavailable` string
+    // and this step would pass for the wrong reason.
+    const stillLive = this.discover();
+    if (!Array.isArray(stillLive?.cards)) {
+      throw new Error('The router stopped answering `discover`, so recipient_unavailable cannot be attributed to the recipient.');
+    }
+    const durable = this.cliJson([
+      'message', 'fetch',
+      '--project', PROJECT,
+      '--recipient', recipient,
+      '--target-kind', 'session',
+      '--message-id', this.lastDurableMessageId,
+    ]);
+    if (durable?.payload?.qa_sentinel !== sentinel) {
+      throw new Error(
+        `Durable recovery broke: fetching ${this.lastDurableMessageId} as the stopped session returned `
+        + `${JSON.stringify(durable?.payload?.qa_sentinel)} instead of ${JSON.stringify(sentinel)}.`,
+      );
+    }
+    return {
+      send_stderr: outcome.stderr.trim(),
+      router_still_answering_discover: true,
+      durable_message_still_fetchable_after_disconnect: this.lastDurableMessageId,
+    };
+  }
+
+  cleanup() {
+    for (const { child } of this.children) {
+      try {
+        child.kill('SIGTERM');
+      } catch {
+        // A child that already exited is the outcome we wanted.
+      }
+    }
+    if (this.options.keep) {
+      process.stdout.write(`\nKept working directory: ${this.dir}\n`);
+      return;
+    }
+    try {
+      fs.rmSync(this.dir, { recursive: true, force: true });
+    } catch (error) {
+      process.stderr.write(`Could not remove ${this.dir}: ${error.message}\n`);
+    }
+  }
+}
+
+async function runCodex(journey) {
+  const version = run('codex', ['--version']);
+  if (version.status !== 0) {
+    throw new Error('`codex` is not on PATH. This check needs the owner\'s Codex CLI installed.');
+  }
+  const login = run('codex', ['login', 'status']);
+  if (login.status !== 0) {
+    throw new Error('`codex login status` reports the owner is not logged in. Run `codex login` first.');
+  }
+  journey.step('codex preconditions', {
+    codex_version: version.stdout.trim(),
+    login_status_exit_code: login.status,
+  });
+
+  journey.startRouter();
+  await journey.waitForRouterSocket();
+  journey.step('router started against the temporary MEMESH_DIR', { socket_path: journey.socketPath });
+
+  const workspaceDir = path.join(journey.dir, 'codex-workspace');
+  fs.mkdirSync(workspaceDir, { recursive: true });
+  // realpath because the companion realpaths both its configured workspace and the
+  // SessionStart `cwd` before it will register; on macOS os.tmpdir() is a symlink.
+  const workspace = fs.realpathSync(workspaceDir);
+  const setup = journey.cliJson([
+    'agent', 'setup', 'codex-session',
+    '--project', PROJECT,
+    '--principal', 'codex-live-journey',
+    '--workspace', workspace,
+    '--json',
+  ]);
+  journey.step('agent setup codex-session', { config_path: setup.config_path, mode: setup.mode });
+
+  const first = run('codex', [
+    'exec', '--json', '--skip-git-repo-check', '--ignore-user-config',
+    '-s', 'read-only', '-C', workspace, 'Reply with exactly READY',
+  ], { timeout: 180_000 });
+  if (first.status !== 0) {
+    throw new Error(`codex exec exited ${first.status}: ${first.stderr.trim().slice(0, 600)}`);
+  }
+  fs.writeFileSync(path.join(journey.dir, 'codex-turn1.jsonl'), first.stdout);
+  const threadId = parseCodexThreadId(first.stdout);
+  journey.step('real Codex thread created', {
+    thread_id: threadId,
+    first_turn_reply: collectCodexAgentMessages(first.stdout).join(' | '),
+  });
+
+  // Registration is harness-driven, and that is a disclosed limitation rather
+  // than a shortcut: `codex exec --ignore-user-config` structurally prevents
+  // the packaged plugin SessionStart hook from running, so there is no way to
+  // reach the shipped registration path from a scripted exec turn. What runs
+  // here is the SHIPPED companion — dist/host-runtime/codex-session.js — fed
+  // the SessionStart payload the hook would have handed it.
+  const companionLog = fs.openSync(path.join(journey.dir, 'codex-session.log'), 'a');
+  const companion = spawn(process.execPath, [dist('dist/host-runtime/codex-session.js')], {
+    env: { ...journey.env, PLUGIN_ROOT: repoRoot },
+    stdio: ['pipe', companionLog, companionLog],
+  });
+  journey.children.push({ name: 'codex-session', child: companion });
+  companion.stdin.end(JSON.stringify({
+    hook_event_name: 'SessionStart',
+    source: 'startup',
+    session_id: threadId,
+    cwd: workspace,
+  }));
+  journey.note(
+    'The Codex registration half is harness-driven: `codex exec --ignore-user-config` cannot load the '
+    + 'packaged plugin SessionStart hook, so this check feeds the shipped dist/host-runtime/codex-session.js '
+    + 'the SessionStart payload that hook would have supplied. Dispatch -> `codex queue` -> model-visible '
+    + 'reply is product-path evidence; the registration step is not.',
+  );
+  const card = await journey.until(
+    'The Codex session never registered with the router',
+    () => journey.discover().cards.find((entry) => entry.session_id === threadId) ?? false,
+    60_000,
+  );
+  journey.step('Codex thread registered with the router', {
+    session_id: card.session_id,
+    principal_id: card.principal_id,
+    host_kind: card.host_kind,
+    generation: card.generation,
+  });
+
+  const sentinel = `codex-${randomUUID().slice(0, 8)}`;
+  const sent = journey.sendAccepted(threadId, sentinel, sentinel, 'codex-cli-queue');
+  journey.lastDurableMessageId = sent.messageId;
+  journey.step('exact-session send accepted by the codex-cli-queue adapter', {
+    sentinel,
+    message_id: sent.messageId,
+    delivery_id: sent.deliveryId,
+    native_delivery: sent.native,
+  });
+
+  // The prompt names neither the sentinel nor either id on purpose. The model
+  // can only produce them by reading the envelope Codex queued.
+  const prompt = 'If a MeMesh envelope containing a qa_sentinel field was injected into this session, '
+    + 'reply with exactly one line: CODEX_RECEIVED_<qa_sentinel> <message_id> <delivery_id>, substituting '
+    + 'the three values from that envelope. Otherwise reply with exactly: NO_ENVELOPE. '
+    + 'Do nothing else and run no commands.';
+  const second = run('codex', [
+    'exec', '--json', '--skip-git-repo-check', '--ignore-user-config',
+    '-s', 'read-only', '-C', workspace, 'resume', threadId, prompt,
+  ], { timeout: 180_000 });
+  if (second.status !== 0) {
+    throw new Error(`codex exec resume exited ${second.status}: ${second.stderr.trim().slice(0, 600)}`);
+  }
+  fs.writeFileSync(path.join(journey.dir, 'codex-turn2.jsonl'), second.stdout);
+  const reply = assertCodexReply({
+    jsonl: second.stdout,
+    sentinel,
+    messageId: sent.messageId,
+    deliveryId: sent.deliveryId,
+  });
+  journey.step('the Codex model quoted the envelope back (model-visible proof)', {
+    model_visible_evidence: reply,
+    proves: 'the reply carries message_id and delivery_id, neither of which appears in the prompt',
+  });
+
+  companion.kill('SIGTERM');
+  await journey.until(
+    'The router still lists the Codex session as live after its companion was stopped',
+    () => journey.discover().cards.every((entry) => entry.session_id !== threadId),
+    15_000,
+  );
+  journey.step('companion stopped and the session left the router directory', { session_id: threadId });
+
+  journey.step('a send to the stopped session fails closed and the durable row survives',
+    journey.provesFailClosed(threadId, sentinel));
+
+  journey.note(
+    '`recipient_unavailable` is a shared failure surface — the same string is returned when the SENDER '
+    + 'cannot reach the router. The final step therefore also records that `message discover` still '
+    + 'answered and that `message fetch` still returned the payload; that pairing is what attributes the '
+    + 'failure to the stopped recipient rather than to a dead router.',
+  );
+  journey.note(
+    'One throwaway Codex thread is created in the owner\'s Codex rollout store and one message is queued '
+    + 'into it. No Codex or MeMesh configuration outside the temporary directory is written, and no auth '
+    + 'file is read: the login precondition is the exit code of `codex login status`.',
+  );
+}
+
+async function runClaude(journey, waitMs) {
+  const version = run('claude', ['--version']);
+  if (version.status !== 0) {
+    throw new Error('`claude` is not on PATH. This check needs Claude Code installed.');
+  }
+  journey.step('claude precondition', { claude_version: version.stdout.trim() });
+
+  journey.startRouter();
+  await journey.waitForRouterSocket();
+  journey.step('router started against the temporary MEMESH_DIR', { socket_path: journey.socketPath });
+
+  const setup = journey.cliJson([
+    'agent', 'setup', 'claude',
+    '--project', PROJECT,
+    '--principal', 'claude-live-journey',
+    '--json',
+  ]);
+  journey.step('agent setup claude', { config_path: setup.config_path, mode: setup.mode });
+
+  const workspace = path.join(journey.dir, 'claude-workspace');
+  fs.mkdirSync(workspace, { recursive: true });
+  const mcpConfig = path.join(journey.dir, 'claude-mcp.json');
+  fs.writeFileSync(mcpConfig, `${JSON.stringify({
+    mcpServers: {
+      memesh: {
+        command: process.execPath,
+        args: [dist('dist/mcp/server.js')],
+        env: { MEMESH_DIR: journey.memeshDir, MEMESH_DB_PATH: journey.dbPath },
+      },
+      'memesh-channel': {
+        command: process.execPath,
+        args: [dist('dist/host-runtime/claude.js'), '--config', setup.config_path],
+        env: { MEMESH_DIR: journey.memeshDir, MEMESH_DB_PATH: journey.dbPath },
+      },
+    },
+  }, null, 2)}\n`, { mode: 0o600 });
+
+  const launch = `cd ${JSON.stringify(workspace)} && claude --dangerously-load-development-channels `
+    + `server:memesh-channel --mcp-config ${JSON.stringify(mcpConfig)} --strict-mcp-config`;
+  journey.say([
+    '',
+    '  ACTION REQUIRED — in a second terminal, run exactly:',
+    '',
+    `    ${launch}`,
+    '',
+    '  Then TYPE NOTHING. Leave the session sitting at its prompt. This check is',
+    '  measuring what the session does on its own when an envelope arrives.',
+    '',
+  ].join('\n'));
+
+  const card = await journey.until(
+    'No Claude channel session registered with the router. Was the session launched with '
+    + '--dangerously-load-development-channels and the local-development warning confirmed?',
+    () => findLiveCards(journey.discover(), { hostKind: 'claude' })[0] ?? false,
+    waitMs,
+  );
+  journey.step('interactive Claude session registered on the channel', {
+    session_id: card.session_id,
+    principal_id: card.principal_id,
+    host_kind: card.host_kind,
+    generation: card.generation,
+    launch_command: launch,
+    operator_prompt: 'none-instructed',
+  });
+
+  const sentinel = `claude-${randomUUID().slice(0, 8)}`;
+  const sent = journey.sendAccepted(card.session_id, sentinel, sentinel, 'claude-channel');
+  journey.lastDurableMessageId = sent.messageId;
+  journey.step('exact-session send accepted by the claude-channel adapter', {
+    sentinel,
+    message_id: sent.messageId,
+    delivery_id: sent.deliveryId,
+    native_delivery: sent.native,
+  });
+
+  journey.say('  Waiting for the session\'s own model to call `intake` on that message. Still type nothing.\n');
+  const intake = await journey.until(
+    `The Claude session never recorded an intake receipt for ${sent.messageId}. host_accept proves only that `
+    + 'the channel took the frame, not that the model saw it (this is exactly the print-mode failure of issue #275).',
+    () => findIntakeReceipt(journey.cliJson([
+      'message', 'receipts',
+      '--project', PROJECT,
+      '--recipient', card.session_id,
+      '--message-id', sent.messageId,
+    ]), { messageId: sent.messageId, actor: card.session_id }),
+    waitMs,
+  );
+  journey.step('the Claude model called intake itself (model-visible proof)', {
+    model_visible_evidence: { receipt_id: intake.receipt_id, receipt_kind: intake.receipt_kind, actor: intake.actor },
+    proves: 'the intake receipt was written by the recipient session, not by this harness',
+  });
+
+  journey.say('\n  ACTION REQUIRED — exit that Claude session now (Ctrl-D or /exit).\n');
+  await journey.until(
+    'The Claude session is still registered with the router. Exit the interactive session to continue.',
+    () => findLiveCards(journey.discover(), { sessionId: card.session_id }).length === 0,
+    waitMs,
+  );
+  journey.step('session disconnected and left the router directory', { session_id: card.session_id });
+
+  journey.step('a send to the stopped session fails closed and the durable row survives',
+    journey.provesFailClosed(card.session_id, sentinel));
+
+  journey.note(
+    'The operator is instructed to type nothing, but this check cannot observe whether anything was typed. '
+    + 'The intake receipt proves the model called `intake` in that session; it does not prove it did so unprompted.',
+  );
+  journey.note(
+    'The intake receipt is matched on its `actor`, which `intake` sets from the caller\'s `recipient`. The model '
+    + 'must therefore intake under its own session id; an intake recorded against the principal id instead would '
+    + 'not match and this check would report no model-visible proof.',
+  );
+  journey.note(
+    'Print mode (`claude -p`) is not supported and is not exercised: a print-mode session does not surface '
+    + 'memesh-channel notifications to the model even when the channel host reports the frame accepted '
+    + '(issue #275), so it cannot produce the model-visible proof this check requires.',
+  );
+  journey.note(
+    '`recipient_unavailable` is a shared failure surface — the same string is returned when the SENDER '
+    + 'cannot reach the router. The final step therefore also records that `message discover` still '
+    + 'answered and that `message fetch` still returned the payload; that pairing is what attributes the '
+    + 'failure to the stopped recipient rather than to a dead router.',
+  );
+}
+
+async function main() {
+  let options;
+  try {
+    options = parseArgs(process.argv.slice(2));
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`);
+    process.exit(2);
+  }
+  if (options.help) {
+    process.stdout.write(`${helpText()}\n`);
+    return;
+  }
+
+  assertDistPresent(repoRoot);
+  const revision = run('git', ['rev-parse', 'HEAD'], { cwd: repoRoot }).stdout.trim();
+  if (revision.length === 0) throw new Error('Could not read the repository revision; the report would name no code.');
+  const journey = new Journey(options);
+  const startedAt = new Date().toISOString();
+  let failure = null;
+
+  process.stdout.write(`memesh live journey — host=${options.host} revision=${revision}\n`);
+  process.stdout.write(`  MEMESH_DIR=${journey.memeshDir}\n\n`);
+
+  try {
+    if (options.host === 'codex') await runCodex(journey);
+    else await runClaude(journey, options.waitMs);
+  } catch (error) {
+    failure = error instanceof Error ? error.message : String(error);
+    journey.steps.push({
+      step: journey.steps.length + 1,
+      name: 'FAILED',
+      status: 'FAIL',
+      at: new Date().toISOString(),
+      error: failure,
+    });
+    process.stderr.write(`  FAIL ${failure}\n`);
+  }
+
+  const report = {
+    schema_version: 'memesh-live-journey/v1',
+    revision,
+    host: options.host,
+    project: PROJECT,
+    started_at: startedAt,
+    finished_at: new Date().toISOString(),
+    verdict: failure === null ? 'PASS' : 'FAIL',
+    memesh_dir: journey.memeshDir,
+    steps: journey.steps,
+    limitations: journey.limitations,
+    ...(failure === null ? {} : { error: failure }),
+  };
+  if (options.out) {
+    const target = path.resolve(options.out);
+    fs.writeFileSync(target, `${JSON.stringify(report, null, 2)}\n`, { mode: 0o600 });
+    process.stdout.write(`\nReport: ${target}\n`);
+  } else {
+    process.stdout.write(`\n${JSON.stringify(report, null, 2)}\n`);
+  }
+  journey.cleanup();
+  process.exit(failure === null ? 0 : 1);
+}
+
+if (process.argv[1] && fs.realpathSync(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exit(1);
+  });
+}

--- a/scripts/qa/live-journey.mjs
+++ b/scripts/qa/live-journey.mjs
@@ -18,9 +18,9 @@
 // model-visible surfaces:
 //
 //   codex  — the next turn's reply must quote the `message_id` and
-//            `delivery_id` from the injected envelope. Neither id exists
-//            anywhere in the prompt, so a reply containing them cannot have
-//            been produced without reading the envelope.
+//            `delivery_id` from the injected envelope, AND that turn must have
+//            run no commands. Both halves are needed: the ids are only
+//            unforgeable if the model could not have read them off disk.
 //   claude — the session's own model must call `intake` on that message. The
 //            intake receipt is written by the recipient session, not by this
 //            harness, so its presence is model-visible proof.
@@ -28,23 +28,42 @@
 // This cannot run in CI. It needs the owner's Codex login, or a human at an
 // interactive Claude session. It is deliberately a script under `scripts/qa/`
 // and NOT a file under `tests/` — a check that cannot run unattended must not
-// sit where an unattended runner will find it. The parts that CAN be checked
-// without a live host (argument parsing, the path refusal, every assertion
-// applied to recorded fixtures) are exported from here and exercised by
-// `tests/qa/live-journey.test.ts`.
+// sit where an unattended runner will find it, and it refuses outright when
+// `CI` is set. The parts that CAN be checked without a live host (argument
+// parsing, every refusal, every assertion applied to recorded fixtures) are
+// exported from here and exercised by `tests/qa/live-journey.test.ts`.
 //
-// SAFETY BOUNDARY
+// SAFETY BOUNDARY, AND WHERE IT STOPS
 //
 // Everything MeMesh writes goes to a fresh `mktemp` MEMESH_DIR that is deleted
-// on exit. The script refuses to run against `$HOME/.memesh`. It reads no auth
-// files: the Codex precondition is `codex login status`, whose exit code is the
-// answer. It writes no host configuration outside the temp directory.
+// on exit. The script refuses to run if that directory would resolve inside the
+// owner's `~/.memesh` — checked on REAL paths, before anything is created, so a
+// symlinked TMPDIR cannot get past it. It reads no auth file: the Codex
+// precondition is the exit code of `codex login status`.
 //
-// The one thing it touches outside the temp directory is the owner's Codex
-// rollout store: `codex exec` creates one throwaway thread there and
-// `codex queue` appends one message to it. That is the product path under
-// test, it is session state rather than configuration, and it is disclosed in
-// the report's `limitations`.
+// Two things are outside that boundary and are declared in every report:
+//
+//   1. `codex exec` creates one throwaway thread in the owner's Codex rollout
+//      store and `codex queue` appends one message to it. That is the product
+//      path under test, and it is session state rather than configuration.
+//   2. The interactive Claude session the operator launches is NOT isolated
+//      from the owner's installed plugins. The printed command passes
+//      `--setting-sources ""` so no user/project/local settings file is loaded,
+//      but whether that also excludes plugin-provided hooks and MCP servers is
+//      NOT verified here. A plugin hook that runs in that session inherits no
+//      MEMESH_DIR and would therefore write the owner's real `~/.memesh`. The
+//      operator is told to confirm with `/hooks` and `/mcp` before proceeding.
+//
+// SHUTDOWN ORDER IS LOAD-BEARING
+//
+// `src/host-runtime/router-client.ts` makes a connected host that sees the
+// router socket disappear spawn a DETACHED packaged router, inheriting its own
+// environment — including this check's `MEMESH_DIR` — and `router.ts` recreates
+// the data directory on start. Killing the router while a host is still
+// connected therefore resurrects the temp directory as an orphan owned by
+// nobody. `Journey.shutdown()` unwinds in the only safe order: companion, then
+// live sessions, then router, then the directory; and if a session is still
+// connected it keeps the directory rather than racing that spawn.
 
 import fs from 'node:fs';
 import os from 'node:os';
@@ -55,6 +74,17 @@ import { fileURLToPath } from 'node:url';
 
 export const PROJECT = 'memesh-live-journey';
 export const DEFAULT_WAIT_MS = 300_000;
+
+/** AF_UNIX `sun_path` is 104 bytes on macOS; the router's socket must fit. */
+export const MAX_SOCKET_PATH_BYTES = 103;
+
+/**
+ * `codex exec --json` item types this check tolerates on the proof turn.
+ * An allowlist, not a denylist: the whole point of the turn is that the model
+ * did nothing but answer, so an unrecognised item type must fail loudly rather
+ * than be assumed harmless.
+ */
+export const ALLOWED_CODEX_ITEM_TYPES = new Set(['agent_message', 'error']);
 
 /** dist artefacts this check runs. Missing any of them is a refusal, not a skip. */
 export const REQUIRED_DIST = [
@@ -73,6 +103,9 @@ export function helpText() {
     '  npm run qa:live-journey -- --host codex  [--out report.json] [--keep] [--wait-ms N]',
     '  npm run qa:live-journey -- --host claude [--out report.json] [--keep] [--wait-ms N]',
     '',
+    'Verified invocation on macOS (the socket path must fit AF_UNIX sun_path):',
+    '  TMPDIR=/private/tmp npm run qa:live-journey -- --host codex --out report.json',
+    '',
     'Options:',
     '  --host <codex|claude>  Which live path to exercise. Required.',
     '  --out <path>           Write the JSON evidence report here (also written on failure).',
@@ -83,14 +116,26 @@ export function helpText() {
     '',
     'Preconditions:',
     '  codex   — `codex` on PATH and `codex login status` reporting a logged-in owner.',
-    '            Costs one or two small Codex turns. Creates one throwaway Codex thread.',
+    '            Costs one or two small Codex turns. Creates one throwaway Codex thread',
+    '            in the owner\'s Codex rollout store.',
     '  claude  — `claude` on PATH, and the owner launching one interactive session with',
     '            the command this script prints. Print mode (`claude -p`) is NOT supported:',
     '            a print-mode session does not surface memesh-channel notifications to the',
     '            model even when the channel host reports the frame accepted (issue #275),',
     '            so it can never produce the model-visible proof this check requires.',
     '',
-    'This check never runs in CI, never touches $HOME/.memesh, and reads no auth files.',
+    'Refuses to run when CI is set, when dist/ is not built, or when the temporary',
+    'MEMESH_DIR would resolve inside the owner\'s ~/.memesh.',
+    '',
+    'Two things sit OUTSIDE the temporary-directory isolation, and the report says so:',
+    '  - Codex registration is harness-driven. The shipped codex-session companion is fed',
+    '    the SessionStart payload the packaged plugin hook would have supplied; only',
+    '    dispatch -> `codex queue` -> model-visible reply is product-path evidence.',
+    '  - The interactive Claude session you launch runs with the owner\'s installed plugins.',
+    '    The printed command passes --setting-sources "" so no settings file is loaded, but',
+    '    that is NOT verified to exclude plugin-provided hooks or MCP servers. A plugin hook',
+    '    running there inherits no MEMESH_DIR and would write the REAL ~/.memesh. Confirm',
+    '    with /hooks and /mcp that only the two servers from --mcp-config are loaded.',
   ].join('\n');
 }
 
@@ -129,23 +174,80 @@ export function parseArgs(argv) {
 }
 
 /**
- * Refuse to run against the owner's real knowledge graph. A live check writes
- * messages, registers hosts and then deletes its whole data directory; pointed
- * at `~/.memesh` that is data loss, not a check.
+ * "Never runs in CI" is worth nothing as prose. Both checks need either the
+ * owner's Codex login or a person at a terminal, so an automated runner that
+ * reaches this line is already misconfigured.
  *
- * @param {{memeshDir: string, dbPath: string, home: string}} input
+ * @param {Record<string, string|undefined>} env
  */
-export function assertSafeMemeshPaths(input) {
-  const home = path.resolve(input.home);
-  const forbidden = path.join(home, '.memesh');
-  for (const [label, candidate] of [['MEMESH_DIR', input.memeshDir], ['MEMESH_DB_PATH', input.dbPath]]) {
-    const resolved = path.resolve(candidate);
+export function assertNotCi(env) {
+  if (env.CI !== undefined && env.CI !== '' && env.CI !== 'false' && env.CI !== '0') {
+    throw new Error(
+      'Refusing to run: CI is set. These checks need the owner\'s Codex login or a person at an '
+      + 'interactive Claude session, and must never be wired into an automated pipeline.',
+    );
+  }
+}
+
+/**
+ * Refuse to run against the owner's real knowledge graph.
+ *
+ * This compares REAL paths, and the caller runs it BEFORE creating anything: a
+ * `path.resolve` prefix test alone is satisfied by a TMPDIR that is a symlink
+ * into `~/.memesh`, which is precisely the case that would delete real memory.
+ *
+ * @param {{candidates: Record<string, string>, home: string, realpath: (p: string) => string}} input
+ */
+export function assertOutsideOwnerMemesh(input) {
+  const forbidden = input.realpath(path.join(path.resolve(input.home), '.memesh'));
+  for (const [label, candidate] of Object.entries(input.candidates)) {
+    const resolved = input.realpath(candidate);
     if (resolved === forbidden || resolved.startsWith(`${forbidden}${path.sep}`)) {
       throw new Error(
         `Refusing to run: ${label} resolves to ${resolved}, inside the owner's ${forbidden}. `
         + 'This check creates and deletes its own data directory and must never be pointed at real memory.',
       );
     }
+  }
+}
+
+/**
+ * Resolve as far as the filesystem allows, then normalise the rest. A path that
+ * does not exist yet (the temp directory before `mkdtemp`) still has to be
+ * judged, and its nearest existing ancestor is what a symlink would hide in.
+ *
+ * @param {string} candidate
+ */
+export function realpathAsFarAsPossible(candidate) {
+  let current = path.resolve(candidate);
+  const tail = [];
+  for (;;) {
+    try {
+      return path.join(fs.realpathSync(current), ...tail);
+    } catch {
+      const parent = path.dirname(current);
+      if (parent === current) return path.resolve(candidate);
+      tail.unshift(path.basename(current));
+      current = parent;
+    }
+  }
+}
+
+/**
+ * The router's Unix socket lives beside the database. macOS caps `sun_path` at
+ * 104 bytes, and the default `os.tmpdir()` on macOS is already ~50 of them, so
+ * a long report path or a deep TMPDIR silently produces an unbindable socket.
+ * Catch it here, with the fix, instead of as a router that never starts.
+ *
+ * @param {string} socketPath
+ */
+export function assertSocketPathFits(socketPath) {
+  const bytes = Buffer.byteLength(socketPath, 'utf8');
+  if (bytes > MAX_SOCKET_PATH_BYTES) {
+    throw new Error(
+      `Refusing to run: the router socket path is ${bytes} bytes (${socketPath}), over the ${MAX_SOCKET_PATH_BYTES}-byte `
+      + 'AF_UNIX limit. Re-run with a shorter temporary root, e.g. TMPDIR=/private/tmp.',
+    );
   }
 }
 
@@ -160,6 +262,17 @@ export function assertDistPresent(repoRoot, exists = (file) => fs.existsSync(fil
       `Refusing to run: this repository has no built dist/ for ${missing.join(', ')}. Run \`npm run build\` first.`,
     );
   }
+}
+
+/**
+ * A report that names a revision is claiming the code it exercised is that
+ * revision. `dist/` is what actually ran, so if any of it predates the newest
+ * source file the report must say so rather than imply a rebuild happened.
+ *
+ * @param {{newestSrcMs: number, oldestDistMs: number}} input
+ */
+export function isDistStale(input) {
+  return input.oldestDistMs < input.newestSrcMs;
 }
 
 /** @param {string} text JSONL as emitted by `codex exec --json` */
@@ -188,7 +301,7 @@ export function parseCodexThreadId(text) {
   throw new Error('Codex emitted no `thread.started` event, so there is no thread to register.');
 }
 
-/** @param {string} text @returns {string[]} every agent_message this turn produced */
+/** @param {string} text @returns {string[]} every agent message in the turn */
 export function collectCodexAgentMessages(text) {
   const messages = [];
   for (const event of parseJsonl(text)) {
@@ -201,17 +314,47 @@ export function collectCodexAgentMessages(text) {
 }
 
 /**
+ * The half of the Codex proof that is easy to forget.
+ *
+ * `message_id` is only unforgeable if the model had no other way to obtain it,
+ * and a `read-only` Codex sandbox still permits reads: a single `cat` of the
+ * temporary database or of this run's own turn-1 log would hand the model every
+ * id in it. So the proof turn must have produced nothing but an answer. Any
+ * command execution, tool call, or unrecognised item type fails the check.
+ *
+ * @param {string} text turn JSONL
+ */
+export function assertCodexRanNoCommands(text) {
+  const offending = [];
+  for (const event of parseJsonl(text)) {
+    if (event?.type !== 'item.completed') continue;
+    const kind = event.item?.type;
+    if (typeof kind !== 'string' || !ALLOWED_CODEX_ITEM_TYPES.has(kind)) {
+      offending.push(typeof kind === 'string' ? kind : '<unknown>');
+    }
+  }
+  if (offending.length > 0) {
+    throw new Error(
+      `The Codex proof turn produced non-answer items (${[...new Set(offending)].join(', ')}). `
+      + 'The reply cannot be treated as model-visible proof, because a turn that runs commands could have '
+      + 'read the identifiers off disk instead of out of the envelope.',
+    );
+  }
+}
+
+/**
  * The model-visible half of the Codex claim.
  *
  * The prompt that produced this reply names neither the sentinel nor either id
- * — it only says "substitute the values from that envelope". So a reply
- * carrying the exact `message_id` is proof the envelope reached the model. The
- * sentinel alone is not: it is the only one of the three a model could in
- * principle guess from context, which is why `message_id` is required too.
+ * — it only says "substitute the values from that envelope". Paired with
+ * `assertCodexRanNoCommands`, a reply carrying the exact `message_id` is proof
+ * the envelope reached the model. The sentinel alone is not: it is the only one
+ * of the three a model could in principle guess, which is why the ids matter.
  *
  * @param {{jsonl: string, sentinel: string, messageId: string, deliveryId: string}} input
  */
 export function assertCodexReply(input) {
+  assertCodexRanNoCommands(input.jsonl);
   const messages = collectCodexAgentMessages(input.jsonl);
   if (messages.length === 0) throw new Error('Codex produced no agent message on the resume turn.');
   const joined = messages.join('\n');
@@ -235,12 +378,14 @@ export function assertCodexReply(input) {
 
 /**
  * `send` returning a message row is NOT delivery. Only
- * `native_delivery.status === "native_accepted"` means a host took the frame.
+ * `native_delivery.status === "native_accepted"` means a host took the frame —
+ * and the receipt has to describe the delivery and the session we addressed,
+ * or it is a receipt for something else.
  *
  * @param {unknown} result parsed `message send` stdout
- * @param {string} expectedAdapterKind
+ * @param {{adapterKind: string, recipient: string}} expected
  */
-export function assertNativeAccepted(result, expectedAdapterKind) {
+export function assertNativeAccepted(result, expected) {
   if (result === null || typeof result !== 'object') throw new Error('message send returned no JSON object.');
   const record = /** @type {Record<string, unknown>} */ (result);
   const native = record.native_delivery;
@@ -251,26 +396,53 @@ export function assertNativeAccepted(result, expectedAdapterKind) {
   if (nativeRecord.status !== 'native_accepted') {
     throw new Error(`native_delivery.status is ${JSON.stringify(nativeRecord.status)}, not "native_accepted".`);
   }
-  if (nativeRecord.adapter_kind !== expectedAdapterKind) {
+  if (nativeRecord.adapter_kind !== expected.adapterKind) {
     throw new Error(
-      `native_delivery.adapter_kind is ${JSON.stringify(nativeRecord.adapter_kind)}, not ${JSON.stringify(expectedAdapterKind)}.`,
+      `native_delivery.adapter_kind is ${JSON.stringify(nativeRecord.adapter_kind)}, not ${JSON.stringify(expected.adapterKind)}.`,
     );
   }
   if (typeof record.message_id !== 'string' || typeof record.delivery_id !== 'string') {
     throw new Error('message send returned no message_id/delivery_id pair.');
+  }
+  if (nativeRecord.delivery_id !== record.delivery_id) {
+    throw new Error(
+      `native_delivery.delivery_id ${JSON.stringify(nativeRecord.delivery_id)} does not match the message's `
+      + `delivery_id ${JSON.stringify(record.delivery_id)}; the acceptance describes a different delivery.`,
+    );
+  }
+  if (record.recipient !== expected.recipient) {
+    throw new Error(
+      `message send reports recipient ${JSON.stringify(record.recipient)}, not ${JSON.stringify(expected.recipient)}.`,
+    );
+  }
+  const receipt = nativeRecord.receipt;
+  const threadId = receipt !== null && typeof receipt === 'object'
+    ? /** @type {Record<string, unknown>} */ (receipt).thread_id
+    : undefined;
+  if (threadId !== undefined && threadId !== expected.recipient) {
+    throw new Error(
+      `the host receipt names thread ${JSON.stringify(threadId)}, not the session we addressed `
+      + `(${JSON.stringify(expected.recipient)}).`,
+    );
   }
   return { messageId: record.message_id, deliveryId: record.delivery_id, native: nativeRecord };
 }
 
 /**
  * The failure path. `recipient_unavailable` is a SHARED failure surface: the
- * same string comes back when the sender cannot reach the router at all. So
- * the caller must pair this with proof that the router is still answering and
- * the durable row survived — see `runCodex`/`runClaude`, which assert both.
+ * same string comes back when the sender cannot reach the router. So the caller
+ * must pair this with proof that the router is still answering and the durable
+ * row survived — see `Journey.provesFailClosed`, which asserts both.
+ *
+ * A null status means the CLI was killed (timeout, signal) rather than having
+ * decided anything, and must not be read as a fail-closed result.
  *
  * @param {{status: number|null, stderr: string}} outcome
  */
 export function assertRecipientUnavailable(outcome) {
+  if (outcome.status === null) {
+    throw new Error('The send process was killed before it produced an exit status; that is not a fail-closed result.');
+  }
   if (outcome.status === 0) {
     throw new Error('Sending to the stopped session succeeded; the exact-session target did not fail closed.');
   }
@@ -324,8 +496,56 @@ export function findLiveCards(discovered, filter = {}) {
   ));
 }
 
+/**
+ * Wait for one live host session to leave the router directory.
+ *
+ * This is the decision that keeps a shutdown from creating an orphan, so it is
+ * separated from the I/O it drives and tested on both outcomes. A host that is
+ * still connected when the router dies starts a detached replacement pointing
+ * at the temporary directory, so "still there after the bound" must be
+ * answerable, not merely unlikely.
+ *
+ * @param {{
+ *   sessionId: string|null,
+ *   isGone: (sessionId: string) => boolean,
+ *   waitMs: number,
+ *   now: () => number,
+ *   sleep: (ms: number) => Promise<void>,
+ *   announce: (text: string) => void,
+ * }} input
+ * @returns {Promise<boolean>} true when nothing is connected any more
+ */
+export async function awaitSessionDisconnect(input) {
+  if (input.sessionId === null) return true;
+  const deadline = input.now() + input.waitMs;
+  let announced = false;
+  while (!input.isGone(input.sessionId)) {
+    if (input.now() >= deadline) return false;
+    if (!announced) {
+      input.announce(
+        'Waiting for the Claude session to disconnect before stopping the router.\n'
+        + 'Exit the Claude session first (Ctrl-D or /exit) — a session that outlives the router\n'
+        + 'will start a detached replacement pointing at this temporary directory.',
+      );
+      announced = true;
+    }
+    await input.sleep(1_000);
+  }
+  return true;
+}
+
+/**
+ * Deleting a directory a live host is about to recreate is worse than leaving
+ * it: the recreated copy is owned by nobody and named in no report.
+ *
+ * @param {{keep: boolean, keptForSafety: boolean}} input
+ */
+export function shouldRemoveWorkingDirectories(input) {
+  return !input.keep && !input.keptForSafety;
+}
+
 // ---------------------------------------------------------------------------
-// Everything below performs I/O and is exercised by the live run, not by tests.
+// Everything below performs I/O. The live run exercises it; the tests do not.
 // ---------------------------------------------------------------------------
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
@@ -351,22 +571,78 @@ function run(command, args, options = {}) {
   };
 }
 
-/** One live-journey run: owns the temp directory, the child processes and the report. */
+/** Newest mtime under a directory tree, in ms. Used for the dist-staleness note. */
+function newestMtimeMs(root) {
+  let newest = 0;
+  const walk = (directory) => {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      const full = path.join(directory, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.isFile()) newest = Math.max(newest, fs.statSync(full).mtimeMs);
+    }
+  };
+  walk(root);
+  return newest;
+}
+
+/** Wait for a child to exit, bounded, escalating to SIGKILL. Never throws. */
+async function stopChild(child, timeoutMs = 10_000) {
+  if (!child || child.exitCode !== null || child.signalCode !== null) return 'already-exited';
+  const exited = new Promise((resolve) => child.once('exit', () => resolve('exited')));
+  try {
+    child.kill('SIGTERM');
+  } catch {
+    return 'already-exited';
+  }
+  const outcome = await Promise.race([exited, sleep(timeoutMs).then(() => 'timeout')]);
+  if (outcome !== 'timeout') return 'exited';
+  try {
+    child.kill('SIGKILL');
+  } catch {
+    // Nothing left to kill is the outcome we wanted.
+  }
+  await Promise.race([exited, sleep(2_000)]);
+  return 'killed';
+}
+
+/** One live-journey run: owns the temp directories, the child processes and the report. */
 class Journey {
   constructor(options) {
     this.options = options;
     this.steps = [];
     this.limitations = [];
-    this.children = [];
-    this.dir = fs.mkdtempSync(path.join(os.tmpdir(), 'memesh-live-journey-'));
+    this.router = null;
+    this.companion = null;
+    this.liveSessionId = null;
+    this.lastDurableMessageId = null;
+    this.keptForSafety = false;
+
+    // Judge the temporary root on REAL paths BEFORE creating anything: a
+    // symlinked TMPDIR is exactly the case a resolve-only prefix test misses.
+    const tmpRoot = os.tmpdir();
+    assertOutsideOwnerMemesh({
+      candidates: { TMPDIR: tmpRoot },
+      home: os.homedir(),
+      realpath: realpathAsFarAsPossible,
+    });
+
+    this.dir = fs.realpathSync(fs.mkdtempSync(path.join(tmpRoot, 'memesh-lj-')));
     this.memeshDir = path.join(this.dir, 'memesh');
     this.dbPath = path.join(this.memeshDir, 'knowledge-graph.db');
-    assertSafeMemeshPaths({ memeshDir: this.memeshDir, dbPath: this.dbPath, home: os.homedir() });
+    this.socketPath = path.join(this.memeshDir, 'agent-router.sock');
+    assertOutsideOwnerMemesh({
+      candidates: { MEMESH_DIR: this.memeshDir, MEMESH_DB_PATH: this.dbPath },
+      home: os.homedir(),
+      realpath: realpathAsFarAsPossible,
+    });
+    assertSocketPathFits(this.socketPath);
     fs.mkdirSync(this.memeshDir, { recursive: true, mode: 0o700 });
     this.env = { ...process.env, MEMESH_DIR: this.memeshDir, MEMESH_DB_PATH: this.dbPath };
-    this.socketPath = path.join(this.memeshDir, 'agent-router.sock');
-    /** Set by the accepted send; the fail-closed step fetches this exact row back. */
-    this.lastDurableMessageId = null;
+
+    // The Codex workspace is a SEPARATE temporary tree. Keeping it out of
+    // `this.dir` means the database and this run's own logs are not sitting one
+    // `..` away from the directory the model is pointed at.
+    this.workspace = null;
   }
 
   step(name, evidence) {
@@ -402,14 +678,27 @@ class Journey {
     return this.cliJson(['message', 'discover', '--project', PROJECT]);
   }
 
+  /** True when nothing is registered for `sessionId` any more. Never throws. */
+  sessionGone(sessionId) {
+    try {
+      return findLiveCards(this.discover(), { sessionId }).length === 0;
+    } catch {
+      return false;
+    }
+  }
+
+  createCodexWorkspace() {
+    this.workspace = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'memesh-lj-ws-')));
+    return this.workspace;
+  }
+
   startRouter() {
     const log = fs.openSync(path.join(this.dir, 'router.log'), 'a');
-    const child = spawn(process.execPath, [dist('dist/host-runtime/router.js')], {
+    this.router = spawn(process.execPath, [dist('dist/host-runtime/router.js')], {
       env: this.env,
       stdio: ['ignore', log, log],
     });
-    this.children.push({ name: 'router', child });
-    return child;
+    return this.router;
   }
 
   async waitForRouterSocket(timeoutMs = 15_000) {
@@ -428,10 +717,9 @@ class Journey {
    */
   async until(describe, predicate, timeoutMs) {
     const deadline = Date.now() + timeoutMs;
-    let last;
     while (Date.now() < deadline) {
-      last = await predicate();
-      if (last) return last;
+      const outcome = await predicate();
+      if (outcome) return outcome;
       await sleep(1_000);
     }
     throw new Error(`${describe} (waited ${Math.round(timeoutMs / 1000)} s)`);
@@ -460,7 +748,7 @@ class Journey {
     if (outcome.status !== 0) {
       throw new Error(`message send exited ${outcome.status}: ${outcome.stderr.trim()}`);
     }
-    return assertNativeAccepted(JSON.parse(outcome.stdout), adapterKind);
+    return assertNativeAccepted(JSON.parse(outcome.stdout), { adapterKind, recipient });
   }
 
   /**
@@ -472,9 +760,6 @@ class Journey {
   provesFailClosed(recipient, sentinel) {
     const outcome = this.send(recipient, sentinel, `${sentinel}-after-stop`);
     assertRecipientUnavailable(outcome);
-    // Both of these are part of the same assertion, not decoration. Without
-    // them a dead router produces the identical `recipient_unavailable` string
-    // and this step would pass for the wrong reason.
     const stillLive = this.discover();
     if (!Array.isArray(stillLive?.cards)) {
       throw new Error('The router stopped answering `discover`, so recipient_unavailable cannot be attributed to the recipient.');
@@ -499,22 +784,53 @@ class Journey {
     };
   }
 
-  cleanup() {
-    for (const { child } of this.children) {
-      try {
-        child.kill('SIGTERM');
-      } catch {
-        // A child that already exited is the outcome we wanted.
-      }
+  /**
+   * Unwind in the only order that cannot leave an orphan.
+   *
+   * A connected host whose router socket vanishes spawns a DETACHED packaged
+   * router with this run's MEMESH_DIR in its environment, and the router
+   * recreates that directory on start. So: companion first, then any live
+   * session, then the router, then the directory — and if a session is still
+   * connected after the bounded wait, keep the directory rather than delete a
+   * tree something is about to recreate. Runs on every exit path.
+   */
+  async shutdown(waitMs = 30_000) {
+    if (this.shuttingDown) return;
+    this.shuttingDown = true;
+
+    await stopChild(this.companion);
+
+    const routerAlive = this.router !== null && this.router.exitCode === null;
+    const disconnected = await awaitSessionDisconnect({
+      sessionId: routerAlive ? this.liveSessionId : null,
+      isGone: (sessionId) => this.sessionGone(sessionId),
+      waitMs,
+      now: Date.now,
+      sleep,
+      announce: (text) => this.say(`\n  ${text.split('\n').join('\n  ')}\n`),
+    });
+    if (!disconnected) {
+      this.keptForSafety = true;
+      process.stderr.write(
+        `\n  WARNING: ${this.liveSessionId} is still connected. Keeping ${this.dir} rather than deleting a\n`
+        + '  directory a live host is about to recreate. Exit that session, then remove it by hand.\n',
+      );
     }
-    if (this.options.keep) {
+
+    await stopChild(this.router);
+
+    if (!shouldRemoveWorkingDirectories({ keep: this.options.keep, keptForSafety: this.keptForSafety })) {
       process.stdout.write(`\nKept working directory: ${this.dir}\n`);
+      if (this.workspace) process.stdout.write(`Kept Codex workspace:   ${this.workspace}\n`);
       return;
     }
-    try {
-      fs.rmSync(this.dir, { recursive: true, force: true });
-    } catch (error) {
-      process.stderr.write(`Could not remove ${this.dir}: ${error.message}\n`);
+    for (const directory of [this.dir, this.workspace]) {
+      if (!directory) continue;
+      try {
+        fs.rmSync(directory, { recursive: true, force: true });
+      } catch (error) {
+        process.stderr.write(`Could not remove ${directory}: ${error.message}\n`);
+      }
     }
   }
 }
@@ -537,11 +853,7 @@ async function runCodex(journey) {
   await journey.waitForRouterSocket();
   journey.step('router started against the temporary MEMESH_DIR', { socket_path: journey.socketPath });
 
-  const workspaceDir = path.join(journey.dir, 'codex-workspace');
-  fs.mkdirSync(workspaceDir, { recursive: true });
-  // realpath because the companion realpaths both its configured workspace and the
-  // SessionStart `cwd` before it will register; on macOS os.tmpdir() is a symlink.
-  const workspace = fs.realpathSync(workspaceDir);
+  const workspace = journey.createCodexWorkspace();
   const setup = journey.cliJson([
     'agent', 'setup', 'codex-session',
     '--project', PROJECT,
@@ -558,36 +870,37 @@ async function runCodex(journey) {
   if (first.status !== 0) {
     throw new Error(`codex exec exited ${first.status}: ${first.stderr.trim().slice(0, 600)}`);
   }
+  // Turn 1's log stays out of the workspace: it names the thread, and the
+  // proof turn must have no on-disk source for anything it quotes.
   fs.writeFileSync(path.join(journey.dir, 'codex-turn1.jsonl'), first.stdout);
   const threadId = parseCodexThreadId(first.stdout);
   journey.step('real Codex thread created', {
     thread_id: threadId,
+    workspace,
     first_turn_reply: collectCodexAgentMessages(first.stdout).join(' | '),
   });
 
-  // Registration is harness-driven, and that is a disclosed limitation rather
-  // than a shortcut: `codex exec --ignore-user-config` structurally prevents
-  // the packaged plugin SessionStart hook from running, so there is no way to
-  // reach the shipped registration path from a scripted exec turn. What runs
-  // here is the SHIPPED companion — dist/host-runtime/codex-session.js — fed
-  // the SessionStart payload the hook would have handed it.
+  // Registration is harness-driven, and that is disclosed rather than hidden.
+  // What runs here is the SHIPPED companion — dist/host-runtime/codex-session.js
+  // — fed the SessionStart payload the packaged plugin hook would have handed it.
   const companionLog = fs.openSync(path.join(journey.dir, 'codex-session.log'), 'a');
-  const companion = spawn(process.execPath, [dist('dist/host-runtime/codex-session.js')], {
+  journey.companion = spawn(process.execPath, [dist('dist/host-runtime/codex-session.js')], {
     env: { ...journey.env, PLUGIN_ROOT: repoRoot },
     stdio: ['pipe', companionLog, companionLog],
   });
-  journey.children.push({ name: 'codex-session', child: companion });
-  companion.stdin.end(JSON.stringify({
+  journey.companion.stdin.end(JSON.stringify({
     hook_event_name: 'SessionStart',
     source: 'startup',
     session_id: threadId,
     cwd: workspace,
   }));
   journey.note(
-    'The Codex registration half is harness-driven: `codex exec --ignore-user-config` cannot load the '
-    + 'packaged plugin SessionStart hook, so this check feeds the shipped dist/host-runtime/codex-session.js '
-    + 'the SessionStart payload that hook would have supplied. Dispatch -> `codex queue` -> model-visible '
-    + 'reply is product-path evidence; the registration step is not.',
+    'The Codex registration half is harness-driven. This run drives the shipped '
+    + 'dist/host-runtime/codex-session.js directly with the SessionStart payload the packaged plugin hook '
+    + 'supplies, because a scripted `codex exec` turn was not observed to register anything on its own. '
+    + 'Whether `--ignore-user-config` is what prevents the plugin hook from loading was NOT verified; on a '
+    + 'machine whose ~/.memesh/hosts has no codex-session.json the shipped companion returns early in any '
+    + 'case. Only dispatch -> `codex queue` -> model-visible reply is product-path evidence.',
   );
   const card = await journey.until(
     'The Codex session never registered with the router',
@@ -611,12 +924,12 @@ async function runCodex(journey) {
     native_delivery: sent.native,
   });
 
-  // The prompt names neither the sentinel nor either id on purpose. The model
-  // can only produce them by reading the envelope Codex queued.
+  // The prompt names neither the sentinel nor either id on purpose, and the
+  // reply is only accepted if the turn also ran no commands.
   const prompt = 'If a MeMesh envelope containing a qa_sentinel field was injected into this session, '
     + 'reply with exactly one line: CODEX_RECEIVED_<qa_sentinel> <message_id> <delivery_id>, substituting '
     + 'the three values from that envelope. Otherwise reply with exactly: NO_ENVELOPE. '
-    + 'Do nothing else and run no commands.';
+    + 'Do nothing else, read no files and run no commands.';
   const second = run('codex', [
     'exec', '--json', '--skip-git-repo-check', '--ignore-user-config',
     '-s', 'read-only', '-C', workspace, 'resume', threadId, prompt,
@@ -633,13 +946,15 @@ async function runCodex(journey) {
   });
   journey.step('the Codex model quoted the envelope back (model-visible proof)', {
     model_visible_evidence: reply,
-    proves: 'the reply carries message_id and delivery_id, neither of which appears in the prompt',
+    proves: 'the reply carries message_id and delivery_id, neither of which appears in the prompt, '
+      + 'and the turn ran no commands, so it had no on-disk source for them',
   });
 
-  companion.kill('SIGTERM');
+  await stopChild(journey.companion);
+  journey.companion = null;
   await journey.until(
     'The router still lists the Codex session as live after its companion was stopped',
-    () => journey.discover().cards.every((entry) => entry.session_id !== threadId),
+    () => journey.sessionGone(threadId),
     15_000,
   );
   journey.step('companion stopped and the session left the router directory', { session_id: threadId });
@@ -655,7 +970,7 @@ async function runCodex(journey) {
   );
   journey.note(
     'One throwaway Codex thread is created in the owner\'s Codex rollout store and one message is queued '
-    + 'into it. No Codex or MeMesh configuration outside the temporary directory is written, and no auth '
+    + 'into it. No Codex or MeMesh configuration outside the temporary directories is written, and no auth '
     + 'file is read: the login precondition is the exit code of `codex login status`.',
   );
 }
@@ -697,15 +1012,26 @@ async function runClaude(journey, waitMs) {
     },
   }, null, 2)}\n`, { mode: 0o600 });
 
-  const launch = `cd ${JSON.stringify(workspace)} && claude --dangerously-load-development-channels `
-    + `server:memesh-channel --mcp-config ${JSON.stringify(mcpConfig)} --strict-mcp-config`;
+  // `--setting-sources ""` loads no user/project/local settings file. It is
+  // accepted by the CLI (an invalid source name is rejected, an empty list is
+  // not), but it is NOT verified to exclude plugin-provided hooks or MCP
+  // servers — hence the confirmation step below rather than a silent claim.
+  const launch = `cd ${JSON.stringify(workspace)} && claude --setting-sources "" `
+    + '--dangerously-load-development-channels server:memesh-channel '
+    + `--mcp-config ${JSON.stringify(mcpConfig)} --strict-mcp-config`;
   journey.say([
     '',
     '  ACTION REQUIRED — in a second terminal, run exactly:',
     '',
     `    ${launch}`,
     '',
-    '  Then TYPE NOTHING. Leave the session sitting at its prompt. This check is',
+    '  Then, BEFORE anything else, confirm the session is not carrying the owner\'s',
+    '  installed MeMesh plugin: run /mcp and check only `memesh` and `memesh-channel`',
+    '  are listed, and run /hooks and check no MeMesh hooks are registered. A plugin',
+    '  hook running there inherits no MEMESH_DIR and would write the REAL ~/.memesh.',
+    '  If either shows the plugin, stop: quit the session and disable the plugin first.',
+    '',
+    '  Otherwise TYPE NOTHING. Leave the session sitting at its prompt. This check is',
     '  measuring what the session does on its own when an envelope arrives.',
     '',
   ].join('\n'));
@@ -716,6 +1042,7 @@ async function runClaude(journey, waitMs) {
     () => findLiveCards(journey.discover(), { hostKind: 'claude' })[0] ?? false,
     waitMs,
   );
+  journey.liveSessionId = card.session_id;
   journey.step('interactive Claude session registered on the channel', {
     session_id: card.session_id,
     principal_id: card.principal_id,
@@ -755,14 +1082,22 @@ async function runClaude(journey, waitMs) {
   journey.say('\n  ACTION REQUIRED — exit that Claude session now (Ctrl-D or /exit).\n');
   await journey.until(
     'The Claude session is still registered with the router. Exit the interactive session to continue.',
-    () => findLiveCards(journey.discover(), { sessionId: card.session_id }).length === 0,
+    () => journey.sessionGone(card.session_id),
     waitMs,
   );
+  journey.liveSessionId = null;
   journey.step('session disconnected and left the router directory', { session_id: card.session_id });
 
   journey.step('a send to the stopped session fails closed and the durable row survives',
     journey.provesFailClosed(card.session_id, sentinel));
 
+  journey.note(
+    'The interactive Claude session is NOT inside this check\'s isolation. The printed command passes '
+    + '--setting-sources "" so no settings file loads, but that is not verified to exclude plugin-provided '
+    + 'hooks or MCP servers; a MeMesh plugin hook running in that session inherits no MEMESH_DIR and would '
+    + 'write the owner\'s real ~/.memesh. The operator is told to confirm with /mcp and /hooks first, and '
+    + 'this check cannot observe whether they did.',
+  );
   journey.note(
     'The operator is instructed to type nothing, but this check cannot observe whether anything was typed. '
     + 'The intake receipt proves the model called `intake` in that session; it does not prove it did so unprompted.',
@@ -798,15 +1133,41 @@ async function main() {
     return;
   }
 
+  assertNotCi(process.env);
   assertDistPresent(repoRoot);
   const revision = run('git', ['rev-parse', 'HEAD'], { cwd: repoRoot }).stdout.trim();
   if (revision.length === 0) throw new Error('Could not read the repository revision; the report would name no code.');
+  const dirty = run('git', ['status', '--porcelain'], { cwd: repoRoot }).stdout.trim() !== '';
+  const newestSrcMs = newestMtimeMs(path.join(repoRoot, 'src'));
+  const oldestDistMs = Math.min(...REQUIRED_DIST.map((relative) => fs.statSync(dist(relative)).mtimeMs));
+  const distStale = isDistStale({ newestSrcMs, oldestDistMs });
+
   const journey = new Journey(options);
   const startedAt = new Date().toISOString();
   let failure = null;
 
-  process.stdout.write(`memesh live journey — host=${options.host} revision=${revision}\n`);
-  process.stdout.write(`  MEMESH_DIR=${journey.memeshDir}\n\n`);
+  process.stdout.write(`memesh live journey — host=${options.host} revision=${revision}${dirty ? ' (DIRTY TREE)' : ''}\n`);
+  process.stdout.write(`  MEMESH_DIR=${journey.memeshDir}\n`);
+  if (dirty) {
+    process.stdout.write('  WARNING: the working tree is dirty, so this report does not describe the revision alone.\n');
+    journey.note('The working tree was dirty when this ran: the report names a revision, but uncommitted changes were present.');
+  }
+  if (distStale) {
+    process.stdout.write('  WARNING: dist/ predates the newest file under src/ — this ran a stale build.\n');
+    journey.note('At least one dist/ artefact this check ran is older than the newest file under src/, so the built code may not correspond to the source at this revision. Run `npm run build`.');
+  }
+  process.stdout.write('\n');
+
+  const finish = async (code) => {
+    await journey.shutdown();
+    process.exit(code);
+  };
+  const onSignal = (signal, code) => {
+    process.stderr.write(`\nReceived ${signal}; shutting down cleanly.\n`);
+    void finish(code);
+  };
+  process.once('SIGINT', () => onSignal('SIGINT', 130));
+  process.once('SIGTERM', () => onSignal('SIGTERM', 143));
 
   try {
     if (options.host === 'codex') await runCodex(journey);
@@ -826,6 +1187,8 @@ async function main() {
   const report = {
     schema_version: 'memesh-live-journey/v1',
     revision,
+    dirty,
+    dist_stale: distStale,
     host: options.host,
     project: PROJECT,
     started_at: startedAt,
@@ -843,8 +1206,7 @@ async function main() {
   } else {
     process.stdout.write(`\n${JSON.stringify(report, null, 2)}\n`);
   }
-  journey.cleanup();
-  process.exit(failure === null ? 0 : 1);
+  await finish(failure === null ? 0 : 1);
 }
 
 if (process.argv[1] && fs.realpathSync(process.argv[1]) === fileURLToPath(import.meta.url)) {

--- a/scripts/qa/live-journey.mjs
+++ b/scripts/qa/live-journey.mjs
@@ -134,8 +134,9 @@ export function helpText() {
     '            model even when the channel host reports the frame accepted (issue #275),',
     '            so it can never produce the model-visible proof this check requires.',
     '',
-    'Refuses to run when CI is set, when dist/ is not built, or when the temporary',
-    'MEMESH_DIR would resolve inside the owner\'s ~/.memesh.',
+    'Refuses to run on Windows (the host-native runtime it exercises is macOS/Linux only),',
+    'when CI is set, when dist/ is not built, or when the temporary MEMESH_DIR would',
+    'resolve inside the owner\'s ~/.memesh.',
     '',
     'Two things sit OUTSIDE the temporary-directory isolation, and the report says so:',
     '  - Codex registration is harness-driven. The shipped codex-session companion is fed',
@@ -181,6 +182,26 @@ export function parseArgs(argv) {
     throw new Error(`--host must be codex or claude, not ${parsed.host}.`);
   }
   return parsed;
+}
+
+/**
+ * The host-native router, its Unix socket and the managed host adapters are
+ * macOS/Linux only (docs/platforms/agent-messaging.md: Windows keeps core
+ * memory, durable messaging and MCP, but host-native wakeup fails closed).
+ * This check exists to exercise exactly that runtime, so on Windows it has
+ * nothing to prove and refuses rather than failing later at a socket it can
+ * never bind.
+ *
+ * @param {string} platform `process.platform`
+ */
+export function assertSupportedPlatform(platform) {
+  if (platform === 'win32') {
+    throw new Error(
+      'Refusing to run: the host-native router and adapters this check exercises are macOS/Linux only '
+      + '(see docs/platforms/agent-messaging.md). On Windows, MeMesh keeps core memory, durable messaging '
+      + 'and MCP, but there is no host-native wakeup for this check to prove.',
+    );
+  }
 }
 
 /**
@@ -1157,6 +1178,7 @@ async function main() {
     return;
   }
 
+  assertSupportedPlatform(process.platform);
   assertNotCi(process.env);
   assertDistPresent(repoRoot);
   const revision = run('git', ['rev-parse', 'HEAD'], { cwd: repoRoot }).stdout.trim();

--- a/scripts/qa/live-journey.mjs
+++ b/scripts/qa/live-journey.mjs
@@ -84,7 +84,17 @@ export const MAX_SOCKET_PATH_BYTES = 103;
  * did nothing but answer, so an unrecognised item type must fail loudly rather
  * than be assumed harmless.
  */
-export const ALLOWED_CODEX_ITEM_TYPES = new Set(['agent_message', 'error']);
+export const ALLOWED_CODEX_ITEM_TYPES = new Set(['agent_message', 'reasoning', 'error']);
+
+/**
+ * `codex exec --json` event types that are lifecycle, not model action. The
+ * no-command check walks EVERY event, not only `item.completed`: a native tool
+ * (read_file, view_image) that surfaced under some other event type would
+ * otherwise be invisible to an item-only scan. Anything not listed fails closed.
+ */
+export const ALLOWED_CODEX_EVENT_TYPES = new Set([
+  'thread.started', 'turn.started', 'turn.completed', 'item.started', 'item.updated', 'item.completed', 'error',
+]);
 
 /** dist artefacts this check runs. Missing any of them is a refusal, not a skip. */
 export const REQUIRED_DIST = [
@@ -327,10 +337,15 @@ export function collectCodexAgentMessages(text) {
 export function assertCodexRanNoCommands(text) {
   const offending = [];
   for (const event of parseJsonl(text)) {
-    if (event?.type !== 'item.completed') continue;
+    const type = event?.type;
+    if (typeof type !== 'string' || !ALLOWED_CODEX_EVENT_TYPES.has(type)) {
+      offending.push(`event:${typeof type === 'string' ? type : '<unknown>'}`);
+      continue;
+    }
+    if (!type.startsWith('item.')) continue;
     const kind = event.item?.type;
     if (typeof kind !== 'string' || !ALLOWED_CODEX_ITEM_TYPES.has(kind)) {
-      offending.push(typeof kind === 'string' ? kind : '<unknown>');
+      offending.push(`item:${typeof kind === 'string' ? kind : '<unknown>'}`);
     }
   }
   if (offending.length > 0) {
@@ -626,16 +641,14 @@ class Journey {
       realpath: realpathAsFarAsPossible,
     });
 
+    // Measure the socket path BEFORE creating anything, on the real temp root
+    // (os.tmpdir() may be a symlink to a longer path), so a refusal leaves no
+    // empty directory behind. mkdtemp appends six characters.
+    assertSocketPathFits(path.join(realpathAsFarAsPossible(tmpRoot), 'memesh-lj-XXXXXX', 'memesh', 'agent-router.sock'));
     this.dir = fs.realpathSync(fs.mkdtempSync(path.join(tmpRoot, 'memesh-lj-')));
     this.memeshDir = path.join(this.dir, 'memesh');
     this.dbPath = path.join(this.memeshDir, 'knowledge-graph.db');
     this.socketPath = path.join(this.memeshDir, 'agent-router.sock');
-    assertOutsideOwnerMemesh({
-      candidates: { MEMESH_DIR: this.memeshDir, MEMESH_DB_PATH: this.dbPath },
-      home: os.homedir(),
-      realpath: realpathAsFarAsPossible,
-    });
-    assertSocketPathFits(this.socketPath);
     fs.mkdirSync(this.memeshDir, { recursive: true, mode: 0o700 });
     this.env = { ...process.env, MEMESH_DIR: this.memeshDir, MEMESH_DB_PATH: this.dbPath };
 
@@ -694,9 +707,13 @@ class Journey {
 
   startRouter() {
     const log = fs.openSync(path.join(this.dir, 'router.log'), 'a');
+    // detached: the router gets its own process group, so a terminal Ctrl-C
+    // reaches the harness (which unwinds in order) and not the router first —
+    // a router killed while a host is still connected is what spawns an orphan.
     this.router = spawn(process.execPath, [dist('dist/host-runtime/router.js')], {
       env: this.env,
       stdio: ['ignore', log, log],
+      detached: true,
     });
     return this.router;
   }
@@ -794,13 +811,18 @@ class Journey {
    * connected after the bounded wait, keep the directory rather than delete a
    * tree something is about to recreate. Runs on every exit path.
    */
-  async shutdown(waitMs = 30_000) {
-    if (this.shuttingDown) return;
-    this.shuttingDown = true;
+  shutdown(waitMs = 30_000) {
+    // Memoised, not guarded: a second caller (signal handler racing the main
+    // path's own failure) must AWAIT the first unwind, not skip it and exit
+    // while rmSync has not run yet.
+    this.shutdownPromise ??= this.unwind(waitMs);
+    return this.shutdownPromise;
+  }
 
+  async unwind(waitMs) {
     await stopChild(this.companion);
 
-    const routerAlive = this.router !== null && this.router.exitCode === null;
+    const routerAlive = this.router !== null && this.router.exitCode === null && this.router.signalCode === null;
     const disconnected = await awaitSessionDisconnect({
       sessionId: routerAlive ? this.liveSessionId : null,
       isGone: (sessionId) => this.sessionGone(sessionId),
@@ -813,7 +835,8 @@ class Journey {
       this.keptForSafety = true;
       process.stderr.write(
         `\n  WARNING: ${this.liveSessionId} is still connected. Keeping ${this.dir} rather than deleting a\n`
-        + '  directory a live host is about to recreate. Exit that session, then remove it by hand.\n',
+        + '  directory a live host is about to recreate. Exit that session, then remove it by hand; if a\n'
+        + '  detached router was started by that host, stop it too: pkill -f dist/host-runtime/router.js\n',
       );
     }
 
@@ -887,6 +910,7 @@ async function runCodex(journey) {
   journey.companion = spawn(process.execPath, [dist('dist/host-runtime/codex-session.js')], {
     env: { ...journey.env, PLUGIN_ROOT: repoRoot },
     stdio: ['pipe', companionLog, companionLog],
+    detached: true, // same reason as the router: the harness, not the terminal, decides the order
   });
   journey.companion.stdin.end(JSON.stringify({
     hook_event_name: 'SessionStart',
@@ -1158,12 +1182,38 @@ async function main() {
   }
   process.stdout.write('\n');
 
+  const emitReport = (failureText) => {
+    const report = {
+      schema_version: 'memesh-live-journey/v1',
+      revision,
+      dirty,
+      dist_stale: distStale,
+      host: options.host,
+      project: PROJECT,
+      started_at: startedAt,
+      finished_at: new Date().toISOString(),
+      verdict: failureText === null ? 'PASS' : 'FAIL',
+      memesh_dir: journey.memeshDir,
+      steps: journey.steps,
+      limitations: journey.limitations,
+      ...(failureText === null ? {} : { error: failureText }),
+    };
+    if (options.out) {
+      const target = path.resolve(options.out);
+      fs.writeFileSync(target, `${JSON.stringify(report, null, 2)}\n`, { mode: 0o600 });
+      process.stdout.write(`\nReport: ${target}\n`);
+    } else {
+      process.stdout.write(`\n${JSON.stringify(report, null, 2)}\n`);
+    }
+  };
   const finish = async (code) => {
     await journey.shutdown();
     process.exit(code);
   };
   const onSignal = (signal, code) => {
     process.stderr.write(`\nReceived ${signal}; shutting down cleanly.\n`);
+    // The partial report is evidence too: which steps passed before the interrupt.
+    try { emitReport(`interrupted by ${signal}`); } catch { /* the report is best effort here */ }
     void finish(code);
   };
   process.once('SIGINT', () => onSignal('SIGINT', 130));
@@ -1184,28 +1234,7 @@ async function main() {
     process.stderr.write(`  FAIL ${failure}\n`);
   }
 
-  const report = {
-    schema_version: 'memesh-live-journey/v1',
-    revision,
-    dirty,
-    dist_stale: distStale,
-    host: options.host,
-    project: PROJECT,
-    started_at: startedAt,
-    finished_at: new Date().toISOString(),
-    verdict: failure === null ? 'PASS' : 'FAIL',
-    memesh_dir: journey.memeshDir,
-    steps: journey.steps,
-    limitations: journey.limitations,
-    ...(failure === null ? {} : { error: failure }),
-  };
-  if (options.out) {
-    const target = path.resolve(options.out);
-    fs.writeFileSync(target, `${JSON.stringify(report, null, 2)}\n`, { mode: 0o600 });
-    process.stdout.write(`\nReport: ${target}\n`);
-  } else {
-    process.stdout.write(`\n${JSON.stringify(report, null, 2)}\n`);
-  }
+  emitReport(failure);
   await finish(failure === null ? 0 : 1);
 }
 

--- a/tests/qa/live-journey.test.ts
+++ b/tests/qa/live-journey.test.ts
@@ -373,7 +373,7 @@ describe('assertCodexReply', () => {
       extraItems: [{ id: 'item_9', type: 'command_execution', command: 'cat turn1.jsonl', exit_code: 0 }],
     });
     expect(() => assertCodexReply({ jsonl: withCommand, ...expected }))
-      .toThrow(/non-answer items \(command_execution\)/);
+      .toThrow(/non-answer items \(item:command_execution\)/);
   });
 
   it('rejects NO_ENVELOPE with the reason, not a generic mismatch', () => {
@@ -414,6 +414,23 @@ describe('assertCodexRanNoCommands', () => {
   it('rejects an unrecognised item type rather than assuming it is harmless', () => {
     const withTool = codexTurn(['ok'], { extraItems: [{ id: 'item_9', type: 'mcp_tool_call', name: 'read_file' }] });
     expect(() => assertCodexRanNoCommands(withTool)).toThrow(/mcp_tool_call/);
+  });
+
+  it('tolerates a reasoning item — thinking is not a model action', () => {
+    const withReasoning = codexTurn(['ok'], { extraItems: [{ id: 'item_9', type: 'reasoning', text: 'considering' }] });
+    expect(() => assertCodexRanNoCommands(withReasoning)).not.toThrow();
+  });
+
+  it('rejects an unrecognised EVENT type, not only an unrecognised item type', () => {
+    // A native tool surfaced under some event other than item.* must not slip
+    // past an item-only scan.
+    const withForeignEvent = `${GOOD_REPLY}\n${JSON.stringify({ type: 'tool.call', name: 'read_file', path: '../memesh/knowledge-graph.db' })}`;
+    expect(() => assertCodexRanNoCommands(withForeignEvent)).toThrow(/event:tool\.call/);
+  });
+
+  it('rejects a command that only STARTED (item.started) even if it never completed', () => {
+    const withStartedCommand = `${GOOD_REPLY}\n${JSON.stringify({ type: 'item.started', item: { id: 'item_9', type: 'command_execution', command: 'cat x' } })}`;
+    expect(() => assertCodexRanNoCommands(withStartedCommand)).toThrow(/item:command_execution/);
   });
 });
 

--- a/tests/qa/live-journey.test.ts
+++ b/tests/qa/live-journey.test.ts
@@ -21,22 +21,32 @@
  * never happened.
  */
 
-import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
 import {
   DEFAULT_WAIT_MS,
+  MAX_SOCKET_PATH_BYTES,
   REQUIRED_DIST,
+  assertCodexRanNoCommands,
   assertCodexReply,
   assertDistPresent,
   assertIntakeReceipt,
   assertNativeAccepted,
+  assertNotCi,
+  assertOutsideOwnerMemesh,
   assertRecipientUnavailable,
-  assertSafeMemeshPaths,
+  assertSocketPathFits,
+  awaitSessionDisconnect,
   collectCodexAgentMessages,
   findIntakeReceipt,
   findLiveCards,
   helpText,
+  isDistStale,
   parseArgs,
   parseCodexThreadId,
+  realpathAsFarAsPossible,
+  shouldRemoveWorkingDirectories,
 } from '../../scripts/qa/live-journey.mjs';
 
 const THREAD = '01a05ead-98e8-7091-a770-81f7339d3b29';
@@ -45,14 +55,18 @@ const DELIVERY_ID = '92f1bda2-5bd9-4da3-86f6-f083253a7ed1';
 const SENTINEL = 'codex-4f19ab27';
 
 /** `codex exec --json` output, in the shape a real turn emits it. */
-function codexTurn(messages: string[], threadId: string = THREAD): string {
+function codexTurn(
+  messages: string[],
+  options: { threadId?: string; extraItems?: Record<string, unknown>[] } = {},
+): string {
   return [
-    JSON.stringify({ type: 'thread.started', thread_id: threadId }),
+    JSON.stringify({ type: 'thread.started', thread_id: options.threadId ?? THREAD }),
     JSON.stringify({ type: 'turn.started' }),
     ...messages.map((text, index) => JSON.stringify({
       type: 'item.completed',
       item: { id: `item_${index}`, type: 'agent_message', text },
     })),
+    ...(options.extraItems ?? []).map((item) => JSON.stringify({ type: 'item.completed', item })),
     JSON.stringify({ type: 'turn.completed', usage: { input_tokens: 1, output_tokens: 1 } }),
     '',
   ].join('\n');
@@ -157,52 +171,129 @@ describe('--help', () => {
     expect(text).toMatch(/issue #275/);
   });
 
-  it('states that it never touches the owner’s real memory directory', () => {
-    expect(helpText()).toMatch(/\$HOME\/\.memesh/);
+  it('discloses the harness-driven Codex registration', () => {
+    expect(helpText()).toMatch(/registration is harness-driven/);
+  });
+
+  it('warns that the launched Claude session is outside the isolation', () => {
+    const text = helpText();
+    expect(text).toMatch(/OUTSIDE the temporary-directory isolation/);
+    expect(text).toMatch(/would write the REAL ~\/\.memesh/);
+    expect(text).toMatch(/\/hooks and \/mcp/);
+  });
+
+  it('names the invocation that was actually verified', () => {
+    expect(helpText()).toMatch(/TMPDIR=\/private\/tmp npm run qa:live-journey/);
   });
 });
 
-describe('assertSafeMemeshPaths', () => {
+describe('assertOutsideOwnerMemesh', () => {
   const home = '/Users/example';
+  const identity = (candidate: string) => candidate;
 
   it('allows a temporary directory outside the owner’s memesh directory', () => {
-    expect(() => assertSafeMemeshPaths({
-      memeshDir: '/private/tmp/memesh-live-journey-abc/memesh',
-      dbPath: '/private/tmp/memesh-live-journey-abc/memesh/knowledge-graph.db',
+    expect(() => assertOutsideOwnerMemesh({
+      candidates: {
+        MEMESH_DIR: '/private/tmp/memesh-lj-abc/memesh',
+        MEMESH_DB_PATH: '/private/tmp/memesh-lj-abc/memesh/knowledge-graph.db',
+      },
       home,
+      realpath: identity,
     })).not.toThrow();
   });
 
   it('refuses when MEMESH_DIR is the owner’s memesh directory', () => {
-    expect(() => assertSafeMemeshPaths({
-      memeshDir: `${home}/.memesh`,
-      dbPath: '/private/tmp/x/knowledge-graph.db',
+    expect(() => assertOutsideOwnerMemesh({
+      candidates: { MEMESH_DIR: `${home}/.memesh` },
       home,
+      realpath: identity,
     })).toThrow(/Refusing to run: MEMESH_DIR/);
   });
 
   it('refuses when MEMESH_DB_PATH sits under the owner’s memesh directory', () => {
-    expect(() => assertSafeMemeshPaths({
-      memeshDir: '/private/tmp/x/memesh',
-      dbPath: `${home}/.memesh/knowledge-graph.db`,
+    expect(() => assertOutsideOwnerMemesh({
+      candidates: { MEMESH_DB_PATH: `${home}/.memesh/knowledge-graph.db` },
       home,
+      realpath: identity,
     })).toThrow(/Refusing to run: MEMESH_DB_PATH/);
   });
 
-  it('refuses a path that only reaches ~/.memesh after normalisation', () => {
-    expect(() => assertSafeMemeshPaths({
-      memeshDir: `${home}/projects/../.memesh/hosts`,
-      dbPath: '/private/tmp/x/knowledge-graph.db',
+  it('refuses a SYMLINKED temp root that really lands in ~/.memesh', () => {
+    // The case a resolve-only prefix test cannot see: the literal path is
+    // outside, the real path is inside, and deleting it would destroy memory.
+    const realpath = (candidate: string) => (
+      candidate.startsWith('/private/tmp/looks-safe')
+        ? candidate.replace('/private/tmp/looks-safe', `${home}/.memesh/hidden`)
+        : candidate
+    );
+    expect(() => assertOutsideOwnerMemesh({
+      candidates: { TMPDIR: '/private/tmp/looks-safe' },
       home,
-    })).toThrow(/Refusing to run/);
+      realpath,
+    })).toThrow(/Refusing to run: TMPDIR/);
   });
 
   it('does not confuse a sibling directory with a prefix match', () => {
-    expect(() => assertSafeMemeshPaths({
-      memeshDir: `${home}/.memesh-scratch/memesh`,
-      dbPath: `${home}/.memesh-scratch/memesh/knowledge-graph.db`,
+    expect(() => assertOutsideOwnerMemesh({
+      candidates: { MEMESH_DIR: `${home}/.memesh-scratch/memesh` },
       home,
+      realpath: identity,
     })).not.toThrow();
+  });
+});
+
+describe('realpathAsFarAsPossible', () => {
+  it('resolves an existing directory', () => {
+    expect(realpathAsFarAsPossible('/tmp')).toBe(fs.realpathSync('/tmp'));
+  });
+
+  it('resolves the existing ancestor of a path that does not exist yet', () => {
+    const resolved = realpathAsFarAsPossible('/tmp/memesh-lj-does-not-exist-yet/memesh');
+    expect(resolved).toBe(path.join(fs.realpathSync('/tmp'), 'memesh-lj-does-not-exist-yet', 'memesh'));
+  });
+});
+
+describe('assertNotCi', () => {
+  it('allows an ordinary owner shell', () => {
+    expect(() => assertNotCi({})).not.toThrow();
+    expect(() => assertNotCi({ CI: '' })).not.toThrow();
+    expect(() => assertNotCi({ CI: 'false' })).not.toThrow();
+  });
+
+  it('refuses under CI, where neither host can exist', () => {
+    expect(() => assertNotCi({ CI: 'true' })).toThrow(/Refusing to run: CI is set/);
+    expect(() => assertNotCi({ CI: '1' })).toThrow(/Refusing to run: CI is set/);
+  });
+});
+
+describe('assertSocketPathFits', () => {
+  it('accepts a short temporary root', () => {
+    expect(() => assertSocketPathFits('/private/tmp/memesh-lj-abc123/memesh/agent-router.sock')).not.toThrow();
+  });
+
+  it('refuses a path over the AF_UNIX limit and names the fix', () => {
+    const tooLong = `/private/tmp/${'d'.repeat(MAX_SOCKET_PATH_BYTES)}/memesh/agent-router.sock`;
+    expect(() => assertSocketPathFits(tooLong)).toThrow(/TMPDIR=\/private\/tmp/);
+  });
+
+  it('measures bytes, not characters', () => {
+    // 61 characters — comfortably under the limit — but 121 UTF-8 bytes, which
+    // is what the kernel counts. A `.length` check would pass this.
+    const twoByteChars = `/${'é'.repeat(60)}`;
+    expect(twoByteChars.length).toBeLessThan(MAX_SOCKET_PATH_BYTES);
+    expect(Buffer.byteLength(twoByteChars, 'utf8')).toBeGreaterThan(MAX_SOCKET_PATH_BYTES);
+    expect(() => assertSocketPathFits(twoByteChars)).toThrow(/AF_UNIX limit/);
+  });
+});
+
+describe('isDistStale', () => {
+  it('is stale when any dist artefact predates the newest source file', () => {
+    expect(isDistStale({ newestSrcMs: 2_000, oldestDistMs: 1_000 })).toBe(true);
+  });
+
+  it('is fresh when every dist artefact is at least as new as the newest source', () => {
+    expect(isDistStale({ newestSrcMs: 1_000, oldestDistMs: 1_000 })).toBe(false);
+    expect(isDistStale({ newestSrcMs: 1_000, oldestDistMs: 2_000 })).toBe(false);
   });
 });
 
@@ -277,6 +368,14 @@ describe('assertCodexReply', () => {
       .toThrow(/does not quote delivery_id/);
   });
 
+  it('rejects an otherwise-perfect reply from a turn that ran a command', () => {
+    const withCommand = codexTurn([`CODEX_RECEIVED_${SENTINEL} ${MESSAGE_ID} ${DELIVERY_ID}`], {
+      extraItems: [{ id: 'item_9', type: 'command_execution', command: 'cat turn1.jsonl', exit_code: 0 }],
+    });
+    expect(() => assertCodexReply({ jsonl: withCommand, ...expected }))
+      .toThrow(/non-answer items \(command_execution\)/);
+  });
+
   it('rejects NO_ENVELOPE with the reason, not a generic mismatch', () => {
     expect(() => assertCodexReply({ jsonl: codexTurn(['NO_ENVELOPE']), ...expected }))
       .toThrow(/not visible to the model/);
@@ -288,15 +387,45 @@ describe('assertCodexReply', () => {
   });
 });
 
+describe('assertCodexRanNoCommands', () => {
+  it('accepts a turn that only answered', () => {
+    expect(() => assertCodexRanNoCommands(GOOD_REPLY)).not.toThrow();
+  });
+
+  it('tolerates Codex’s own error notices, which are not model actions', () => {
+    const withNotice = codexTurn(['READY'], {
+      extraItems: [{ id: 'item_9', type: 'error', message: 'Skill descriptions were shortened.' }],
+    });
+    expect(() => assertCodexRanNoCommands(withNotice)).not.toThrow();
+  });
+
+  it('REJECTS a turn that ran a command — the model could have read the ids off disk', () => {
+    const withCommand = codexTurn([`CODEX_RECEIVED_${SENTINEL} ${MESSAGE_ID} ${DELIVERY_ID}`], {
+      extraItems: [{
+        id: 'item_9',
+        type: 'command_execution',
+        command: '/bin/zsh -lc \'cat ../memesh/knowledge-graph.db\'',
+        exit_code: 0,
+      }],
+    });
+    expect(() => assertCodexRanNoCommands(withCommand)).toThrow(/command_execution/);
+  });
+
+  it('rejects an unrecognised item type rather than assuming it is harmless', () => {
+    const withTool = codexTurn(['ok'], { extraItems: [{ id: 'item_9', type: 'mcp_tool_call', name: 'read_file' }] });
+    expect(() => assertCodexRanNoCommands(withTool)).toThrow(/mcp_tool_call/);
+  });
+});
+
 describe('assertNativeAccepted', () => {
   it('accepts a send whose exact session took the frame', () => {
-    expect(assertNativeAccepted(ACCEPTED_SEND, 'codex-cli-queue'))
+    expect(assertNativeAccepted(ACCEPTED_SEND, { adapterKind: 'codex-cli-queue', recipient: THREAD }))
       .toMatchObject({ messageId: MESSAGE_ID, deliveryId: DELIVERY_ID });
   });
 
   it('rejects a durable send with NO native_delivery block', () => {
     const { native_delivery: _dropped, ...durableOnly } = ACCEPTED_SEND;
-    expect(() => assertNativeAccepted(durableOnly, 'codex-cli-queue'))
+    expect(() => assertNativeAccepted(durableOnly, { adapterKind: 'codex-cli-queue', recipient: THREAD }))
       .toThrow(/no native_delivery block/);
   });
 
@@ -305,17 +434,43 @@ describe('assertNativeAccepted', () => {
       ...ACCEPTED_SEND,
       native_delivery: { ...ACCEPTED_SEND.native_delivery, status: 'recipient_unavailable' },
     };
-    expect(() => assertNativeAccepted(unavailable, 'codex-cli-queue'))
+    expect(() => assertNativeAccepted(unavailable, { adapterKind: 'codex-cli-queue', recipient: THREAD }))
       .toThrow(/not "native_accepted"/);
   });
 
   it('rejects acceptance by the wrong adapter', () => {
-    expect(() => assertNativeAccepted(ACCEPTED_SEND, 'claude-channel'))
+    expect(() => assertNativeAccepted(ACCEPTED_SEND, { adapterKind: 'claude-channel', recipient: THREAD }))
       .toThrow(/adapter_kind is "codex-cli-queue"/);
   });
 
+  it('rejects an acceptance whose delivery_id belongs to a different delivery', () => {
+    const mismatched = {
+      ...ACCEPTED_SEND,
+      native_delivery: { ...ACCEPTED_SEND.native_delivery, delivery_id: 'ffffffff-0000-4000-8000-000000000000' },
+    };
+    expect(() => assertNativeAccepted(mismatched, { adapterKind: 'codex-cli-queue', recipient: THREAD }))
+      .toThrow(/describes a different delivery/);
+  });
+
+  it('rejects a host receipt naming a different thread', () => {
+    const wrongThread = {
+      ...ACCEPTED_SEND,
+      native_delivery: {
+        ...ACCEPTED_SEND.native_delivery,
+        receipt: { ...ACCEPTED_SEND.native_delivery.receipt, thread_id: 'ffffffff-0000-4000-8000-000000000000' },
+      },
+    };
+    expect(() => assertNativeAccepted(wrongThread, { adapterKind: 'codex-cli-queue', recipient: THREAD }))
+      .toThrow(/not the session we addressed/);
+  });
+
+  it('rejects a send whose recipient is not the session we addressed', () => {
+    expect(() => assertNativeAccepted(ACCEPTED_SEND, { adapterKind: 'codex-cli-queue', recipient: 'someone-else' }))
+      .toThrow(/reports recipient/);
+  });
+
   it('rejects a result that is not an object', () => {
-    expect(() => assertNativeAccepted('ok', 'codex-cli-queue')).toThrow(/no JSON object/);
+    expect(() => assertNativeAccepted('ok', { adapterKind: 'codex-cli-queue', recipient: THREAD })).toThrow(/no JSON object/);
   });
 });
 
@@ -330,6 +485,11 @@ describe('assertRecipientUnavailable', () => {
   it('rejects a send to a stopped session that SUCCEEDED', () => {
     expect(() => assertRecipientUnavailable({ status: 0, stderr: '' }))
       .toThrow(/did not fail closed/);
+  });
+
+  it('rejects a KILLED send process — no exit status is not a decision', () => {
+    expect(() => assertRecipientUnavailable({ status: null, stderr: 'recipient_unavailable' }))
+      .toThrow(/killed before it produced an exit status/);
   });
 
   it('rejects a different failure wearing a non-zero exit code', () => {
@@ -362,6 +522,70 @@ describe('intake receipts', () => {
   it('treats an empty projection as no proof', () => {
     expect(findIntakeReceipt([], { messageId: MESSAGE_ID, actor: THREAD })).toBeNull();
     expect(findIntakeReceipt(null, { messageId: MESSAGE_ID, actor: THREAD })).toBeNull();
+  });
+});
+
+describe('shutdown decision', () => {
+  const noSleep = () => Promise.resolve();
+
+  it('is immediately safe when no session was ever registered', async () => {
+    const announce = vi.fn();
+    await expect(awaitSessionDisconnect({
+      sessionId: null,
+      isGone: () => false,
+      waitMs: 30_000,
+      now: () => 0,
+      sleep: noSleep,
+      announce,
+    })).resolves.toBe(true);
+    expect(announce).not.toHaveBeenCalled();
+  });
+
+  it('is safe once the session has left the router directory', async () => {
+    let calls = 0;
+    await expect(awaitSessionDisconnect({
+      sessionId: 'abc',
+      isGone: () => (calls += 1) > 2,
+      waitMs: 30_000,
+      now: () => 0,
+      sleep: noSleep,
+      announce: () => {},
+    })).resolves.toBe(true);
+  });
+
+  it('tells the operator what to do, once, while it waits', async () => {
+    let calls = 0;
+    const announce = vi.fn();
+    await awaitSessionDisconnect({
+      sessionId: 'abc',
+      isGone: () => (calls += 1) > 3,
+      waitMs: 30_000,
+      now: () => 0,
+      sleep: noSleep,
+      announce,
+    });
+    expect(announce).toHaveBeenCalledTimes(1);
+    expect(announce.mock.calls[0][0]).toMatch(/detached replacement/);
+  });
+
+  it('is NOT safe when the session is still connected at the bound', async () => {
+    // The orphan case: a connected host whose router disappears spawns a
+    // detached replacement that recreates this very directory.
+    let clock = 0;
+    await expect(awaitSessionDisconnect({
+      sessionId: 'abc',
+      isGone: () => false,
+      waitMs: 5_000,
+      now: () => (clock += 2_000),
+      sleep: noSleep,
+      announce: () => {},
+    })).resolves.toBe(false);
+  });
+
+  it('keeps the directory when a session is still connected, and removes it otherwise', () => {
+    expect(shouldRemoveWorkingDirectories({ keep: false, keptForSafety: false })).toBe(true);
+    expect(shouldRemoveWorkingDirectories({ keep: false, keptForSafety: true })).toBe(false);
+    expect(shouldRemoveWorkingDirectories({ keep: true, keptForSafety: false })).toBe(false);
   });
 });
 

--- a/tests/qa/live-journey.test.ts
+++ b/tests/qa/live-journey.test.ts
@@ -34,6 +34,7 @@ import {
   assertIntakeReceipt,
   assertNativeAccepted,
   assertNotCi,
+  assertSupportedPlatform,
   assertOutsideOwnerMemesh,
   assertRecipientUnavailable,
   assertSocketPathFits,
@@ -187,7 +188,10 @@ describe('--help', () => {
   });
 });
 
-describe('assertOutsideOwnerMemesh', () => {
+// POSIX path literals below: on Windows `path.resolve('/Users/example')` gains a
+// drive letter and never matches the fixture, and `/tmp` does not exist. The
+// runtime under test is macOS/Linux only, so this follows the repo's idiom.
+describe.skipIf(process.platform === 'win32')('assertOutsideOwnerMemesh', () => {
   const home = '/Users/example';
   const identity = (candidate: string) => candidate;
 
@@ -242,7 +246,7 @@ describe('assertOutsideOwnerMemesh', () => {
   });
 });
 
-describe('realpathAsFarAsPossible', () => {
+describe.skipIf(process.platform === 'win32')('realpathAsFarAsPossible', () => {
   it('resolves an existing directory', () => {
     expect(realpathAsFarAsPossible('/tmp')).toBe(fs.realpathSync('/tmp'));
   });
@@ -250,6 +254,17 @@ describe('realpathAsFarAsPossible', () => {
   it('resolves the existing ancestor of a path that does not exist yet', () => {
     const resolved = realpathAsFarAsPossible('/tmp/memesh-lj-does-not-exist-yet/memesh');
     expect(resolved).toBe(path.join(fs.realpathSync('/tmp'), 'memesh-lj-does-not-exist-yet', 'memesh'));
+  });
+});
+
+describe('assertSupportedPlatform', () => {
+  it('refuses on Windows, naming the documented boundary', () => {
+    expect(() => assertSupportedPlatform('win32')).toThrow(/macOS\/Linux only/);
+  });
+
+  it('allows the platforms the host-native runtime supports', () => {
+    expect(() => assertSupportedPlatform('darwin')).not.toThrow();
+    expect(() => assertSupportedPlatform('linux')).not.toThrow();
   });
 });
 

--- a/tests/qa/live-journey.test.ts
+++ b/tests/qa/live-journey.test.ts
@@ -1,0 +1,388 @@
+/**
+ * Unit tests for the pure half of `scripts/qa/live-journey.mjs`.
+ *
+ * The live check itself cannot run here — it needs the owner's Codex login or a
+ * human at an interactive Claude session, and a test suite that shells out to
+ * either would be a test that passes by not running. What CAN be pinned is
+ * everything the live run *decides*: how it parses its arguments, when it
+ * refuses to start, and — the part that matters — whether each assertion
+ * actually rejects the evidence it is supposed to reject.
+ *
+ * The fixtures below are the recorded shapes from a real journey on 87edb292:
+ * `codex exec --json` event lines, a `message send` result with its
+ * `native_delivery` block, and a `message receipts` projection. They are inline
+ * rather than read from disk on purpose — this suite must pass on a clean
+ * clone, and the original logs live outside the repository.
+ *
+ * Every assertion is tested from BOTH sides. A test that only feeds an
+ * assertion the input it accepts proves the happy path and nothing else; the
+ * negative cases here are the ones that would have caught a `qa_sentinel`-only
+ * check, an intake-free receipts projection, or a send whose native delivery
+ * never happened.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_WAIT_MS,
+  REQUIRED_DIST,
+  assertCodexReply,
+  assertDistPresent,
+  assertIntakeReceipt,
+  assertNativeAccepted,
+  assertRecipientUnavailable,
+  assertSafeMemeshPaths,
+  collectCodexAgentMessages,
+  findIntakeReceipt,
+  findLiveCards,
+  helpText,
+  parseArgs,
+  parseCodexThreadId,
+} from '../../scripts/qa/live-journey.mjs';
+
+const THREAD = '01a05ead-98e8-7091-a770-81f7339d3b29';
+const MESSAGE_ID = 'b234ba88-fe4b-4f75-98b2-259c17097f41';
+const DELIVERY_ID = '92f1bda2-5bd9-4da3-86f6-f083253a7ed1';
+const SENTINEL = 'codex-4f19ab27';
+
+/** `codex exec --json` output, in the shape a real turn emits it. */
+function codexTurn(messages: string[], threadId: string = THREAD): string {
+  return [
+    JSON.stringify({ type: 'thread.started', thread_id: threadId }),
+    JSON.stringify({ type: 'turn.started' }),
+    ...messages.map((text, index) => JSON.stringify({
+      type: 'item.completed',
+      item: { id: `item_${index}`, type: 'agent_message', text },
+    })),
+    JSON.stringify({ type: 'turn.completed', usage: { input_tokens: 1, output_tokens: 1 } }),
+    '',
+  ].join('\n');
+}
+
+const GOOD_REPLY = codexTurn([
+  'Acknowledged. No action taken.',
+  `CODEX_RECEIVED_${SENTINEL} ${MESSAGE_ID} ${DELIVERY_ID}`,
+]);
+
+const ACCEPTED_SEND = {
+  message_id: MESSAGE_ID,
+  delivery_id: DELIVERY_ID,
+  project: 'memesh-live-journey',
+  sender: 'memesh-live-journey-harness',
+  recipient: THREAD,
+  target_kind: 'session',
+  native_delivery: {
+    status: 'native_accepted',
+    delivery_id: DELIVERY_ID,
+    adapter_kind: 'codex-cli-queue',
+    receipt: { host: 'codex-cli', status: 'queued', thread_id: THREAD },
+    accepted_at: '2026-09-01 20:34:52',
+  },
+};
+
+/** A `message receipts` projection: host_accept present, intake present. */
+const RECEIPTS_WITH_INTAKE = [
+  {
+    fact_source: 'agent_host_accept',
+    receipt_kind: 'host_accept',
+    message_id: MESSAGE_ID,
+    recipient: THREAD,
+    actor: 'claude-channel',
+    created_at: '2026-09-01 20:48:48',
+  },
+  {
+    fact_source: 'agent_message_receipt',
+    receipt_id: '2aef2959-ac4e-4040-9820-c84f9b33dec7',
+    receipt_kind: 'intake',
+    intake_state: 'ingested',
+    message_id: MESSAGE_ID,
+    recipient: THREAD,
+    actor: THREAD,
+    created_at: '2026-09-01 20:50:13',
+  },
+];
+
+/** The same projection with the model's own intake missing — host_accept only. */
+const RECEIPTS_WITHOUT_INTAKE = [RECEIPTS_WITH_INTAKE[0]];
+
+describe('parseArgs', () => {
+  it('accepts each supported host', () => {
+    expect(parseArgs(['--host', 'codex']).host).toBe('codex');
+    expect(parseArgs(['--host', 'claude']).host).toBe('claude');
+  });
+
+  it('defaults out/keep/wait-ms', () => {
+    const parsed = parseArgs(['--host', 'codex']);
+    expect(parsed.out).toBeNull();
+    expect(parsed.keep).toBe(false);
+    expect(parsed.waitMs).toBe(DEFAULT_WAIT_MS);
+  });
+
+  it('reads --out, --keep and --wait-ms', () => {
+    const parsed = parseArgs(['--host', 'claude', '--out', 'report.json', '--keep', '--wait-ms', '30000']);
+    expect(parsed).toMatchObject({ host: 'claude', out: 'report.json', keep: true, waitMs: 30_000 });
+  });
+
+  it('requires a host', () => {
+    expect(() => parseArgs([])).toThrow(/--host is required/);
+  });
+
+  it('rejects an unsupported host rather than guessing one', () => {
+    expect(() => parseArgs(['--host', 'gemini'])).toThrow(/must be codex or claude/);
+  });
+
+  it('rejects unknown arguments instead of ignoring them', () => {
+    expect(() => parseArgs(['--host', 'codex', '--print'])).toThrow(/Unknown argument --print/);
+  });
+
+  it('rejects a flag whose value is missing', () => {
+    expect(() => parseArgs(['--host'])).toThrow(/--host requires a value/);
+    expect(() => parseArgs(['--host', 'codex', '--out', '--keep'])).toThrow(/--out requires a value/);
+  });
+
+  it('bounds --wait-ms', () => {
+    expect(() => parseArgs(['--host', 'codex', '--wait-ms', '10'])).toThrow(/between 1000 and 3600000/);
+    expect(() => parseArgs(['--host', 'codex', '--wait-ms', 'soon'])).toThrow(/between 1000 and 3600000/);
+  });
+
+  it('does not demand a host when only --help was asked for', () => {
+    expect(parseArgs(['--help'])).toMatchObject({ help: true, host: null });
+  });
+});
+
+describe('--help', () => {
+  it('says print mode is unsupported and names the issue', () => {
+    const text = helpText();
+    expect(text).toMatch(/claude -p/);
+    expect(text).toMatch(/NOT supported/);
+    expect(text).toMatch(/issue #275/);
+  });
+
+  it('states that it never touches the owner’s real memory directory', () => {
+    expect(helpText()).toMatch(/\$HOME\/\.memesh/);
+  });
+});
+
+describe('assertSafeMemeshPaths', () => {
+  const home = '/Users/example';
+
+  it('allows a temporary directory outside the owner’s memesh directory', () => {
+    expect(() => assertSafeMemeshPaths({
+      memeshDir: '/private/tmp/memesh-live-journey-abc/memesh',
+      dbPath: '/private/tmp/memesh-live-journey-abc/memesh/knowledge-graph.db',
+      home,
+    })).not.toThrow();
+  });
+
+  it('refuses when MEMESH_DIR is the owner’s memesh directory', () => {
+    expect(() => assertSafeMemeshPaths({
+      memeshDir: `${home}/.memesh`,
+      dbPath: '/private/tmp/x/knowledge-graph.db',
+      home,
+    })).toThrow(/Refusing to run: MEMESH_DIR/);
+  });
+
+  it('refuses when MEMESH_DB_PATH sits under the owner’s memesh directory', () => {
+    expect(() => assertSafeMemeshPaths({
+      memeshDir: '/private/tmp/x/memesh',
+      dbPath: `${home}/.memesh/knowledge-graph.db`,
+      home,
+    })).toThrow(/Refusing to run: MEMESH_DB_PATH/);
+  });
+
+  it('refuses a path that only reaches ~/.memesh after normalisation', () => {
+    expect(() => assertSafeMemeshPaths({
+      memeshDir: `${home}/projects/../.memesh/hosts`,
+      dbPath: '/private/tmp/x/knowledge-graph.db',
+      home,
+    })).toThrow(/Refusing to run/);
+  });
+
+  it('does not confuse a sibling directory with a prefix match', () => {
+    expect(() => assertSafeMemeshPaths({
+      memeshDir: `${home}/.memesh-scratch/memesh`,
+      dbPath: `${home}/.memesh-scratch/memesh/knowledge-graph.db`,
+      home,
+    })).not.toThrow();
+  });
+});
+
+describe('assertDistPresent', () => {
+  it('names every missing artefact rather than the first one', () => {
+    expect(() => assertDistPresent('/repo', () => false))
+      .toThrow(/router\.js.*cli\.js.*codex-session\.js/s);
+  });
+
+  it('passes when every required artefact exists', () => {
+    expect(() => assertDistPresent('/repo', () => true)).not.toThrow();
+    expect(REQUIRED_DIST).toContain('dist/host-runtime/router.js');
+  });
+});
+
+describe('parseCodexThreadId', () => {
+  it('reads the thread id Codex printed', () => {
+    expect(parseCodexThreadId(GOOD_REPLY)).toBe(THREAD);
+  });
+
+  it('fails closed when Codex started no thread', () => {
+    expect(() => parseCodexThreadId('{"type":"turn.completed"}\n')).toThrow(/no `thread.started` event/);
+  });
+
+  it('ignores non-JSON noise interleaved on the stream', () => {
+    expect(parseCodexThreadId(`warning: something\n${GOOD_REPLY}`)).toBe(THREAD);
+  });
+});
+
+describe('collectCodexAgentMessages', () => {
+  it('collects every agent message in the turn, not just the last', () => {
+    expect(collectCodexAgentMessages(GOOD_REPLY)).toEqual([
+      'Acknowledged. No action taken.',
+      `CODEX_RECEIVED_${SENTINEL} ${MESSAGE_ID} ${DELIVERY_ID}`,
+    ]);
+  });
+
+  it('ignores non-agent-message items such as command executions', () => {
+    const withCommand = [
+      JSON.stringify({
+        type: 'item.completed',
+        item: { id: 'item_0', type: 'command_execution', command: 'ls', exit_code: 0 },
+      }),
+      JSON.stringify({ type: 'item.completed', item: { id: 'item_1', type: 'agent_message', text: 'READY' } }),
+    ].join('\n');
+    expect(collectCodexAgentMessages(withCommand)).toEqual(['READY']);
+  });
+});
+
+describe('assertCodexReply', () => {
+  const expected = { sentinel: SENTINEL, messageId: MESSAGE_ID, deliveryId: DELIVERY_ID };
+
+  it('accepts a reply quoting the sentinel and both ids', () => {
+    expect(assertCodexReply({ jsonl: GOOD_REPLY, ...expected }))
+      .toContain(`CODEX_RECEIVED_${SENTINEL}`);
+  });
+
+  it('rejects a reply carrying the WRONG message_id', () => {
+    const wrong = codexTurn([`CODEX_RECEIVED_${SENTINEL} 00000000-0000-4000-8000-000000000000 ${DELIVERY_ID}`]);
+    expect(() => assertCodexReply({ jsonl: wrong, ...expected }))
+      .toThrow(/does not quote message_id b234ba88/);
+  });
+
+  it('rejects a reply with the sentinel but no ids at all', () => {
+    expect(() => assertCodexReply({ jsonl: codexTurn([`CODEX_RECEIVED_${SENTINEL}`]), ...expected }))
+      .toThrow(/does not quote message_id/);
+  });
+
+  it('rejects a reply carrying the wrong delivery_id', () => {
+    const wrong = codexTurn([`CODEX_RECEIVED_${SENTINEL} ${MESSAGE_ID} 11111111-1111-4111-8111-111111111111`]);
+    expect(() => assertCodexReply({ jsonl: wrong, ...expected }))
+      .toThrow(/does not quote delivery_id/);
+  });
+
+  it('rejects NO_ENVELOPE with the reason, not a generic mismatch', () => {
+    expect(() => assertCodexReply({ jsonl: codexTurn(['NO_ENVELOPE']), ...expected }))
+      .toThrow(/not visible to the model/);
+  });
+
+  it('rejects a turn that produced no agent message', () => {
+    expect(() => assertCodexReply({ jsonl: '{"type":"turn.completed"}', ...expected }))
+      .toThrow(/no agent message/);
+  });
+});
+
+describe('assertNativeAccepted', () => {
+  it('accepts a send whose exact session took the frame', () => {
+    expect(assertNativeAccepted(ACCEPTED_SEND, 'codex-cli-queue'))
+      .toMatchObject({ messageId: MESSAGE_ID, deliveryId: DELIVERY_ID });
+  });
+
+  it('rejects a durable send with NO native_delivery block', () => {
+    const { native_delivery: _dropped, ...durableOnly } = ACCEPTED_SEND;
+    expect(() => assertNativeAccepted(durableOnly, 'codex-cli-queue'))
+      .toThrow(/no native_delivery block/);
+  });
+
+  it('rejects a send whose native delivery was not accepted', () => {
+    const unavailable = {
+      ...ACCEPTED_SEND,
+      native_delivery: { ...ACCEPTED_SEND.native_delivery, status: 'recipient_unavailable' },
+    };
+    expect(() => assertNativeAccepted(unavailable, 'codex-cli-queue'))
+      .toThrow(/not "native_accepted"/);
+  });
+
+  it('rejects acceptance by the wrong adapter', () => {
+    expect(() => assertNativeAccepted(ACCEPTED_SEND, 'claude-channel'))
+      .toThrow(/adapter_kind is "codex-cli-queue"/);
+  });
+
+  it('rejects a result that is not an object', () => {
+    expect(() => assertNativeAccepted('ok', 'codex-cli-queue')).toThrow(/no JSON object/);
+  });
+});
+
+describe('assertRecipientUnavailable', () => {
+  it('accepts a non-zero exit naming recipient_unavailable', () => {
+    expect(() => assertRecipientUnavailable({
+      status: 1,
+      stderr: 'Error: recipient_unavailable: the exact active session did not accept the native message.\n',
+    })).not.toThrow();
+  });
+
+  it('rejects a send to a stopped session that SUCCEEDED', () => {
+    expect(() => assertRecipientUnavailable({ status: 0, stderr: '' }))
+      .toThrow(/did not fail closed/);
+  });
+
+  it('rejects a different failure wearing a non-zero exit code', () => {
+    expect(() => assertRecipientUnavailable({ status: 1, stderr: 'Error: native_message_too_large' }))
+      .toThrow(/Expected recipient_unavailable/);
+  });
+});
+
+describe('intake receipts', () => {
+  it('finds the intake the recipient session wrote', () => {
+    expect(findIntakeReceipt(RECEIPTS_WITH_INTAKE, { messageId: MESSAGE_ID, actor: THREAD }))
+      .toMatchObject({ receipt_kind: 'intake', actor: THREAD });
+  });
+
+  it('rejects a projection carrying host_accept but NO intake', () => {
+    expect(() => assertIntakeReceipt(RECEIPTS_WITHOUT_INTAKE, { messageId: MESSAGE_ID, actor: THREAD }))
+      .toThrow(/No intake receipt written by/);
+  });
+
+  it('rejects an intake written by a different session', () => {
+    expect(() => assertIntakeReceipt(RECEIPTS_WITH_INTAKE, { messageId: MESSAGE_ID, actor: 'someone-else' }))
+      .toThrow(/No intake receipt written by someone-else/);
+  });
+
+  it('rejects an intake for a different message', () => {
+    expect(() => assertIntakeReceipt(RECEIPTS_WITH_INTAKE, { messageId: 'other-message', actor: THREAD }))
+      .toThrow(/No intake receipt/);
+  });
+
+  it('treats an empty projection as no proof', () => {
+    expect(findIntakeReceipt([], { messageId: MESSAGE_ID, actor: THREAD })).toBeNull();
+    expect(findIntakeReceipt(null, { messageId: MESSAGE_ID, actor: THREAD })).toBeNull();
+  });
+});
+
+describe('findLiveCards', () => {
+  const discovered = {
+    cards: [
+      { session_id: THREAD, principal_id: 'codex-live-journey', host_kind: 'codex', active: true, generation: 1 },
+      { session_id: 'abc', principal_id: 'claude-live-journey', host_kind: 'claude', active: true, generation: 1 },
+    ],
+  };
+
+  it('filters by host kind', () => {
+    expect(findLiveCards(discovered, { hostKind: 'claude' }).map((card) => card.session_id)).toEqual(['abc']);
+  });
+
+  it('filters by session id', () => {
+    expect(findLiveCards(discovered, { sessionId: THREAD })).toHaveLength(1);
+  });
+
+  it('returns nothing for a router answer with no cards array', () => {
+    expect(findLiveCards({}, { hostKind: 'claude' })).toEqual([]);
+    expect(findLiveCards(null)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Turns the ad-hoc live journey that proved v4.8.3's exact-session delivery into a repeatable, owner-run check: `npm run qa:live-journey -- --host codex|claude [--out report.json]` (`scripts/qa/live-journey.mjs`). This is the last open box on #270 and #272.

- Runs this checkout's `dist/` router/hosts/CLI against a fresh `mkdtemp` `MEMESH_DIR` (0700); refuses any path under `$HOME/.memesh`; reads no auth files (Codex precondition is the exit code of `codex login status`); deletes the temp dir on exit; never runs in CI.
- Passes only on **model-visible** proof, not `host_accept`: Codex must quote the envelope's `message_id` and `delivery_id` back on a resumed turn; Claude must write an `intake` receipt from the interactive session the operator launched with the printed command.
- Then stops the session and requires `recipient_unavailable` **while** `message fetch` still returns the payload and `discover` still answers — the same string is returned when the sender cannot reach the router (#274), so the assertion is a triple.
- Disclosed in `--help`, docs and the report: Codex registration is harness-driven (`--ignore-user-config` bypasses the plugin SessionStart hook); print-mode Claude is unsupported (#275); the Claude check cannot observe whether the operator typed anything.

## Type of change

- [x] Feature (`feat`)
- [x] Test only (`test`)
- [x] Docs only (`docs`)

## Docs synced

- [x] `CHANGELOG.md` `[Unreleased]`
- [x] `docs/platforms/agent-messaging.md` — new "Repeatable owner-run live checks" section
- [x] `CODEMAP.md`, `package.json` script inventory

## Verification (worktree at the PR head)

- `node scripts/run-tests-isolated.mjs tests/qa/live-journey.test.ts` → exit 0, 45/45
- Mutations: invert `assertCodexReply`'s message_id check → 4 failed / 41 passed; disable `assertNativeAccepted`'s status check → 1 failed / 44 passed; restored → 45/45
- `npm run lint` 0, `npm run typecheck` 0, `check-doc-claims` 0, `check-codemap-parity` 0, `npm run verify:release` 0
- **Runtime, `--host codex`, twice on this tree** (once by the implementer, once by the orchestrator): exit 0, 9/9 PASS; model reply `CODEX_RECEIVED_codex-39846d5f c59ee55b-cf2b-4ee1-badd-a0371a8bb034 25ecd2c5-e096-412e-a2bb-9e71b3e4e1fa`; no temp dir or process leaked
- `--host claude --wait-ms 5000` → exit 1 with a named cause ("No Claude channel session registered with the router…") — steps 1–4 live, **steps 5–9 (send → intake → disconnect → fail-closed) have not yet been exercised against a real interactive session**

## Test plan

- CI on this head.
- Before closing #272: one owner-run `npm run qa:live-journey -- --host claude` with the printed interactive launch command; attach the report.
- Before closing #270: attach the `--host codex` report (already produced on this tree).

## Round 2 (commit 10e91b31) — cross-model review findings closed

A read-only fable review of e3228d65 returned PASS_WITH_CONCERNS with four P1s. All are closed in 10e91b31:

- **P1-1 orphan router** — `Journey.shutdown()` unwinds companion → live session (bounded wait, operator told to exit) → router → directories, awaiting each exit with SIGKILL escalation, and keeps the directory when a session is still connected at the bound (a connected host respawns a detached router into a deleted temp dir). SIGINT/SIGTERM take the same path (exit 130/143).
- **P1-2 forgeable ids under `-s read-only`** — `assertCodexRanNoCommands` fails the proof turn on any `item.completed` outside `{agent_message, error}`; the Codex workspace is a separate `mkdtemp` outside the journey directory; the prompt also says "read no files".
- **P1-3 Claude session isolation** — the printed command passes `--setting-sources ""` (accepted by the CLI; not verified to exclude plugin hooks/MCP), the operator is told to confirm with `/mcp` and `/hooks`, and `--help`/docs/report limitations state the launched session is outside the isolation.
- **P1-4 revision binding** — the report records `dirty` and `dist_stale` and warns on both.
- P2: `--help` discloses the harness-driven registration; the `~/.memesh` refusal compares real paths before `mkdtemp` (symlink test); `CI` set → refuse; `assertNativeAccepted` also checks `delivery_id`, `recipient`, receipt `thread_id`; `assertRecipientUnavailable` rejects a killed process; socket path ≤ 103 bytes self-check; `--ignore-user-config` claim reworded to what was observed.

Verification on 10e91b31 (orchestrator, not the implementer): `tests/qa/live-journey.test.ts` 70/70; mutation (allowlist inverted) → 3 failed / 67 passed, restored 70/70; lint / typecheck / check-doc-claims / check-codemap-parity / verify:release all exit 0; `TMPDIR=/private/tmp node scripts/qa/live-journey.mjs --host codex` → PASS 9/9, `dist_stale: false`, model reply `CODEX_RECEIVED_codex-567bfae4 71171b66-… 71899dd9-…`, no temp dir or process left. A second fable review of the delta is in progress; **the Claude path's send → intake → disconnect steps still need one owner-run interactive session before #272 closes.**

## Round 3 (commit 0b3d12fb) — second fable review closed

The second fable review (of 10e91b31) returned PASS_WITH_CONCERNS with one new defect and two residues; 0b3d12fb closes them: `shutdown()` is memoised on a promise (a racing signal handler no longer exits before `rmSync` runs); router and companion are spawned `detached` so a terminal Ctrl-C reaches only the harness, which unwinds in order; the no-command check walks every `codex exec --json` event (unknown event types fail closed, `item.*` must carry an allow-listed item type, `reasoning` allowed, an `item.started` command rejected); the socket-length check runs before `mkdtemp`; a signal writes the partial report first.

Verification on 0b3d12fb: `tests/qa/live-journey.test.ts` 73/73; mutation (event-level check removed) → 1 failed / 72 passed, restored 73/73; lint / typecheck 0. **Evidence Gates** ledger rebuilt at base `f53c31e0`: `eg check` PASS (`live-journey-check` CODE_COMPLETE with a known_bad_mutation failure_path and a real `--host codex` process_boundary run — PASS 9/9, model reply `CODEX_RECEIVED_codex-ca52b1f5 3cb1543b-… 99a23d10-…`; `live-journey-docs` CODE_COMPLETE); `eg status`: implementation verified, review/runtime/human-authorization unverified (eg does not attest Claude Code reviewers). A third fable delta review is running. The Claude path's send → intake → disconnect steps still need one owner-run interactive session before #272 closes.


## Round 4 (rebased onto `b223cf12`) — Windows CI closed, evidence re-recorded

Both Windows legs failed on five tests in this PR's own new test file. The cause was the fixtures, not the functions: `assertOutsideOwnerMemesh` was fed POSIX literals (`/Users/example`) with an identity realpath, so on Windows `path.resolve` prepends the runner's drive and the comparison can never match; `realpathAsFarAsPossible` was fed `/tmp`, which resolves to a non-existent `D:\tmp` and threw ENOENT while building the *expected* value. Driven with real OS-native paths, as production does, both functions are correct on Windows.

The deeper point: the check has nothing to prove there. The host-native router, its Unix socket and the managed adapters are macOS/Linux only (`docs/platforms/agent-messaging.md`). So `assertSupportedPlatform` now refuses on `win32` before anything is created — named in `--help` beside the other refusals, tested on every platform — and the two POSIX-fixture describes take the repo's existing `describe.skipIf(process.platform === 'win32')` idiom, the same guard `tests/host-runtime/*.test.ts` already use for this surface.

Verification on the rebased head: `tests/qa/live-journey.test.ts` 75/75; mutation (win32 branch disabled) → 1 failed / 74 passed, restored 75/75; `npm run lint`, `npm run typecheck`, `npm run verify:release` all exit 0. **Evidence Gates** ledger rebuilt at base `b223cf12`: `eg check` PASS — `live-journey-check` CODE_COMPLETE (focused_test, static_check, a known_bad_mutation failure_path, and a real `--host codex` process_boundary run: verdict PASS, `dirty: false`, `dist_stale: false`), `live-journey-docs` CODE_COMPLETE. `eg status` remains BLOCKED on review / runtime / human-authorization, which eg cannot attest for a Claude Code reviewer.

Still open before #272 can close: one owner-run `npm run qa:live-journey -- --host claude` against a real interactive session.
