### PR TITLE
test(router): give the discover test a lease that survives a slow runner

### DIFF
--- a/tests/core/agent-router.test.ts
+++ b/tests/core/agent-router.test.ts
@@ -629,7 +629,14 @@ describe.runIf(process.platform !== 'win32').sequential('AgentRouter real SQLite
 
   it('discovers only live registrations in the requested project with declared metadata', async () => {
     const { db, socketPath, token } = setup();
-    await startRouter(db, socketPath, token, { lease_ms: 250 });
+    // A long lease on purpose: this test proves that live registrations are
+    // listed, not that expiry works (the next test expires the lease in
+    // SQLite directly). With lease_ms: 250 the client heartbeats every 125 ms,
+    // and a CI runner under load (a 577 s suite instead of ~300 s) let the
+    // lease lapse between connect and discover, returning [] — run
+    // 33598450056, Release Verification Gate, on a PR that never touched
+    // this code.
+    await startRouter(db, socketPath, token, { lease_ms: 5_000 });
     await RouterHostClient.connect({
       socketPath, token, project: 'project-a', principal: 'principal-codex', session: 'session-codex',
       model: 'gpt-5.6-luna', workSummary: 'review router contract',


### PR DESCRIPTION
## Summary

Test-only. `tests/core/agent-router.test.ts` › "discovers only live registrations in the requested project with declared metadata" started the router with `lease_ms: 250` (client heartbeat every 125 ms). On a loaded Linux runner — run 33598450056, Release Verification Gate on PR #281, where the suite took 577 s instead of ~300 s — the lease lapsed between the two `connect`s and the `discover`, and the assertion saw `[]`. The same test passed on the other twelve legs of that run, on #279/#280, and locally on the same commit.

The test proves that live registrations are listed with their metadata; expiry is proven by the following test, which expires the lease in SQLite directly. It now uses a 5 s lease.

## Type of change

- [x] Test only (`test`)

## Verification

- `node scripts/run-tests-isolated.mjs tests/core/agent-router.test.ts` → exit 0, 19 passed / 1 skipped
- `npm run lint` 0, `npm run typecheck` 0

## Test plan

- CI on this head. No product change; no CHANGELOG entry (tests only).
