### PR TITLE
fix(codex): keep SessionEnd hook within host timeout

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "memesh",
       "source": "./",
       "description": "MeMesh \u2014 agentic memory for coding agents. Captured from the agent's real work via hooks, recalled when it acts. One SQLite file, zero cloud required.",
-      "version": "4.9.2",
+      "version": "4.9.3",
       "author": {
         "name": "PCIRCLE AI"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -4,7 +4,7 @@
   "author": {
     "name": "PCIRCLE AI"
   },
-  "version": "4.9.2",
+  "version": "4.9.3",
   "mcpServers": "./.claude-plugin/mcp.json",
   "homepage": "https://github.com/PCIRCLE-AI/memesh",
   "repository": "https://github.com/PCIRCLE-AI/memesh",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memesh",
   "description": "MeMesh — agentic memory for coding agents.",
-  "version": "4.9.2",
+  "version": "4.9.3",
   "mcpServers": "./.codex-plugin/mcp.json"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to MeMesh are documented here.
 
+## [4.9.3] — 2026-09-09
+
+### Fixed
+
+- **Codex SessionEnd no longer requests an unsupported hook timeout.** The
+  lifecycle hook now declares the host-compatible three-second ceiling, so
+  Codex does not clamp the packaged manifest at load time.
+
 ## [4.9.2] — 2026-09-09
 
 ### Fixed

--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -1,6 +1,6 @@
 # CODEMAP
 
-**Version**: 4.9.2
+**Version**: 4.9.3
 
 A navigation map for the codebase: *"I want to change X — which file?"* For the
 design rationale behind these modules see [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md);

--- a/dist/skills-manifest.json
+++ b/dist/skills-manifest.json
@@ -8,7 +8,7 @@
     },
     {
       "path": ".claude-plugin/plugin.json",
-      "sha256": "e0f61b71df7525c477ce0644cbf0e1ff947bbe3d060b05fa46017e6ddc1d2425",
+      "sha256": "e1ff07fff7c5002f916e6c55172e953e726a24f46a2a705585fef53d726867d6",
       "bytes": 572
     },
     {
@@ -18,13 +18,13 @@
     },
     {
       "path": ".codex-plugin/plugin.json",
-      "sha256": "a864c5c1108e51baf1aa8be8762b63d29059d52bf05c164779632091e9b684df",
+      "sha256": "c68af5ed07947baf7ef3d66c5262cf3a34ac20f0981cf223ecc652d6e298bca8",
       "bytes": 154
     },
     {
       "path": "hooks/hooks.json",
-      "sha256": "59a2663c82e4b54910b1eba2657f8ddcea375b54bb1e70e8c4a3fc7cb036443b",
-      "bytes": 2567
+      "sha256": "01673b7843f42206a7452e2755f0c060086fb50d3e741aa7232789f696b6718f",
+      "bytes": 2566
     },
     {
       "path": "scripts/hooks/_generated/agent-message-inbox.js",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # MeMesh Plugin Architecture
 
-**Version**: 4.9.2
+**Version**: 4.9.3
 
 > Looking for "which file do I change for X?" — see [CODEMAP.md](../CODEMAP.md).
 

--- a/docs/api/API_REFERENCE.md
+++ b/docs/api/API_REFERENCE.md
@@ -1,7 +1,7 @@
 # MeMesh Plugin -- API Reference
 
 **Protocol**: Model Context Protocol (MCP) over stdio
-**Version**: 4.9.2
+**Version**: 4.9.3
 **Compatibility**: Works with Claude Code plugins, Claude Managed Agents (via MCP connector), and any MCP-compatible client.
 
 **Native Integrations**: Beyond MCP, MeMesh integrates as a native memory provider for Hermes Agent (Python `MemoryProvider` plugin). A source-only OpenClaw TypeScript memory-capability plugin is also included, but it is not published or live-tested. Neither path is an HTTP bridge. See [docs/platforms/](../platforms/) for platform-specific guides.

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -13,7 +13,7 @@
 # is the honest floor rather than a copied one.
 id = "memesh"
 name = "MeMesh"
-version = "4.9.2"
+version = "4.9.3"
 min_herdr_version = "0.7.0"
 description = "Local SQLite memory shared across coding agents — decisions, lessons, and why the code looks the way it does."
 platforms = ["linux", "macos", "windows"]

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -51,7 +51,7 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/dist/host-runtime/codex-session.js",
-            "timeout": 10
+            "timeout": 3
           }
         ]
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pcircle/memesh",
-  "version": "4.9.2",
+  "version": "4.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pcircle/memesh",
-      "version": "4.9.2",
+      "version": "4.9.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcircle/memesh",
-  "version": "4.9.2",
+  "version": "4.9.3",
   "description": "MeMesh — agentic memory for coding agents. Captured from the agent's real work via hooks, recalled when it acts. One SQLite file, zero cloud required.",
   "main": "dist/index.js",
   "type": "module",

