### PR TITLE
fix(tests): three guards that could not fail, and the silent failure one of them hid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,41 @@ All notable changes to MeMesh are documented here.
 
 ### Fixed
 
+- **Three release-gate guards that could not fail, and the silent failure one
+  of them was hiding.** A mutation audit reintroduced the defect each guard was
+  written for and re-ran the suite: with all three defects present at once,
+  3286 tests were green.
+  - `check-generated-mirror`'s "a failed build must fail the gate" assertion
+    matched `/catch[\s\S]{0,200}process\.exit\(1\)/` against the whole
+    script, which has FOUR such pairs — deleting the exit from the *build*
+    catch satisfied it via one of the other three. That is not cosmetic:
+    `npm run build` is an `&&` chain, so a `tsc` failure short-circuits it and
+    `scripts/hooks/_generated/` is never regenerated — the exact hook/core
+    divergence this gate exists to catch — after which the gate diffs, finds
+    nothing, and prints a green tick. The assertion is now scoped to the build
+    catch's own block.
+  - `check-doc-claims`'s test-count rule was pinned by asserting the gate
+    *imports* the shared predicate. The gate could keep the import and filter
+    with a private English-only regex at the call site, which is the drift the
+    test was written for; replacing the call with `/\b\d[\d,]*\s+tests?\b/i`
+    (blind to `630 項測試`) left the suite green. Now pinned at the call site,
+    plus a behavioural probe that runs the shipped gate against a Chinese
+    test-count claim and requires it to exit 1 naming the file.
+  - The session-start banner's per-host upgrade advice was pinned by asserting
+    three strings were present in one function. The defect is a wrong *mapping*,
+    not a missing string: making the codex branch unreachable handed every
+    Codex user the Claude Code command with all three strings still in place.
+    Now pinned as a pairing — the codex predicate and the codex command in one
+    branch.
+- **`pluginHostOf` collapsed "could not ask" into "not Codex".** It was
+  `detectPluginHost?.(root) ?? null` inside a bare `catch { return null }`, and
+  `null` is a legitimate answer meaning "this path is not under any plugin
+  cache" — so a module that failed to load, or a detector that threw, produced
+  the identical banner a confident "not Codex" would, with no mutation needed.
+  It now returns `'unknown'` for that state, matching what
+  `getCurrentInstallChannel` already did, and the banner names both upgrade
+  paths rather than guessing one.
+
 - **`memesh pin`/`unpin --json` no longer reports a pin that never happened.**
   `setPinned` echoed the *requested* `pinned` argument back in its result even
   when the named entity did not exist, so `memesh pin --name nonexistent

--- a/dist/skills-manifest.json
+++ b/dist/skills-manifest.json
@@ -123,8 +123,8 @@
     },
     {
       "path": "scripts/hooks/session-start.js",
-      "sha256": "64fb72cf4a273ea74faf4467d6d9b0b4f9e3085e5f6cc992377da04bb23a4cbb",
-      "bytes": 60929
+      "sha256": "9883ce003e9fa4326cfd71699d56365d6ec72e9f866b27566067c9d0c871b9b0",
+      "bytes": 62069
     },
     {
       "path": "scripts/hooks/session-summary.js",

--- a/scripts/hooks/session-start.js
+++ b/scripts/hooks/session-start.js
@@ -334,11 +334,24 @@ function detectInstallChannelHook(pluginRoot) {
  * Claude Code wording rather than suppressing the hint entirely — the
  * banner is more useful naming the majority host than naming none.
  */
+/**
+ * Which plugin host is this install under — or `'unknown'` when we could not
+ * ask.
+ *
+ * `null` is a real answer from `detectPluginHost`: "this path is not under any
+ * plugin cache". So `detectPluginHost?.(root) ?? null` inside a bare catch,
+ * which is what this was, gave a module that failed to load and a detector
+ * that threw the SAME value as a confident "not Codex" — and
+ * `pluginUpgradeLine` then handed every Codex user the Claude Code command.
+ * `getCurrentInstallChannel` above already returns `'unknown'` for exactly
+ * this state; this now matches it.
+ */
 function pluginHostOf(pluginRoot) {
+  if (typeof _installChannelMod?.detectPluginHost !== 'function') return 'unknown';
   try {
-    return _installChannelMod?.detectPluginHost?.(pluginRoot) ?? null;
+    return _installChannelMod.detectPluginHost(pluginRoot);
   } catch {
-    return null;
+    return 'unknown';
   }
 }
 
@@ -354,8 +367,16 @@ function pluginHostOf(pluginRoot) {
  * happened. One owner, so it cannot happen again.
  */
 function pluginUpgradeLine(pluginRoot) {
-  if (pluginHostOf(pluginRoot) === 'codex') {
+  const host = pluginHostOf(pluginRoot);
+  if (host === 'codex') {
     return `    Run: codex plugin marketplace upgrade pcircle-memesh && codex plugin add memesh@pcircle-memesh`;
+  }
+  if (host === 'unknown') {
+    // Naming one host's command here would be a guess presented as an
+    // instruction. Rare — it needs `dist/core/install-channel.js` to be
+    // missing or unloadable — but that is a broken install, which is exactly
+    // when wrong upgrade advice costs the most.
+    return `    Run: memesh upgrade-plugin   (on Codex: codex plugin marketplace upgrade pcircle-memesh && codex plugin add memesh@pcircle-memesh)`;
   }
   return `    Run: memesh upgrade-plugin   (no CLI? npx @pcircle/memesh upgrade-plugin — or reinstall from /plugin UI)`;
 }

--- a/tests/doc-claims-test-count.test.ts
+++ b/tests/doc-claims-test-count.test.ts
@@ -14,6 +14,7 @@
 import { describe, it, expect } from 'vitest';
 import fs from 'fs';
 import path from 'path';
+import { spawnSync } from 'child_process';
 import { statesTestCount } from '../scripts/lib/test-count-claim.mjs';
 
 describe('the READMEs-state-no-test-count rule', () => {
@@ -47,6 +48,48 @@ describe('the READMEs-state-no-test-count rule', () => {
     );
     expect(gate).toContain("import { statesTestCount } from './lib/test-count-claim.mjs'");
     expect(gate, 'the gate kept a private regex copy').not.toMatch(/項測試\s*\/[a-z]*;/);
+    // The import alone proves nothing — the gate can keep it and still filter
+    // with a private regex at the call site, which is the drift this test was
+    // written for. Measured: replacing the call with an English-only
+    // `/\b\d[\d,]*\s+tests?\b/i` — the original defect verbatim, blind to
+    // `630 項測試` — left this file and the whole suite green.
+    expect(
+      gate,
+      'the gate imports statesTestCount but no longer calls it on the README list',
+    ).toMatch(/readmes\.filter\(\s*f\s*=>\s*statesTestCount\(/);
+  });
+
+  it('the shipped gate really rejects a README that states a count, in Chinese', () => {
+    // The behavioural half. Everything above reads source text or calls the
+    // predicate directly; none of it runs `check-doc-claims.mjs`, so none of it
+    // can tell whether the gate a release depends on still enforces this.
+    //
+    // The probe is phrased in Chinese on purpose: an English-only regex — the
+    // exact shape that drifted here before — cannot see it, so a gate that
+    // stopped using the shared predicate exits 0 and fails this test.
+    // `check-doc-claims.mjs` fixes its repo root from `import.meta.url`, so it
+    // cannot be pointed at a fixture directory; a real file, removed in
+    // `finally`, is the only way to ask it.
+    const repoRoot = path.join(__dirname, '..');
+    const probe = path.join(repoRoot, 'README.guardprobe.md');
+    fs.writeFileSync(probe, '```bash\nnpm test  # 630 項測試\n```\n');
+    let out: string;
+    let status: number | null;
+    try {
+      const r = spawnSync(process.execPath, [path.join(repoRoot, 'scripts/check-doc-claims.mjs')], {
+        cwd: repoRoot,
+        encoding: 'utf8',
+      });
+      out = `${r.stdout ?? ''}${r.stderr ?? ''}`;
+      status = r.status;
+    } finally {
+      fs.rmSync(probe, { force: true });
+    }
+    expect(status, out).toBe(1);
+    // The message, not just the exit code: this gate runs about twenty checks,
+    // and any one of them tripping on the extra file would produce exit 1 for
+    // a reason that has nothing to do with test counts.
+    expect(out).toContain('README(s) state a hardcoded test count: README.guardprobe.md');
   });
 
   it('the repository itself currently states no test count', () => {

--- a/tests/hooks/banner-channel-coverage.test.ts
+++ b/tests/hooks/banner-channel-coverage.test.ts
@@ -89,5 +89,36 @@ describe('session-start banners cover every install channel', () => {
     expect(body, 'the helper does not consult the plugin host').toMatch(/pluginHostOf\(/);
     expect(body, 'no Codex-specific command').toMatch(/codex plugin marketplace upgrade/);
     expect(body, 'no Claude Code command').toMatch(/memesh upgrade-plugin/);
+    // The three assertions above are satisfied by the strings merely being
+    // PRESENT, and the defect here is a wrong mapping, not a missing string.
+    // Measured: changing the predicate to `=== 'codex-disabled'` — so every
+    // Codex user is handed the Claude Code command — left all three green, and
+    // the whole suite with them. Pin the pairing instead: the codex predicate
+    // and the codex command inside one branch.
+    expect(body, 'the helper no longer asks pluginHostOf for the value it branches on')
+      .toMatch(/const host = pluginHostOf\(pluginRoot\);/);
+    expect(
+      body,
+      "the codex branch no longer returns the codex command — the strings are all still there, the mapping is not",
+    ).toMatch(/if \(host === 'codex'\) \{[\s\S]{0,200}?codex plugin marketplace upgrade/);
+  });
+
+  it("says so when it could not ask which host this is, rather than assuming Claude Code", () => {
+    // `pluginHostOf` used to be `detectPluginHost?.(root) ?? null` inside a
+    // bare `catch { return null }`. `null` is a legitimate answer — "this path
+    // is not under any plugin cache" — so a module that failed to load, or a
+    // detector that threw, produced the same value as a confident "not Codex"
+    // and every Codex user silently got the Claude Code command. That is the
+    // same wrong outcome as the mutation above, reachable in production with
+    // no mutation at all.
+    const src = fs.readFileSync(HOOK, 'utf8');
+    const start = src.indexOf('function pluginHostOf(');
+    expect(start, 'pluginHostOf not found').toBeGreaterThan(-1);
+    const body = src.slice(start, src.indexOf('\nfunction ', start + 1));
+    expect(body, 'a missing detector still collapses into a host answer').toMatch(/return 'unknown'/);
+    expect(body, "a thrown detector still collapses into a host answer").toMatch(/catch\s*\{[^}]*'unknown'/);
+    const line = src.slice(src.indexOf('function pluginUpgradeLine('));
+    expect(line.slice(0, line.indexOf('\nfunction ', 1)), 'the unknown case is not handled separately')
+      .toMatch(/'unknown'/);
   });
 });

--- a/tests/release-scripts-safety.test.ts
+++ b/tests/release-scripts-safety.test.ts
@@ -117,7 +117,28 @@ describe('Feature: release scripts never edit the real ~/.memesh', () => {
     expect(buildAt, 'the gate diffs before it builds').toBeLessThan(diffAt);
     // A failed build must fail the gate. Reporting "output is current" because
     // the compiler crashed is the same class of lie one level up.
-    expect(text).toMatch(/catch[\s\S]{0,200}process\.exit\(1\)/);
+    //
+    // Scoped to the BUILD catch, deliberately. This used to be
+    // `expect(text).toMatch(/catch[\s\S]{0,200}process\.exit\(1\)/)`, and the
+    // script has FOUR `process.exit(1)` calls each preceded by a catch — any
+    // one of them satisfied an unanchored regex, so deleting the exit from the
+    // build catch left this test green. Measured: with that one line removed,
+    // this file passed and so did the whole suite.
+    //
+    // What that costs is not hypothetical. `npm run build` is an `&&` chain
+    // (`check-schema-drift && tsc && generate-hook-core && …`), so a tsc
+    // failure short-circuits it and `scripts/hooks/_generated/` is never
+    // regenerated — the exact hook/core divergence this gate's own docblock
+    // names as the class behind the P0 FTS omission. Falling through to
+    // `git diff --stat` then finds nothing to report and prints a green tick.
+    const buildCatchStart = text.indexOf('} catch (err) {', buildAt);
+    expect(buildCatchStart, 'the build call has no catch').toBeGreaterThan(-1);
+    const buildCatchEnd = text.indexOf('\n}\n', buildCatchStart);
+    expect(buildCatchEnd, 'the build catch is unterminated').toBeGreaterThan(buildCatchStart);
+    expect(
+      text.slice(buildCatchStart, buildCatchEnd),
+      'a failed build no longer fails the gate: it falls through to the diff, which is empty on any tree whose committed output already matches HEAD',
+    ).toContain('process.exit(1)');
   });
 
   it('installs dashboard deps from the lockfile, not the ranges', () => {


### PR DESCRIPTION
A mutation audit reintroduced the defect each of these guards was written for
and re-ran the suite. **With all three defects present at once, the suite was
green.**

```
node scripts/run-tests-isolated.mjs   -> exit=0
  Test Files  229 passed | 1 skipped (230)
  Tests  3275 passed | 11 skipped (3286)
```

All three defects live in `scripts/*.mjs` and `scripts/hooks/*.js`, which are
not compiled, so no stale `dist/` can explain the green.

---

## 1. A failed build reported "output is current"

`tests/release-scripts-safety.test.ts` asserted:

```ts
expect(text).toMatch(/catch[\s\S]{0,200}process\.exit\(1\)/);
```

against the whole of `scripts/check-generated-mirror.mjs` — which has **four**
`catch` / `process.exit(1)` pairs. Deleting the exit from the *build* catch was
satisfied by any of the other three.

Why that matters, and it is not hypothetical — I hit a real `tsc` failure in a
fresh worktree while writing this PR. `npm run build` is an `&&` chain
(`check-schema-drift && tsc && generate-hook-core && …`), so a tsc failure
short-circuits it and **`scripts/hooks/_generated/` is never regenerated** —
the exact hook/core divergence this gate's own docblock names as "the class of
bug behind the P0 FTS omission: a hook wrote an entity but indexed it
differently from core, so the memory was stored and unrecallable." The gate
then falls through to `git diff --stat`, finds nothing, and prints its green
tick.

Now scoped to the build catch's own block, so the other three exits cannot
satisfy it.

## 2. The docs gate could go CJK-blind again

The test-count rule was pinned by asserting the gate **imports** the shared
predicate. The gate can keep the import and filter with a private regex at the
call site — which is precisely the drift this test was written for, and the
file's own header records that it happened once already.

Two assertions now, at different levels:

- the call site, not just the import: `readmes.filter(f => statesTestCount(`
- a behavioural test that runs the shipped gate against a README stating
  `630 項測試` and requires **exit 1 naming the file**

The probe is in Chinese on purpose: an English-only regex — the original defect
verbatim — cannot see it. It matches the gate's exact message rather than just
the exit code, because that gate runs about twenty checks and any of them
tripping on the extra file would give exit 1 for an unrelated reason.
`check-doc-claims.mjs` fixes its repo root from `import.meta.url` and cannot be
pointed at a fixture directory, so a real file (removed in `finally`) is the
only way to ask it.

## 3. Codex users were handed the Claude Code upgrade command

The per-host upgrade advice was pinned by asserting three strings appear
somewhere in one function body. The defect is a wrong **mapping**, not a
missing string: making the codex branch unreachable handed every Codex user
`memesh upgrade-plugin` with all three strings still in place.

Now pinned as a pairing — the predicate and the codex command inside one
branch.

### …and the silent failure that guard was covering

`pluginHostOf` was:

```js
try { return _installChannelMod?.detectPluginHost?.(pluginRoot) ?? null; }
catch { return null; }
```

`null` is a **legitimate** answer from `detectPluginHost` — "this path is not
under any plugin cache". So a module that failed to load, or a detector that
threw, produced the identical value as a confident "not Codex", and every Codex
user got the wrong upgrade command **with no mutation at all**. Same wrong
outcome as the mutation above, reachable in production.

Fixed here rather than noted: it now returns `'unknown'` for that state,
matching what `getCurrentInstallChannel` in the same file already did, and
`pluginUpgradeLine` names both upgrade paths for it instead of guessing one.
Rare — it needs `dist/core/install-channel.js` missing or unloadable — but that
is a broken install, which is when wrong upgrade advice costs the most.

---

## Verification, at `913740c2`

```
node scripts/run-tests-isolated.mjs   -> exit=0
  Test Files  229 passed | 1 skipped (230)
  Tests  3277 passed | 11 skipped (3288)
npm run verify:release                -> exit=0   (all nine steps)
```

Break-tests, using the audit's own mutations — each was **exit=0 (green) on
`main`** and is exit=1 here. Mutate → run → restore, byte-identical restore
asserted by reading the file back:

| Mutation | on main | here |
|---|---|---|
| delete `process.exit(1)` from the build catch | exit=0 | **exit=1** |
| replace `statesTestCount()` with `/\b\d[\d,]*\s+tests?\b/i` | exit=0 | **exit=1** |
| change the codex predicate to `'codex-disabled'` | exit=0 | **exit=1** |
| revert `pluginHostOf` to `?? null` inside a bare catch | exit=0 | **exit=1** |

All four restored → exit=0.

## Scope, stated plainly

The audit mutation-tested **6 guards across 6 files**: 3 confirmed weak (above),
2 held and are discarded here without comment, 1 was weak at its own file but
caught by a sibling test elsewhere, so the repository is protected and no change
was made for it.

**Not covered, and therefore claiming nothing:** `tests/storage/*`,
`tests/dashboard/*`, `tests/transports/*` and the CLI transports had zero
mutations run against them. A heuristic scan flagged 59 loops that could iterate
vacuously; four were inspected and every one carried a real anti-vacuity guard,
so the sweep stopped there rather than burn runs on a pattern that kept holding.
