### PR TITLE
test(router): give the heartbeat test a lease that survives a slow runner

### DIFF
--- a/tests/core/agent-router.test.ts
+++ b/tests/core/agent-router.test.ts
@@ -695,7 +695,14 @@ describe.runIf(process.platform !== 'win32').sequential('AgentRouter real SQLite
 
   it('does not infer missing metadata and heartbeat refreshes the authoritative lease', async () => {
     const { db, socketPath, token } = setup();
-    await startRouter(db, socketPath, token, { lease_ms: 120 });
+    // A long lease on purpose, for the same reason as the discover test above.
+    // What this proves is that a heartbeat moves lease_expires_at_ms forward
+    // and that absent metadata stays null — neither needs the lease to be
+    // short. With lease_ms: 120 the client heartbeats every 60 ms, and a
+    // loaded CI runner let the registration lapse between connect and the
+    // first discover, so `initial.cards` came back empty: run 33635969712,
+    // ubuntu Node 24, on a PR that never touched this code.
+    await startRouter(db, socketPath, token, { lease_ms: 5_000 });
     const host = await RouterHostClient.connect({
       socketPath, token, project: 'project-a', principal: 'principal-a', session: 'session-a',
     });
@@ -712,7 +719,7 @@ describe.runIf(process.platform !== 'win32').sequential('AgentRouter real SQLite
     await expect(sendAgentRouterRequest(socketPath, {
       version: 1, type: 'heartbeat', request_id: randomUUID(), project: 'project-a',
       session_instance_id: 'session-a', connection_id: host.connectionId, generation: host.generation, hops: 0,
-    })).resolves.toMatchObject({ generation: host.generation, lease_ms: 120 });
+    })).resolves.toMatchObject({ generation: host.generation, lease_ms: 5_000 });
     const refreshed = await discover();
     expect((refreshed.cards as Frame[])[0].lease_expires_at_ms).toBeGreaterThan(initialLease);
   });


### PR DESCRIPTION
## Summary

Test-only. Second instance of the flake PR #283 fixed for the sibling test in the same file.

`does not infer missing metadata and heartbeat refreshes the authoritative lease` started the router with `lease_ms: 120`, so the client heartbeated every 60 ms. On a loaded ubuntu Node 24 runner the registration lapsed between `connect` and the first `discover`, and `initial.cards` came back empty — run 33635969712, on PR #285, which never touched this code.

The short lease is not what the test proves: it asserts that absent metadata stays `null` and that a heartbeat moves `lease_expires_at_ms` forward. The `120` in the heartbeat assertion only echoes the configured value. Both hold at 5 s, and the explicit 10 ms sleep before the heartbeat still makes the refreshed lease strictly greater. Expiry itself stays proven by the following test, which expires the lease in SQLite directly.

## Type of change

- [x] Test only (`test`)

## Verification

- `node scripts/run-tests-isolated.mjs tests/core/agent-router.test.ts` → exit 0, 19 passed / 1 skipped
- `npm run lint` 0, `npm run typecheck` 0

No CHANGELOG entry (tests only), so this merges without conflicting with the other open PRs — the same reason #283 could go in first.