--- a/tests/codex-plugin-fresh-consumer.test.ts
+++ b/tests/codex-plugin-fresh-consumer.test.ts
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { MemeshDatabase } from '../src/storage/sqlite.js';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const packageVersion = (JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8')) as { version: string }).version;
 const temporaryDirectories: string[] = [];
 const children: ChildProcess[] = [];
 const routerSockets: string[] = [];
@@ -218,7 +219,7 @@ describe('Codex plugin fresh consumer', () => {
       encoding: 'utf8',
     });
     expect(result.status, result.stderr).toBe(0);
-    expect(result.stdout.trim()).toBe('4.9.2');
+    expect(result.stdout.trim()).toBe(packageVersion);
   });
 
   it.skipIf(process.platform === 'win32')('serve binds only the requested port in the packaged CLI', async () => {

--- a/tests/hooks/auto-update-consent.test.ts
+++ b/tests/hooks/auto-update-consent.test.ts
@@ -12,13 +12,15 @@ import {
   writeAutoUpdateConsent,
 } from '../../scripts/hooks/_shared.js';
 
+const CURRENT_VERSION = JSON.parse(readFileSync(path.resolve('package.json'), 'utf8')).version as string;
+
 describe('Feature: per-session update consent', () => {
   it('gives a channel-accurate first-use action for a source checkout', () => {
     const dir = mkdtempSync(path.join(tmpdir(), 'memesh-update-consent-'));
     const dbPath = path.join(dir, 'memesh.db');
     const cachePath = path.join(dir, 'update-cache.json');
     writeFileSync(cachePath, JSON.stringify({
-      currentVersion: '4.9.2',
+      currentVersion: CURRENT_VERSION,
       latestVersion: '4.10.0',
       lastSuccessfulCheckAt: new Date().toISOString(),
     }));
@@ -50,7 +52,7 @@ describe('Feature: per-session update consent', () => {
     const dbPath = path.join(dir, 'memesh.db');
     const cachePath = path.join(dir, 'update-cache.json');
     writeFileSync(cachePath, JSON.stringify({
-      currentVersion: '4.9.2', latestVersion: '4.10.0',
+      currentVersion: CURRENT_VERSION, latestVersion: '4.10.0',
       lastSuccessfulCheckAt: new Date().toISOString(),
     }));
     const env = { ...process.env, MEMESH_DIR: dir, MEMESH_DB_PATH: dbPath, MEMESH_UPDATE_CHECK_PATH: cachePath };
@@ -76,8 +78,8 @@ describe('Feature: per-session update consent', () => {
     const previousDir = process.env.MEMESH_DIR;
     process.env.MEMESH_DIR = dir;
     try {
-      writeAutoUpdateConsent('channel-session', '4.9.2', '4.10.0', 'npm-global', 'approved');
-      expect(findAutoUpdateConsent('channel-session', '4.9.2', '4.10.0', 'plugin-marketplace')).toBeNull();
+      writeAutoUpdateConsent('channel-session', CURRENT_VERSION, '4.10.0', 'npm-global', 'approved');
+      expect(findAutoUpdateConsent('channel-session', CURRENT_VERSION, '4.10.0', 'plugin-marketplace')).toBeNull();
     } finally {
       if (previousDir === undefined) delete process.env.MEMESH_DIR;
       else process.env.MEMESH_DIR = previousDir;
@@ -89,15 +91,15 @@ describe('Feature: per-session update consent', () => {
     const previousDir = process.env.MEMESH_DIR;
     process.env.MEMESH_DIR = dir;
     try {
-      expect(claimUpdatePrompt('same-session', '4.9.2', '4.10.0', 'source-checkout')).toBe(true);
-      expect(claimUpdatePrompt('same-session', '4.9.2', '4.10.0', 'plugin-marketplace')).toBe(false);
-      expect(readUpdatePromptClaim('same-session', '4.9.2', '4.10.0')).toMatchObject({
+      expect(claimUpdatePrompt('same-session', CURRENT_VERSION, '4.10.0', 'source-checkout')).toBe(true);
+      expect(claimUpdatePrompt('same-session', CURRENT_VERSION, '4.10.0', 'plugin-marketplace')).toBe(false);
+      expect(readUpdatePromptClaim('same-session', CURRENT_VERSION, '4.10.0')).toMatchObject({
         sessionId: 'same-session',
         channel: 'source-checkout',
         decision: 'pending',
       });
-      expect(finalizeUpdatePromptClaim('same-session', '4.9.2', '4.10.0')).toBe(true);
-      expect(claimUpdatePrompt('same-session', '4.9.2', '4.10.0', 'source-checkout')).toBe(false);
+      expect(finalizeUpdatePromptClaim('same-session', CURRENT_VERSION, '4.10.0')).toBe(true);
+      expect(claimUpdatePrompt('same-session', CURRENT_VERSION, '4.10.0', 'source-checkout')).toBe(false);
     } finally {
       if (previousDir === undefined) delete process.env.MEMESH_DIR;
       else process.env.MEMESH_DIR = previousDir;
@@ -113,10 +115,10 @@ describe('Feature: per-session update consent', () => {
     try {
       const child = spawnSync(process.execPath, ['--input-type=module', '-e',
         `import { claimUpdatePrompt } from ${JSON.stringify(pathToFileURL(shared).href)};\n`
-        + `process.exit(claimUpdatePrompt('crashed-session', '4.9.2', '4.10.0', 'source-checkout') ? 0 : 1);`,
+        + `process.exit(claimUpdatePrompt('crashed-session', ${JSON.stringify(CURRENT_VERSION)}, '4.10.0', 'source-checkout') ? 0 : 1);`,
       ], { env, encoding: 'utf8' });
       expect(child.status, child.stderr).toBe(0);
-      expect(claimUpdatePrompt('crashed-session', '4.9.2', '4.10.0', 'source-checkout')).toBe(true);
+      expect(claimUpdatePrompt('crashed-session', CURRENT_VERSION, '4.10.0', 'source-checkout')).toBe(true);
     } finally {
       if (previousDir === undefined) delete process.env.MEMESH_DIR;
       else process.env.MEMESH_DIR = previousDir;
@@ -129,7 +131,7 @@ describe('Feature: per-session update consent', () => {
     const cachePath = path.join(dir, 'update-cache.json');
     const transcriptPath = path.join(dir, 'transcript.jsonl');
     writeFileSync(cachePath, JSON.stringify({
-      currentVersion: '4.9.2', latestVersion: '4.10.0',
+      currentVersion: CURRENT_VERSION, latestVersion: '4.10.0',
       lastSuccessfulCheckAt: new Date().toISOString(),
     }));
     writeFileSync(transcriptPath, [
@@ -156,12 +158,12 @@ describe('Feature: per-session update consent', () => {
     const previousDir = process.env.MEMESH_DIR;
     process.env.MEMESH_DIR = dir;
     try {
-      writeAutoUpdateConsent('stop-consent-session', '4.9.2', '4.10.0', 'source-checkout', 'approved');
-      writeAutoUpdateConsent('stop-consent-session', '4.9.2', '4.10.0', 'unknown', 'approved');
+      writeAutoUpdateConsent('stop-consent-session', CURRENT_VERSION, '4.10.0', 'source-checkout', 'approved');
+      writeAutoUpdateConsent('stop-consent-session', CURRENT_VERSION, '4.10.0', 'unknown', 'approved');
       for (const channel of ['npm-global', 'npm-local', 'plugin-marketplace']) {
-        writeAutoUpdateConsent('stop-consent-session', '4.9.2', '4.10.0', channel, 'approved');
+        writeAutoUpdateConsent('stop-consent-session', CURRENT_VERSION, '4.10.0', channel, 'approved');
       }
-      expect(findAutoUpdateConsent('stop-consent-session', '4.9.2', '4.10.0', 'source-checkout')).toMatchObject({ decision: 'approved' });
+      expect(findAutoUpdateConsent('stop-consent-session', CURRENT_VERSION, '4.10.0', 'source-checkout')).toMatchObject({ decision: 'approved' });
     } finally {
       if (previousDir === undefined) delete process.env.MEMESH_DIR;
       else process.env.MEMESH_DIR = previousDir;

--- a/tests/hooks/hook-time-budgets.test.ts
+++ b/tests/hooks/hook-time-budgets.test.ts
@@ -51,6 +51,12 @@ describe('every declared hook states its own budget', () => {
     const untimed = all.filter((h) => h.timeout === undefined).map((h) => `${h.event}:${path.basename(h.command)}`);
     expect(untimed, 'a hook with no timeout can hold up the user for the harness default').toEqual([]);
   });
+
+  it('keeps Codex SessionEnd within its host timeout ceiling', () => {
+    const sessionEnd = declaredHooks().filter((hook) => hook.event === 'SessionEnd');
+    expect(sessionEnd, 'fixture: SessionEnd is not declared').toHaveLength(1);
+    expect(sessionEnd[0].timeout, 'Codex clamps SessionEnd hooks above 3 seconds').toBeLessThanOrEqual(3);
+  });
 });
 
 describe('the SQLite lock wait fits inside the smallest budget', () => {


### PR DESCRIPTION
## Root cause\nCodex Desktop clamps hook timeouts above 3 seconds; the packaged SessionEnd hook declared 10 seconds, so every 4.9.2 load reported a clamp warning.\n\n## Fix\n- declare SessionEnd at the host-compatible 3-second ceiling\n- add a regression test that rejects future SessionEnd budgets above 3 seconds\n- bump to 4.9.3 because this shipped surface changed after the 4.9.2 version bump\n\n## Evidence\n- npm run build (smoke: 6/6)\n- focused hook-time-budgets + codex-session tests: 38 passed, 1 skipped\n- version coherence and generated mirror checks passed