### PR TITLE
ci: name the derivation, not a version that goes stale

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,7 +280,11 @@ jobs:
       - name: Verify packaged artifact
         run: npm run test:packaged
 
-      - name: Verify packaged upgrade from v4.7.3
+      # The version was written down in two places and both went stale: this
+      # name said v4.7.3 while the script pinned v4.8.2. The script derives
+      # every path it proves from package.json and the registry now, so the
+      # step names the derivation — there is no version here to go stale.
+      - name: Verify every derived packaged upgrade path
         run: npm run test:packaged:upgrade
 
   dashboard-e2e-smoke:


### PR DESCRIPTION
## Summary

One step name. It said "Verify packaged upgrade from v4.7.3" while the script it runs had been pinned to v4.8.2 for four releases — the same fact written in two places, drifting apart in the usual way. PR #296 made the script derive every upgrade path from `package.json` and the registry, so the step now names the derivation and there is no version left here to go stale.

## Type of change

- [x] Build / CI / chore

## Why this is its own PR

Editing anything under `.github/workflows/` reclassifies a change to the `infrastructure_operations` surface in the evidence ledger, whose floor (`OPERATIONALLY_VERIFIED`) implementer-produced evidence cannot reach — so bundling this one-line rename into #296 would have made that PR's ledger unable to close. Separating it keeps both truthful.

## Verification

- [x] `python3 yaml.safe_load` of the workflow lists the `package-smoke` steps as `['Checkout', 'Setup Node.js', 'Install dependencies', 'Build', 'Verify packaged artifact', 'Verify every derived packaged upgrade path']`
- [x] `node scripts/run-tests-isolated.mjs tests/release-scripts-safety.test.ts --maxWorkers=1` → `Tests 22 passed`, exit=0 — that file asserts `ci.yml` still runs `npm run test:packaged:upgrade`, which is the part that must not change
- [x] Behaviour unchanged: same job, same command, only the display name differs

## Known limitations / follow-ups

- Nothing else in this branch. The comment above the step explains why the name no longer carries a version, so the next person does not put one back.
