### PR TITLE
chore(release): bump version 4.8.4 -> 4.8.5

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "memesh",
       "source": "./",
       "description": "MeMesh \u2014 agentic memory for coding agents. Captured from the agent's real work via hooks, recalled when it acts. One SQLite file, zero cloud required.",
-      "version": "4.8.4",
+      "version": "4.8.5",
       "author": {
         "name": "PCIRCLE AI"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -4,7 +4,7 @@
   "author": {
     "name": "PCIRCLE AI"
   },
-  "version": "4.8.4",
+  "version": "4.8.5",
   "mcpServers": "./.claude-plugin/mcp.json",
   "homepage": "https://github.com/PCIRCLE-AI/memesh",
   "repository": "https://github.com/PCIRCLE-AI/memesh",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memesh",
   "description": "MeMesh — agentic memory for coding agents.",
-  "version": "4.8.4",
+  "version": "4.8.5",
   "mcpServers": "./.codex-plugin/mcp.json"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to MeMesh are documented here.
 
 ## [Unreleased]
 
-## [4.8.4] — 2026-09-04
+## [4.8.5] — 2026-09-05
 
 ### Added
 
@@ -528,6 +528,21 @@ All notable changes to MeMesh are documented here.
   project-local install still get separate cache slots. `_shared.js`'s
   independent `readUpdateCheckCache()` path formula is untouched by this —
   it only reads, and the filename scheme did not change.
+
+- **The Claude channel's own instructions told the model it did not need to
+  acknowledge a message it received.** `npm run qa:live-journey -- --host
+  claude` requires the session's own model to call `intake` on an incoming
+  envelope as model-visible proof it was seen; two runs failed identically,
+  because `CHANNEL_INSTRUCTIONS` literally said "no ... acknowledgement of
+  model receipt" is needed, and the model followed that correctly. The
+  instructions now say to call `message` with `action: "intake"` on a full
+  envelope. This does not fix `--host claude` itself — two further runs
+  (one with `--setting-sources ""` removed as a diagnostic) still failed the
+  same way, which appears to be how the currently installed Claude Code
+  CLI's "Channels (experimental)" feature surfaces notifications to the
+  model rather than anything in this repository. `--host claude` remains a
+  known-non-functional `qa:live-journey` path; `--host codex` is what
+  produced this release's live-journey receipt.
 
 ## [4.8.3] — 2026-08-31
 

--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -1,6 +1,6 @@
 # CODEMAP
 
-**Version**: 4.8.4
+**Version**: 4.8.5
 
 A navigation map for the codebase: *"I want to change X — which file?"* For the
 design rationale behind these modules see [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md);

--- a/dist/skills-manifest.json
+++ b/dist/skills-manifest.json
@@ -8,7 +8,7 @@
     },
     {
       "path": ".claude-plugin/plugin.json",
-      "sha256": "2b425a0b6ca6c6a2a549d273616ee0aa418a485960aa5f05ba44a38a6d49e9b5",
+      "sha256": "e44629d387537f864f2bb637b752078d4701dacbc1ef893b41f60e812c98b2b4",
       "bytes": 572
     },
     {
@@ -18,7 +18,7 @@
     },
     {
       "path": ".codex-plugin/plugin.json",
-      "sha256": "1ce4c7b5a8f04cfe1dde55adb6b1af580141de3a73eca0ee5a7bbb066d39b725",
+      "sha256": "b6c3d5f56425f81c131c52f708f6ef128244d6ccd37ac7361c8c5db3f1bc897d",
       "bytes": 154
     },
     {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # MeMesh Plugin Architecture
 
-**Version**: 4.8.4
+**Version**: 4.8.5
 
 > Looking for "which file do I change for X?" — see [CODEMAP.md](../CODEMAP.md).
 

--- a/docs/api/API_REFERENCE.md
+++ b/docs/api/API_REFERENCE.md
@@ -1,7 +1,7 @@
 # MeMesh Plugin -- API Reference
 
 **Protocol**: Model Context Protocol (MCP) over stdio
-**Version**: 4.8.4
+**Version**: 4.8.5
 **Compatibility**: Works with Claude Code plugins, Claude Managed Agents (via MCP connector), and any MCP-compatible client.
 
 **Native Integrations**: Beyond MCP, MeMesh integrates as a native memory provider for Hermes Agent (Python `MemoryProvider` plugin) and OpenClaw (TypeScript memory-capability plugin) — same tier as their built-in backends, not HTTP bridges. See [docs/platforms/](../platforms/) for platform-specific guides.

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -13,7 +13,7 @@
 # is the honest floor rather than a copied one.
 id = "memesh"
 name = "MeMesh"
-version = "4.8.4"
+version = "4.8.5"
 min_herdr_version = "0.7.0"
 description = "Local SQLite memory shared across coding agents — decisions, lessons, and why the code looks the way it does."
 platforms = ["linux", "macos", "windows"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pcircle/memesh",
-  "version": "4.8.4",
+  "version": "4.8.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pcircle/memesh",
-      "version": "4.8.4",
+      "version": "4.8.5",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcircle/memesh",
-  "version": "4.8.4",
+  "version": "4.8.5",
   "description": "MeMesh — agentic memory for coding agents. Captured from the agent's real work via hooks, recalled when it acts. One SQLite file, zero cloud required.",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## What it does
Bumps all 10 version anchors (package.json, package-lock.json x2, both plugin.json manifests, marketplace.json, CHANGELOG.md, CODEMAP.md, docs/ARCHITECTURE.md, docs/api/API_REFERENCE.md, herdr-plugin.toml) from 4.8.4 to 4.8.5, renames the CHANGELOG `[4.8.4]` section to `[4.8.5]` with today's date, and adds an entry documenting the Claude channel intake-instructions fix (PR #301).

## Why it is needed
`package.json` was bumped to 4.8.4 in an earlier commit, but shipped files (`dist/host-runtime/claude.*`, from PR #300 and PR #301) kept changing after that bump while chasing this release's own gate failures. `scripts/lib/release-preconditions.mjs`'s "shipped files changed after bump" guard correctly refuses to cut 4.8.4 as-is — a plugin cache keyed by version would stage 4.8.4 and never see those later fixes. Bumping to 4.8.5 in its own commit, with nothing shipped changing after it, resolves this cleanly.

## How to test
```
node scripts/check-version-coherence.mjs   # all 10 anchors agree at 4.8.5
npm run qa:pre-release                      # build + verify:artifact + audit:memory, all PASS
```

## Linked issues
None.