### PR TITLE
chore(release): prepare v4.9.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "memesh",
       "source": "./",
       "description": "MeMesh \u2014 agentic memory for coding agents. Captured from the agent's real work via hooks, recalled when it acts. One SQLite file, zero cloud required.",
-      "version": "4.9.1",
+      "version": "4.9.2",
       "author": {
         "name": "PCIRCLE AI"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -4,7 +4,7 @@
   "author": {
     "name": "PCIRCLE AI"
   },
-  "version": "4.9.1",
+  "version": "4.9.2",
   "mcpServers": "./.claude-plugin/mcp.json",
   "homepage": "https://github.com/PCIRCLE-AI/memesh",
   "repository": "https://github.com/PCIRCLE-AI/memesh",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memesh",
   "description": "MeMesh — agentic memory for coding agents.",
-  "version": "4.9.1",
+  "version": "4.9.2",
   "mcpServers": "./.codex-plugin/mcp.json"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to MeMesh are documented here.
 
+## [4.9.2] — 2026-09-09
+
+### Fixed
+
+- **First-use startup no longer races database initialization.** The detached
+  post-banner status refresh now waits until the user's memory database exists,
+  avoiding a partial-schema read during the same startup that initializes a new
+  installation. The first-use update consent prompt remains visible and
+  session-scoped.
+
 ## [4.9.1] — 2026-09-09
 
 ### Fixed

--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -1,6 +1,6 @@
 # CODEMAP
 
-**Version**: 4.9.1
+**Version**: 4.9.2
 
 A navigation map for the codebase: *"I want to change X — which file?"* For the
 design rationale behind these modules see [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md);

--- a/dist/skills-manifest.json
+++ b/dist/skills-manifest.json
@@ -8,7 +8,7 @@
     },
     {
       "path": ".claude-plugin/plugin.json",
-      "sha256": "60e01653d5d2f11b2aff0e02924c42cb11c9e05baa37e261b791b78c2db279de",
+      "sha256": "e0f61b71df7525c477ce0644cbf0e1ff947bbe3d060b05fa46017e6ddc1d2425",
       "bytes": 572
     },
     {
@@ -18,7 +18,7 @@
     },
     {
       "path": ".codex-plugin/plugin.json",
-      "sha256": "56b330ae2e65cfbc7cec59cee01d40b1754b0889d75de59d49c11524ba5ac28a",
+      "sha256": "a864c5c1108e51baf1aa8be8762b63d29059d52bf05c164779632091e9b684df",
       "bytes": 154
     },
     {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # MeMesh Plugin Architecture
 
-**Version**: 4.9.1
+**Version**: 4.9.2
 
 > Looking for "which file do I change for X?" — see [CODEMAP.md](../CODEMAP.md).
 

--- a/docs/api/API_REFERENCE.md
+++ b/docs/api/API_REFERENCE.md
@@ -1,7 +1,7 @@
 # MeMesh Plugin -- API Reference
 
 **Protocol**: Model Context Protocol (MCP) over stdio
-**Version**: 4.9.1
+**Version**: 4.9.2
 **Compatibility**: Works with Claude Code plugins, Claude Managed Agents (via MCP connector), and any MCP-compatible client.
 
 **Native Integrations**: Beyond MCP, MeMesh integrates as a native memory provider for Hermes Agent (Python `MemoryProvider` plugin). A source-only OpenClaw TypeScript memory-capability plugin is also included, but it is not published or live-tested. Neither path is an HTTP bridge. See [docs/platforms/](../platforms/) for platform-specific guides.

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -13,7 +13,7 @@
 # is the honest floor rather than a copied one.
 id = "memesh"
 name = "MeMesh"
-version = "4.9.1"
+version = "4.9.2"
 min_herdr_version = "0.7.0"
 description = "Local SQLite memory shared across coding agents — decisions, lessons, and why the code looks the way it does."
 platforms = ["linux", "macos", "windows"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pcircle/memesh",
-  "version": "4.9.1",
+  "version": "4.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pcircle/memesh",
-      "version": "4.9.1",
+      "version": "4.9.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcircle/memesh",
-  "version": "4.9.1",
+  "version": "4.9.2",
   "description": "MeMesh — agentic memory for coding agents. Captured from the agent's real work via hooks, recalled when it acts. One SQLite file, zero cloud required.",
   "main": "dist/index.js",
   "type": "module",

--- a/tests/codex-plugin-fresh-consumer.test.ts
+++ b/tests/codex-plugin-fresh-consumer.test.ts
@@ -218,7 +218,7 @@ describe('Codex plugin fresh consumer', () => {
       encoding: 'utf8',
     });
     expect(result.status, result.stderr).toBe(0);
-    expect(result.stdout.trim()).toBe('4.9.1');
+    expect(result.stdout.trim()).toBe('4.9.2');
   });
 
   it.skipIf(process.platform === 'win32')('serve binds only the requested port in the packaged CLI', async () => {

--- a/tests/hooks/auto-update-consent.test.ts
+++ b/tests/hooks/auto-update-consent.test.ts
@@ -18,7 +18,7 @@ describe('Feature: per-session update consent', () => {
     const dbPath = path.join(dir, 'memesh.db');
     const cachePath = path.join(dir, 'update-cache.json');
     writeFileSync(cachePath, JSON.stringify({
-      currentVersion: '4.9.1',
+      currentVersion: '4.9.2',
       latestVersion: '4.10.0',
       lastSuccessfulCheckAt: new Date().toISOString(),
     }));
@@ -50,7 +50,7 @@ describe('Feature: per-session update consent', () => {
     const dbPath = path.join(dir, 'memesh.db');
     const cachePath = path.join(dir, 'update-cache.json');
     writeFileSync(cachePath, JSON.stringify({
-      currentVersion: '4.9.1', latestVersion: '4.10.0',
+      currentVersion: '4.9.2', latestVersion: '4.10.0',
       lastSuccessfulCheckAt: new Date().toISOString(),
     }));
     const env = { ...process.env, MEMESH_DIR: dir, MEMESH_DB_PATH: dbPath, MEMESH_UPDATE_CHECK_PATH: cachePath };
@@ -76,8 +76,8 @@ describe('Feature: per-session update consent', () => {
     const previousDir = process.env.MEMESH_DIR;
     process.env.MEMESH_DIR = dir;
     try {
-      writeAutoUpdateConsent('channel-session', '4.9.1', '4.10.0', 'npm-global', 'approved');
-      expect(findAutoUpdateConsent('channel-session', '4.9.1', '4.10.0', 'plugin-marketplace')).toBeNull();
+      writeAutoUpdateConsent('channel-session', '4.9.2', '4.10.0', 'npm-global', 'approved');
+      expect(findAutoUpdateConsent('channel-session', '4.9.2', '4.10.0', 'plugin-marketplace')).toBeNull();
     } finally {
       if (previousDir === undefined) delete process.env.MEMESH_DIR;
       else process.env.MEMESH_DIR = previousDir;
@@ -89,15 +89,15 @@ describe('Feature: per-session update consent', () => {
     const previousDir = process.env.MEMESH_DIR;
     process.env.MEMESH_DIR = dir;
     try {
-      expect(claimUpdatePrompt('same-session', '4.9.1', '4.10.0', 'source-checkout')).toBe(true);
-      expect(claimUpdatePrompt('same-session', '4.9.1', '4.10.0', 'plugin-marketplace')).toBe(false);
-      expect(readUpdatePromptClaim('same-session', '4.9.1', '4.10.0')).toMatchObject({
+      expect(claimUpdatePrompt('same-session', '4.9.2', '4.10.0', 'source-checkout')).toBe(true);
+      expect(claimUpdatePrompt('same-session', '4.9.2', '4.10.0', 'plugin-marketplace')).toBe(false);
+      expect(readUpdatePromptClaim('same-session', '4.9.2', '4.10.0')).toMatchObject({
         sessionId: 'same-session',
         channel: 'source-checkout',
         decision: 'pending',
       });
-      expect(finalizeUpdatePromptClaim('same-session', '4.9.1', '4.10.0')).toBe(true);
-      expect(claimUpdatePrompt('same-session', '4.9.1', '4.10.0', 'source-checkout')).toBe(false);
+      expect(finalizeUpdatePromptClaim('same-session', '4.9.2', '4.10.0')).toBe(true);
+      expect(claimUpdatePrompt('same-session', '4.9.2', '4.10.0', 'source-checkout')).toBe(false);
     } finally {
       if (previousDir === undefined) delete process.env.MEMESH_DIR;
       else process.env.MEMESH_DIR = previousDir;
@@ -113,10 +113,10 @@ describe('Feature: per-session update consent', () => {
     try {
       const child = spawnSync(process.execPath, ['--input-type=module', '-e',
         `import { claimUpdatePrompt } from ${JSON.stringify(pathToFileURL(shared).href)};\n`
-        + `process.exit(claimUpdatePrompt('crashed-session', '4.9.1', '4.10.0', 'source-checkout') ? 0 : 1);`,
+        + `process.exit(claimUpdatePrompt('crashed-session', '4.9.2', '4.10.0', 'source-checkout') ? 0 : 1);`,
       ], { env, encoding: 'utf8' });
       expect(child.status, child.stderr).toBe(0);
-      expect(claimUpdatePrompt('crashed-session', '4.9.1', '4.10.0', 'source-checkout')).toBe(true);
+      expect(claimUpdatePrompt('crashed-session', '4.9.2', '4.10.0', 'source-checkout')).toBe(true);
     } finally {
       if (previousDir === undefined) delete process.env.MEMESH_DIR;
       else process.env.MEMESH_DIR = previousDir;
@@ -129,7 +129,7 @@ describe('Feature: per-session update consent', () => {
     const cachePath = path.join(dir, 'update-cache.json');
     const transcriptPath = path.join(dir, 'transcript.jsonl');
     writeFileSync(cachePath, JSON.stringify({
-      currentVersion: '4.9.1', latestVersion: '4.10.0',
+      currentVersion: '4.9.2', latestVersion: '4.10.0',
       lastSuccessfulCheckAt: new Date().toISOString(),
     }));
     writeFileSync(transcriptPath, [
@@ -156,12 +156,12 @@ describe('Feature: per-session update consent', () => {
     const previousDir = process.env.MEMESH_DIR;
     process.env.MEMESH_DIR = dir;
     try {
-      writeAutoUpdateConsent('stop-consent-session', '4.9.1', '4.10.0', 'source-checkout', 'approved');
-      writeAutoUpdateConsent('stop-consent-session', '4.9.1', '4.10.0', 'unknown', 'approved');
+      writeAutoUpdateConsent('stop-consent-session', '4.9.2', '4.10.0', 'source-checkout', 'approved');
+      writeAutoUpdateConsent('stop-consent-session', '4.9.2', '4.10.0', 'unknown', 'approved');
       for (const channel of ['npm-global', 'npm-local', 'plugin-marketplace']) {
-        writeAutoUpdateConsent('stop-consent-session', '4.9.1', '4.10.0', channel, 'approved');
+        writeAutoUpdateConsent('stop-consent-session', '4.9.2', '4.10.0', channel, 'approved');
       }
-      expect(findAutoUpdateConsent('stop-consent-session', '4.9.1', '4.10.0', 'source-checkout')).toMatchObject({ decision: 'approved' });
+      expect(findAutoUpdateConsent('stop-consent-session', '4.9.2', '4.10.0', 'source-checkout')).toMatchObject({ decision: 'approved' });
     } finally {
       if (previousDir === undefined) delete process.env.MEMESH_DIR;
       else process.env.MEMESH_DIR = previousDir;


### PR DESCRIPTION
## Scope
- publish the first-use update refresh race fix that landed after v4.9.1 was tagged
- align release metadata, generated manifest, and version-sensitive regression fixtures

## Evidence
- npm test -- --run tests/hooks/auto-update-consent.test.ts tests/hooks/session-start.test.ts tests/codex-plugin-fresh-consumer.test.ts --reporter=dot
- 3 files, 41 tests passed
- check-version-coherence and generated-mirror checks passed

## Release note
This is a new version because v4.9.1 is protected and already points at an older immutable candidate.