### PR TITLE
fix: avoid first-session update refresh race

### DIFF
--- a/dist/skills-manifest.json
+++ b/dist/skills-manifest.json
@@ -123,8 +123,8 @@
     },
     {
       "path": "scripts/hooks/session-start.js",
-      "sha256": "cf7535921e5f0758a18e4d7010854762d0372d70db185a578e7a1b3ca61807a4",
-      "bytes": 67464
+      "sha256": "76b51d8fd8cb2dbc157ebccbf1d9eaab8c6b40306110a7d082c98b72cfcd5600",
+      "bytes": 68087
     },
     {
       "path": "scripts/hooks/session-summary.js",

--- a/scripts/hooks/session-start.js
+++ b/scripts/hooks/session-start.js
@@ -545,6 +545,15 @@ function runPostBannerUpdateTasks() {
   if (__postBannerRan) return;
   __postBannerRan = true;
   try {
+    // A first-use session has no database yet. Starting the detached
+    // `memesh status` refresh in that state makes status create/migrate the
+    // database while the next SessionStart may already be opening it
+    // read-only. SQLite can expose that window as a partially-created schema
+    // (for example, `entities` exists while `tags` does not), turning a
+    // harmless update notice into "memories not loaded". The next session
+    // after the first capture will refresh the cache once the database is
+    // fully established; consent itself was already emitted above.
+    if (!existsSync(dbPath)) return;
     let installedVersion = null;
     try {
       const pluginRoot = resolvePluginRoot(import.meta.url);

--- a/tests/hooks/auto-update-consent.test.ts
+++ b/tests/hooks/auto-update-consent.test.ts
@@ -60,6 +60,9 @@ describe('Feature: per-session update consent', () => {
       input: input(session_id), env, encoding: 'utf8',
     }).trim());
     expect(String(runStart('decline-session').systemMessage)).toContain('cannot be upgraded automatically');
+    // A first-use SessionStart must not let its detached update refresh create
+    // a partially migrated database behind the next hook invocation.
+    expect(existsSync(dbPath)).toBe(false);
 
     const userPrompt = path.resolve('scripts/hooks/user-prompt-intent.js');
     execFileSync('node', [userPrompt], {
@@ -67,6 +70,7 @@ describe('Feature: per-session update consent', () => {
     });
     expect(String(runStart('decline-session').systemMessage)).not.toContain('Reply “Upgrade”');
     expect(String(runStart('new-session').systemMessage)).toContain('cannot be upgraded automatically');
+    expect(existsSync(dbPath)).toBe(false);
     expect(existsSync(path.join(dir, 'update-consent'))).toBe(false);
 
     const previousDir = process.env.MEMESH_DIR;


### PR DESCRIPTION
## Summary
- avoid launching detached `memesh status` before the first database exists
- preserve first-use update consent while preventing a partial schema window for the next SessionStart
- add a regression assertion that no DB is created by the first-use hook

## Evidence
- `npx vitest run tests/hooks/auto-update-consent.test.ts --maxWorkers=1`
- `npm test -- --run --reporter=dot` (225 files, 3369 passed, 9 skipped)

The existing v4.9.1 tag/release is not moved by this PR.