### PR TITLE
release: v4.9.4 artifact integrity and upgrade gates

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "memesh",
       "source": "./",
       "description": "MeMesh \u2014 agentic memory for coding agents. Captured from the agent's real work via hooks, recalled when it acts. One SQLite file, zero cloud required.",
-      "version": "4.9.3",
+      "version": "4.9.4",
       "author": {
         "name": "PCIRCLE AI"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -4,7 +4,7 @@
   "author": {
     "name": "PCIRCLE AI"
   },
-  "version": "4.9.3",
+  "version": "4.9.4",
   "mcpServers": "./.claude-plugin/mcp.json",
   "homepage": "https://github.com/PCIRCLE-AI/memesh",
   "repository": "https://github.com/PCIRCLE-AI/memesh",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memesh",
   "description": "MeMesh — agentic memory for coding agents.",
-  "version": "4.9.3",
+  "version": "4.9.4",
   "mcpServers": "./.codex-plugin/mcp.json"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ All notable changes to MeMesh are documented here.
 - **Pre-release coverage now protects the updater's own checker.** A copied
   or incomplete updater refuses to install a plugin archive when its trusted
   artifact-integrity checker is absent.
+- **The npm package ships the checker's one dependency.** The
+  artifact-integrity checker imports `scripts/lib/npm-bin.mjs`, which the
+  package did not include, so the checker could not load from an npm install
+  and `memesh upgrade-plugin` — which prefers the npm-installed copy of the
+  updater — would have refused every upgrade. A test now unpacks the real
+  tarball and runs the checker from it. The checker also rejects a symlinked
+  directory above a hook target, not only a symlinked file.
 
 ## [4.9.3] — 2026-09-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,11 @@ All notable changes to MeMesh are documented here.
 ### Fixed
 
 - **Plugin upgrades now fail closed before cache replacement when the staged
-  artifact is incomplete.** The release gate validates every hook, plugin
-  manifest, MCP entrypoint, and npm-packed target before an upgrade can swap
-  the live cache; missing or swapped targets leave the existing cache and
-  registry unchanged.
+  artifact is incomplete.** Before an upgrade can swap the live cache, the
+  updater validates every hook, plugin manifest, and MCP entrypoint in the
+  staged copy; missing or swapped targets leave the existing cache and
+  registry unchanged. The release gate runs the same checker and additionally
+  confirms every target is present in the npm-packed artifact.
 - **Release audits no longer inherit an unsafe or unbounded npm cache.** The
   consumer audit uses a private temporary cache and bounded subprocess
   lifetimes, reporting a controlled failure instead of hanging or being

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to MeMesh are documented here.
 
+## [4.9.4] — 2026-09-09
+
+### Fixed
+
+- **Plugin upgrades now fail closed before cache replacement when the staged
+  artifact is incomplete.** The release gate validates every hook, plugin
+  manifest, MCP entrypoint, and npm-packed target before an upgrade can swap
+  the live cache; missing or swapped targets leave the existing cache and
+  registry unchanged.
+- **Release audits no longer inherit an unsafe or unbounded npm cache.** The
+  consumer audit uses a private temporary cache and bounded subprocess
+  lifetimes, reporting a controlled failure instead of hanging or being
+  affected by root-owned cache state.
+- **Pre-release coverage now protects the updater's own checker.** A copied
+  or incomplete updater refuses to install a plugin archive when its trusted
+  artifact-integrity checker is absent.
+
 ## [4.9.3] — 2026-09-09
 
 ### Fixed

--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -1,6 +1,6 @@
 # CODEMAP
 
-**Version**: 4.9.3
+**Version**: 4.9.4
 
 A navigation map for the codebase: *"I want to change X — which file?"* For the
 design rationale behind these modules see [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md);

--- a/dist/skills-manifest.json
+++ b/dist/skills-manifest.json
@@ -8,7 +8,7 @@
     },
     {
       "path": ".claude-plugin/plugin.json",
-      "sha256": "e1ff07fff7c5002f916e6c55172e953e726a24f46a2a705585fef53d726867d6",
+      "sha256": "cfb107b54e757ba86356a0defdebf7b1f12fbf45acbf8920d91793d849f33f4e",
       "bytes": 572
     },
     {
@@ -18,7 +18,7 @@
     },
     {
       "path": ".codex-plugin/plugin.json",
-      "sha256": "c68af5ed07947baf7ef3d66c5262cf3a34ac20f0981cf223ecc652d6e298bca8",
+      "sha256": "627cae483533b13ec22c0288c8e1abc2d2a7521bc6ccad7813b1065b5ab91816",
       "bytes": 154
     },
     {

--- a/dist/skills-manifest.json
+++ b/dist/skills-manifest.json
@@ -97,6 +97,11 @@
       "bytes": 48742
     },
     {
+      "path": "scripts/hooks/auto-update-runner.mjs",
+      "sha256": "6435dbe0d142f52349da0c2ef8f82c455935be506a1b9e78f09f117c776d02b7",
+      "bytes": 7347
+    },
+    {
       "path": "scripts/hooks/decision-nudge.js",
       "sha256": "424bf5cd4f68cb55e441a5aed1db78b262df2a5ef4a7e60a56db2f9d3f103d5d",
       "bytes": 7391

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # MeMesh Plugin Architecture
 
-**Version**: 4.9.3
+**Version**: 4.9.4
 
 > Looking for "which file do I change for X?" — see [CODEMAP.md](../CODEMAP.md).
 

--- a/docs/api/API_REFERENCE.md
+++ b/docs/api/API_REFERENCE.md
@@ -1,7 +1,7 @@
 # MeMesh Plugin -- API Reference
 
 **Protocol**: Model Context Protocol (MCP) over stdio
-**Version**: 4.9.3
+**Version**: 4.9.4
 **Compatibility**: Works with Claude Code plugins, Claude Managed Agents (via MCP connector), and any MCP-compatible client.
 
 **Native Integrations**: Beyond MCP, MeMesh integrates as a native memory provider for Hermes Agent (Python `MemoryProvider` plugin). A source-only OpenClaw TypeScript memory-capability plugin is also included, but it is not published or live-tested. Neither path is an HTTP bridge. See [docs/platforms/](../platforms/) for platform-specific guides.

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -13,7 +13,7 @@
 # is the honest floor rather than a copied one.
 id = "memesh"
 name = "MeMesh"
-version = "4.9.3"
+version = "4.9.4"
 min_herdr_version = "0.7.0"
 description = "Local SQLite memory shared across coding agents — decisions, lessons, and why the code looks the way it does."
 platforms = ["linux", "macos", "windows"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pcircle/memesh",
-  "version": "4.9.3",
+  "version": "4.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pcircle/memesh",
-      "version": "4.9.3",
+      "version": "4.9.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcircle/memesh",
-  "version": "4.9.3",
+  "version": "4.9.4",
   "description": "MeMesh — agentic memory for coding agents. Captured from the agent's real work via hooks, recalled when it acts. One SQLite file, zero cloud required.",
   "main": "dist/index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "README.md",
     "LICENSE",
     "llms-install.md",
+    "scripts/check-plugin-hook-artifact.mjs",
     "AGENTS.md"
   ],
   "scripts": {
@@ -49,7 +50,8 @@
     "audit:prod": "node scripts/check-consumer-audit.mjs",
     "audit:memory": "node scripts/audit/memory-invariants.mjs",
     "check:entry-points-start": "node scripts/check-entry-points-start.mjs",
-    "verify:release": "npm run lint && npm run typecheck && node scripts/check-version-coherence.mjs && node scripts/check-generated-mirror.mjs && node scripts/check-agent-message-sync.mjs && npm run check:surface-parity && node scripts/check-doc-claims.mjs && node scripts/audit/verification-audit.mjs && npm run audit:prod && npm run check:entry-points-start",
+    "check:plugin-hook-artifact": "node scripts/check-plugin-hook-artifact.mjs",
+    "verify:release": "npm run lint && npm run typecheck && node scripts/check-version-coherence.mjs && node scripts/check-generated-mirror.mjs && node scripts/check-agent-message-sync.mjs && npm run check:surface-parity && node scripts/check-doc-claims.mjs && node scripts/audit/verification-audit.mjs && npm run audit:prod && npm run check:entry-points-start && npm run check:plugin-hook-artifact",
     "release:finish": "node scripts/finish-release.mjs",
     "verify:artifact": "npm run verify:release && npm run test:isolated && npm run test:packaged && npm run test:packaged:upgrade",
     "prepublishOnly": "npm run build && npm run verify:artifact",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "LICENSE",
     "llms-install.md",
     "scripts/check-plugin-hook-artifact.mjs",
+    "scripts/lib/npm-bin.mjs",
     "AGENTS.md"
   ],
   "scripts": {

--- a/scripts/audit/baseline.json
+++ b/scripts/audit/baseline.json
@@ -555,6 +555,11 @@
       "class": "SAFE",
       "reason": "set -uo pipefail at file top (line 31) preserves the left command's verdict; printf cannot meaningfully fail on a literal string, so the `if printf ... | grep -qE ...; then` reads grep's own match result -- the intended verdict, not a swallowed one.",
       "triaged": "2026-09-05"
+    },
+    "C6 tests/plugin-hook-artifact.test.ts": {
+      "class": "WIRING-PIN",
+      "reason": "The test reads the upgrade script only to pin that artifact validation occurs before the live-cache swap; the executable behavior is separately exercised by the checker negative fixtures and the release gate.",
+      "triaged": "2026-09-09"
     }
   }
 }

--- a/scripts/check-consumer-audit.mjs
+++ b/scripts/check-consumer-audit.mjs
@@ -41,11 +41,28 @@ function npmOptions(options = {}) {
     timeout: options.timeout ?? npmTimeoutMs,
     killSignal: options.killSignal ?? 'SIGTERM',
     env: {
-      ...process.env,
-      ...(options.env ?? {}),
+      ...withoutNpmCache(process.env),
+      ...withoutNpmCache(options.env ?? {}),
       npm_config_cache: npmCacheDir,
     },
   };
+}
+
+/**
+ * Windows environment names are case-insensitive, and Node's child_process
+ * resolves a duplicate that differs only in case by keeping the
+ * lexicographically first key (`N` sorts before `n`). Vitest deliberately adds
+ * an upper-cased copy of every variable to its Windows workers, so under the
+ * suite `process.env` carries `NPM_CONFIG_CACHE` — the GitHub runner's
+ * `C:\npm\cache` — and `{ ...process.env, npm_config_cache }` handed THAT to
+ * npm while the private directory sat unused. Measured on windows-latest:
+ * the fake npm in `tests/consumer-audit-gate.test.ts` reported the runner
+ * cache. Drop every spelling before setting ours.
+ */
+function withoutNpmCache(env) {
+  return Object.fromEntries(
+    Object.entries(env).filter(([key]) => key.toLowerCase() !== 'npm_config_cache'),
+  );
 }
 
 /**

--- a/scripts/check-consumer-audit.mjs
+++ b/scripts/check-consumer-audit.mjs
@@ -27,6 +27,7 @@ import { npmSync, assertSafeShellArg } from './lib/npm-bin.mjs';
  */
 const AUDIT_LEVEL = 'high';
 const repoRoot = process.cwd();
+const npmTimeoutMs = 180_000;
 
 let workDir;
 let npmCacheDir;
@@ -34,6 +35,8 @@ let npmCacheDir;
 function npmOptions(options = {}) {
   return {
     ...options,
+    timeout: options.timeout ?? npmTimeoutMs,
+    killSignal: options.killSignal ?? 'SIGTERM',
     env: {
       ...process.env,
       ...(options.env ?? {}),

--- a/scripts/check-consumer-audit.mjs
+++ b/scripts/check-consumer-audit.mjs
@@ -27,7 +27,10 @@ import { npmSync, assertSafeShellArg } from './lib/npm-bin.mjs';
  */
 const AUDIT_LEVEL = 'high';
 const repoRoot = process.cwd();
-const npmTimeoutMs = 180_000;
+const configuredTimeout = Number(process.env.MEMESH_CONSUMER_AUDIT_TIMEOUT_MS);
+const npmTimeoutMs = Number.isFinite(configuredTimeout) && configuredTimeout > 0
+  ? configuredTimeout
+  : 180_000;
 
 let workDir;
 let npmCacheDir;
@@ -138,6 +141,10 @@ try {
       `  \`overrides\` only at the install root, so they do not reach consumers.\n`
   );
   console.error(auditOut);
+  exitWith(1);
+} catch (error) {
+  const timedOut = error?.code === 'ETIMEDOUT' || error?.signal === 'SIGTERM';
+  console.error(`✗ consumer audit could not complete${timedOut ? ' (npm command timed out)' : ''}: ${error instanceof Error ? error.message : String(error)}`);
   exitWith(1);
 } finally {
   cleanup();

--- a/scripts/check-consumer-audit.mjs
+++ b/scripts/check-consumer-audit.mjs
@@ -29,6 +29,18 @@ const AUDIT_LEVEL = 'high';
 const repoRoot = process.cwd();
 
 let workDir;
+let npmCacheDir;
+
+function npmOptions(options = {}) {
+  return {
+    ...options,
+    env: {
+      ...process.env,
+      ...(options.env ?? {}),
+      npm_config_cache: npmCacheDir,
+    },
+  };
+}
 
 /**
  * `process.exit()` does NOT run a pending `finally`. Every exit path below is a
@@ -41,6 +53,10 @@ function cleanup() {
     fs.rmSync(workDir, { recursive: true, force: true });
     workDir = undefined;
   }
+  if (npmCacheDir) {
+    fs.rmSync(npmCacheDir, { recursive: true, force: true });
+    npmCacheDir = undefined;
+  }
 }
 
 /** Exit, having actually cleaned up. */
@@ -50,9 +66,14 @@ function exitWith(code) {
 }
 
 try {
+  // Never inherit a maintainer's global npm cache. It may be root-owned (or
+  // contain stale metadata), turning a release gate into an opaque exit 255
+  // before it reaches the consumer install/audit it claims to measure.
+  npmCacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memesh-consumer-npm-cache-'));
   const packOut = npmSync(['pack', '--silent'], {
     cwd: repoRoot,
     encoding: 'utf8',
+    ...npmOptions(),
   }).trim();
   // Split on CRLF too — npm's stdout on Windows ends lines with \r\n, and a
   // trailing \r would corrupt both the path join and the validation below.
@@ -76,11 +97,11 @@ try {
   fs.copyFileSync(tarballPath, path.join(workDir, tarball));
   fs.unlinkSync(tarballPath);
 
-  npmSync(['init', '-y'], { cwd: workDir, stdio: 'ignore' });
-  npmSync(['install', '--omit=dev', '--ignore-scripts', `./${tarball}`], {
+  npmSync(['init', '-y'], npmOptions({ cwd: workDir, stdio: 'ignore' }));
+  npmSync(['install', '--omit=dev', '--ignore-scripts', `./${tarball}`], npmOptions({
     cwd: workDir,
     stdio: 'ignore',
-  });
+  }));
 
   // Prove the install actually produced a tree. Auditing an empty directory
   // reports zero vulnerabilities, which would make this gate pass by doing
@@ -94,10 +115,10 @@ try {
   let auditOut = '';
   let clean = true;
   try {
-    auditOut = npmSync(['audit', '--omit=dev', `--audit-level=${AUDIT_LEVEL}`], {
+    auditOut = npmSync(['audit', '--omit=dev', `--audit-level=${AUDIT_LEVEL}`], npmOptions({
       cwd: workDir,
       encoding: 'utf8',
-    });
+    }));
   } catch (err) {
     clean = false;
     auditOut = `${err.stdout ?? ''}${err.stderr ?? ''}`;

--- a/scripts/check-consumer-audit.mjs
+++ b/scripts/check-consumer-audit.mjs
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { npmSync, assertSafeShellArg } from './lib/npm-bin.mjs';
+import { npmSync, assertSafeShellArg, envWithNpmCache } from './lib/npm-bin.mjs';
 
 /**
  * Audit the dependency tree a CONSUMER resolves, not the one this repo has.
@@ -40,29 +40,9 @@ function npmOptions(options = {}) {
     ...options,
     timeout: options.timeout ?? npmTimeoutMs,
     killSignal: options.killSignal ?? 'SIGTERM',
-    env: {
-      ...withoutNpmCache(process.env),
-      ...withoutNpmCache(options.env ?? {}),
-      npm_config_cache: npmCacheDir,
-    },
+    // Never inherit the caller's npm cache, under any spelling (see npm-bin.mjs).
+    env: envWithNpmCache(npmCacheDir),
   };
-}
-
-/**
- * Windows environment names are case-insensitive, and Node's child_process
- * resolves a duplicate that differs only in case by keeping the
- * lexicographically first key (`N` sorts before `n`). Vitest deliberately adds
- * an upper-cased copy of every variable to its Windows workers, so under the
- * suite `process.env` carries `NPM_CONFIG_CACHE` — the GitHub runner's
- * `C:\npm\cache` — and `{ ...process.env, npm_config_cache }` handed THAT to
- * npm while the private directory sat unused. Measured on windows-latest:
- * the fake npm in `tests/consumer-audit-gate.test.ts` reported the runner
- * cache. Drop every spelling before setting ours.
- */
-function withoutNpmCache(env) {
-  return Object.fromEntries(
-    Object.entries(env).filter(([key]) => key.toLowerCase() !== 'npm_config_cache'),
-  );
 }
 
 /**

--- a/scripts/check-plugin-hook-artifact.mjs
+++ b/scripts/check-plugin-hook-artifact.mjs
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+/** Verify plugin hooks and host entrypoints before a cache/artifact swap. */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+export const CLAUDE_PLUGIN_ROOT_PREFIX = '${CLAUDE_PLUGIN_ROOT}/';
+
+function isSubpath(parent, child) {
+  const relative = path.relative(parent, child);
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+export function hookTargetsFromManifest(manifest) {
+  const targets = [];
+  for (const [event, entries] of Object.entries(manifest?.hooks ?? {})) {
+    if (!Array.isArray(entries)) throw new Error(`${event} is not an array in hooks/hooks.json`);
+    for (const entry of entries) {
+      for (const hook of entry?.hooks ?? []) {
+        if (hook?.type !== 'command') continue;
+        if (typeof hook.command !== 'string' || !hook.command.startsWith(CLAUDE_PLUGIN_ROOT_PREFIX)) {
+          throw new Error(`${event} command must start with ${CLAUDE_PLUGIN_ROOT_PREFIX}`);
+        }
+        const relative = hook.command.slice(CLAUDE_PLUGIN_ROOT_PREFIX.length);
+        if (!relative || /\s/.test(relative) || path.posix.normalize(relative) !== relative || relative.startsWith('../')) {
+          throw new Error(`${event} command is not a single safe plugin-relative path: ${hook.command}`);
+        }
+        targets.push({ event, relative });
+      }
+    }
+  }
+  if (targets.length === 0) throw new Error('hooks/hooks.json declares no command hooks');
+  return targets;
+}
+
+export function readHookManifest(root) {
+  return JSON.parse(fs.readFileSync(path.join(root, 'hooks', 'hooks.json'), 'utf8'));
+}
+
+export function validateHookTargets(root, manifest = readHookManifest(root)) {
+  const rootPath = path.resolve(root);
+  const targets = hookTargetsFromManifest(manifest);
+  const missing = [];
+  for (const target of targets) {
+    const resolved = path.resolve(rootPath, target.relative);
+    try {
+      // lstat is intentional: stat() follows an in-root symlink to an
+      // external file, which would let a staged cache execute ambient bytes.
+      if (isSubpath(rootPath, resolved) && fs.lstatSync(resolved).isFile()) continue;
+    } catch {
+      // Report the same bounded finding for missing and unreadable targets.
+    }
+    missing.push({ ...target, resolved });
+  }
+  return { targets, missing, ok: missing.length === 0 };
+}
+
+function safeRelativePath(value, label) {
+  if (typeof value !== 'string' || !value.startsWith('./')) {
+    throw new Error(`${label} must be a ./ relative path`);
+  }
+  const relative = value.slice(2);
+  if (!relative || path.posix.normalize(relative) !== relative || relative.startsWith('../') || path.isAbsolute(relative)) {
+    throw new Error(`${label} is not a safe plugin-relative path: ${value}`);
+  }
+  return relative;
+}
+
+function regularFile(root, relative, label) {
+  const rootPath = path.resolve(root);
+  const resolved = path.resolve(rootPath, relative);
+  if (!isSubpath(rootPath, resolved)) throw new Error(`${label} escapes plugin root: ${relative}`);
+  try {
+    if (fs.lstatSync(resolved).isFile()) return relative;
+  } catch {
+    // Fall through to one bounded diagnostic.
+  }
+  throw new Error(`${label} is missing or not a regular file: ${relative}`);
+}
+
+export function validatePluginEntrypoints(root) {
+  const packageJson = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'));
+  const targets = [];
+  for (const [relativeManifest, expectedPrefix] of [
+    ['.claude-plugin/plugin.json', '${CLAUDE_PLUGIN_ROOT}/'],
+    ['.codex-plugin/plugin.json', './'],
+  ]) {
+    regularFile(root, relativeManifest, relativeManifest);
+    const plugin = JSON.parse(fs.readFileSync(path.join(root, relativeManifest), 'utf8'));
+    if (plugin.name !== 'memesh') throw new Error(`${relativeManifest} has unexpected plugin name`);
+    if (plugin.version !== packageJson.version) throw new Error(`${relativeManifest} version does not match package.json`);
+    const mcpManifest = safeRelativePath(plugin.mcpServers, `${relativeManifest} mcpServers`);
+    regularFile(root, mcpManifest, `${relativeManifest} mcpServers`);
+    targets.push({ kind: 'manifest', relative: relativeManifest });
+    targets.push({ kind: 'manifest', relative: mcpManifest });
+    const manifest = JSON.parse(fs.readFileSync(path.join(root, mcpManifest), 'utf8'));
+    const entry = manifest.mcpServers?.memesh;
+    if (!entry || entry.command !== 'node' || !Array.isArray(entry.args) || typeof entry.args[0] !== 'string') {
+      throw new Error(`${mcpManifest} has no valid mcpServers.memesh node entry`);
+    }
+    const rawTarget = entry.args[0];
+    if (!rawTarget.startsWith(expectedPrefix)) {
+      throw new Error(`${mcpManifest} entry must start with ${expectedPrefix}`);
+    }
+    const target = rawTarget.slice(expectedPrefix.length);
+    if (path.posix.normalize(target) !== target || target.startsWith('../') || path.isAbsolute(target)) {
+      throw new Error(`${mcpManifest} entry is not a safe plugin-relative path: ${rawTarget}`);
+    }
+    regularFile(root, target, `${mcpManifest} entrypoint`);
+    targets.push({ kind: 'entrypoint', relative: target });
+  }
+  return { targets };
+}
+
+export function validateArtifactPaths(targets, files) {
+  const shipped = new Set(files.map((file) => typeof file === 'string' ? file : file.path));
+  const missing = targets.filter((target) => !shipped.has(target.relative));
+  return { missing, ok: missing.length === 0 };
+}
+
+function packFiles(root) {
+  const npmCache = fs.mkdtempSync(path.join(os.tmpdir(), 'memesh-pack-cache-'));
+  let packed;
+  try {
+    packed = spawnSync('npm', ['pack', '--dry-run', '--json', '--ignore-scripts'], {
+      cwd: root,
+      encoding: 'utf8',
+      env: { ...process.env, npm_config_cache: npmCache },
+    });
+  } finally {
+    fs.rmSync(npmCache, { recursive: true, force: true });
+  }
+  if (packed.status !== 0) {
+    throw new Error(`npm pack --dry-run failed (exit ${packed.status ?? 'unknown'}): ${(packed.stderr || '').trim()}`);
+  }
+  let report;
+  try { report = JSON.parse(packed.stdout); } catch { throw new Error('npm pack --dry-run did not return valid JSON'); }
+  const entry = Array.isArray(report) ? report[0] : report;
+  if (!entry || !Array.isArray(entry.files)) throw new Error('npm pack --dry-run returned no file list');
+  return entry.files;
+}
+
+export function checkPluginHookArtifact(root, { checkPack = true } = {}) {
+  const source = validateHookTargets(root);
+  const plugin = validatePluginEntrypoints(root);
+  const allTargets = [...source.targets, ...plugin.targets];
+  if (!checkPack) return { ...source, plugin, artifact: null };
+  return { ...source, plugin, artifact: validateArtifactPaths(allTargets, packFiles(root)) };
+}
+
+function main(argv) {
+  const rootIndex = argv.indexOf('--root');
+  const root = path.resolve(rootIndex === -1 ? process.cwd() : (argv[rootIndex + 1] || ''));
+  const checkPack = !argv.includes('--skip-pack');
+  try {
+    const result = checkPluginHookArtifact(root, { checkPack });
+    if (!result.ok) {
+      for (const item of result.missing) console.error(`Missing hook target: ${item.event} -> ${item.resolved}`);
+      process.exit(1);
+    }
+    if (result.artifact && !result.artifact.ok) {
+      for (const item of result.artifact.missing) console.error(`Hook target omitted from npm artifact: ${item.event} -> ${item.relative}`);
+      process.exit(1);
+    }
+    console.log(`plugin artifact integrity: PASS (${result.targets.length} hook targets, ${result.plugin.targets.length} plugin/MCP targets${checkPack ? ', npm artifact checked' : ''})`);
+  } catch (error) {
+    console.error(`plugin hook integrity: ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+  }
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) main(process.argv.slice(2));

--- a/scripts/check-plugin-hook-artifact.mjs
+++ b/scripts/check-plugin-hook-artifact.mjs
@@ -3,8 +3,8 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
+import { npmSync } from './lib/npm-bin.mjs';
 
 export const CLAUDE_PLUGIN_ROOT_PREFIX = '${CLAUDE_PLUGIN_ROOT}/';
 
@@ -122,24 +122,29 @@ export function validateArtifactPaths(targets, files) {
 
 function packFiles(root) {
   const npmCache = fs.mkdtempSync(path.join(os.tmpdir(), 'memesh-pack-cache-'));
-  let packed;
   try {
-    packed = spawnSync('npm', ['pack', '--dry-run', '--json', '--ignore-scripts'], {
+    const stdout = npmSync(['pack', '--dry-run', '--json', '--ignore-scripts'], {
       cwd: root,
       encoding: 'utf8',
       env: { ...process.env, npm_config_cache: npmCache },
     });
+    let report;
+    try { report = JSON.parse(String(stdout)); } catch { throw new Error('npm pack --dry-run did not return valid JSON'); }
+    const entry = Array.isArray(report) ? report[0] : report;
+    if (!entry || !Array.isArray(entry.files)) throw new Error('npm pack --dry-run returned no file list');
+    return entry.files;
+  } catch (error) {
+    if (error instanceof Error && /npm pack --dry-run (?:did not return|returned no)/.test(error.message)) throw error;
+    const record = error && typeof error === 'object' ? /** @type {Record<string, unknown>} */ (error) : {};
+    const status = typeof record.status === 'number' ? record.status : 'unknown';
+    const stderr = typeof record.stderr === 'string' ? record.stderr.trim() : '';
+    throw new Error(
+      `npm pack --dry-run failed (exit ${status}): ${stderr || (error instanceof Error ? error.message : String(error))}`,
+      { cause: error },
+    );
   } finally {
     fs.rmSync(npmCache, { recursive: true, force: true });
   }
-  if (packed.status !== 0) {
-    throw new Error(`npm pack --dry-run failed (exit ${packed.status ?? 'unknown'}): ${(packed.stderr || '').trim()}`);
-  }
-  let report;
-  try { report = JSON.parse(packed.stdout); } catch { throw new Error('npm pack --dry-run did not return valid JSON'); }
-  const entry = Array.isArray(report) ? report[0] : report;
-  if (!entry || !Array.isArray(entry.files)) throw new Error('npm pack --dry-run returned no file list');
-  return entry.files;
 }
 
 export function checkPluginHookArtifact(root, { checkPack = true } = {}) {

--- a/scripts/check-plugin-hook-artifact.mjs
+++ b/scripts/check-plugin-hook-artifact.mjs
@@ -180,7 +180,7 @@ function main(argv) {
       process.exit(1);
     }
     if (result.artifact && !result.artifact.ok) {
-      for (const item of result.artifact.missing) console.error(`Hook target omitted from npm artifact: ${item.event} -> ${item.relative}`);
+      for (const item of result.artifact.missing) console.error(`Target omitted from npm artifact: ${item.event ?? item.kind} -> ${item.relative}`);
       process.exit(1);
     }
     console.log(`plugin artifact integrity: PASS (${result.targets.length} hook targets, ${result.plugin.targets.length} plugin/MCP targets${checkPack ? ', npm artifact checked' : ''})`);
@@ -200,11 +200,13 @@ function main(argv) {
  */
 function isEntrypoint(argv1) {
   if (!argv1) return false;
-  try {
-    return fs.realpathSync(fileURLToPath(import.meta.url)) === fs.realpathSync(path.resolve(argv1));
-  } catch {
-    return false;
-  }
+  const self = fileURLToPath(import.meta.url);
+  const given = path.resolve(argv1);
+  if (self === given) return true;
+  // A realpath failure must not become "not the entrypoint": that is exit 0
+  // with nothing checked, the fail-closed guard's caller only reads the exit
+  // code, and a staged plugin would swap in unverified. Let it throw.
+  return fs.realpathSync(self) === fs.realpathSync(given);
 }
 
 if (isEntrypoint(process.argv[1])) main(process.argv.slice(2));

--- a/scripts/check-plugin-hook-artifact.mjs
+++ b/scripts/check-plugin-hook-artifact.mjs
@@ -4,7 +4,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { npmSync } from './lib/npm-bin.mjs';
+import { npmSync, envWithNpmCache } from './lib/npm-bin.mjs';
 
 export const CLAUDE_PLUGIN_ROOT_PREFIX = '${CLAUDE_PLUGIN_ROOT}/';
 
@@ -46,15 +46,25 @@ export function validateHookTargets(root, manifest = readHookManifest(root)) {
   for (const target of targets) {
     const resolved = path.resolve(rootPath, target.relative);
     try {
-      // lstat is intentional: stat() follows an in-root symlink to an
-      // external file, which would let a staged cache execute ambient bytes.
-      if (isSubpath(rootPath, resolved) && fs.lstatSync(resolved).isFile()) continue;
+      if (isContainedRegularFile(rootPath, resolved)) continue;
     } catch {
       // Report the same bounded finding for missing and unreadable targets.
     }
     missing.push({ ...target, resolved });
   }
   return { targets, missing, ok: missing.length === 0 };
+}
+
+/**
+ * True only for a regular file whose every path component lives inside root.
+ * `lstat` rejects a symlink as the last component; `realpathSync` on both
+ * sides rejects a symlinked directory ABOVE it — `scripts/hooks -> /elsewhere`
+ * passed the lstat-only check and would have let a staged cache execute
+ * ambient bytes. Throws on a missing path, like the fs calls it wraps.
+ */
+function isContainedRegularFile(rootPath, resolved) {
+  if (!isSubpath(rootPath, resolved) || !fs.lstatSync(resolved).isFile()) return false;
+  return isSubpath(fs.realpathSync(rootPath), fs.realpathSync(resolved));
 }
 
 function safeRelativePath(value, label) {
@@ -73,7 +83,7 @@ function regularFile(root, relative, label) {
   const resolved = path.resolve(rootPath, relative);
   if (!isSubpath(rootPath, resolved)) throw new Error(`${label} escapes plugin root: ${relative}`);
   try {
-    if (fs.lstatSync(resolved).isFile()) return relative;
+    if (isContainedRegularFile(rootPath, resolved)) return relative;
   } catch {
     // Fall through to one bounded diagnostic.
   }
@@ -126,7 +136,7 @@ function packFiles(root) {
     const stdout = npmSync(['pack', '--dry-run', '--json', '--ignore-scripts'], {
       cwd: root,
       encoding: 'utf8',
-      env: { ...process.env, npm_config_cache: npmCache },
+      env: envWithNpmCache(npmCache),
     });
     let report;
     try { report = JSON.parse(String(stdout)); } catch { throw new Error('npm pack --dry-run did not return valid JSON'); }
@@ -157,7 +167,11 @@ export function checkPluginHookArtifact(root, { checkPack = true } = {}) {
 
 function main(argv) {
   const rootIndex = argv.indexOf('--root');
-  const root = path.resolve(rootIndex === -1 ? process.cwd() : (argv[rootIndex + 1] || ''));
+  if (rootIndex !== -1 && (!argv[rootIndex + 1] || argv[rootIndex + 1].startsWith('--'))) {
+    console.error('plugin hook integrity: --root requires a directory argument');
+    process.exit(2);
+  }
+  const root = path.resolve(rootIndex === -1 ? process.cwd() : argv[rootIndex + 1]);
   const checkPack = !argv.includes('--skip-pack');
   try {
     const result = checkPluginHookArtifact(root, { checkPack });
@@ -176,4 +190,21 @@ function main(argv) {
   }
 }
 
-if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) main(process.argv.slice(2));
+/**
+ * Run `main` only when this file is the entrypoint. Both sides go through
+ * realpath: Node resolves symlinks in `import.meta.url` but not in argv[1],
+ * so `node /var/folders/.../check-plugin-hook-artifact.mjs` (macOS tmp is a
+ * symlink) compared unequal, skipped `main`, and exited 0 with no output — a
+ * silent PASS from a checker that had checked nothing. Pinned by the tarball
+ * test in tests/plugin-hook-artifact.test.ts, which asserts on the output.
+ */
+function isEntrypoint(argv1) {
+  if (!argv1) return false;
+  try {
+    return fs.realpathSync(fileURLToPath(import.meta.url)) === fs.realpathSync(path.resolve(argv1));
+  } catch {
+    return false;
+  }
+}
+
+if (isEntrypoint(process.argv[1])) main(process.argv.slice(2));

--- a/scripts/generate-skills-manifest.mjs
+++ b/scripts/generate-skills-manifest.mjs
@@ -15,7 +15,7 @@
 //
 // What's covered:
 //   - skills/**/SKILL.md           (loaded as Claude system prompt)
-//   - scripts/hooks/*.js           (run in user's Claude Code process)
+//   - scripts/hooks/*.{js,mjs}     (run in user's Claude Code process)
 //   - hooks/hooks.json             (declares which hooks are active)
 //   - .claude-plugin/mcp.json, .claude-plugin/plugin.json,
 //     .codex-plugin/mcp.json, .codex-plugin/plugin.json
@@ -78,8 +78,9 @@ const targets = [];
 // Skills — every file under skills/
 targets.push(...await walk(join(repoRoot, 'skills'), true));
 
-// Hooks — every .js under scripts/hooks
-targets.push(...(await walk(join(repoRoot, 'scripts', 'hooks'), true)).filter(p => p.endsWith('.js')));
+// Hooks — every JavaScript hook runtime, including the detached `.mjs`
+// auto-update runner selected by `_shared.js`.
+targets.push(...(await walk(join(repoRoot, 'scripts', 'hooks'), true)).filter(p => p.endsWith('.js') || p.endsWith('.mjs')));
 
 // Single-file artefacts (declarative wiring read by Claude Code itself).
 //

--- a/scripts/lib/npm-bin.mjs
+++ b/scripts/lib/npm-bin.mjs
@@ -103,3 +103,21 @@ export function npmSync(args, opts = {}) {
 export function npxSync(args, opts = {}) {
   return runSync(NPX, args, opts);
 }
+
+/**
+ * `baseEnv` with every spelling of `npm_config_cache` removed and the private
+ * cache set. Windows environment names are case-insensitive and Node keeps
+ * the lexicographically first of two keys that differ only in case (`N`
+ * before `n`); Vitest adds an upper-cased copy of every variable to its
+ * Windows workers. So `{ ...process.env, npm_config_cache }` handed npm the
+ * runner's `NPM_CONFIG_CACHE=C:\npm\cache` and never the private directory —
+ * measured on windows-latest with the fake npm in
+ * `tests/consumer-audit-gate.test.ts`.
+ */
+export function envWithNpmCache(cacheDir, baseEnv = process.env) {
+  const env = Object.fromEntries(
+    Object.entries(baseEnv).filter(([key]) => key.toLowerCase() !== 'npm_config_cache'),
+  );
+  env.npm_config_cache = cacheDir;
+  return env;
+}

--- a/scripts/qa/live-journey.mjs
+++ b/scripts/qa/live-journey.mjs
@@ -2125,7 +2125,7 @@ async function runCodexSessionAutoRegistration(journey) {
   for (const sessionId of [threadId, secondThreadId]) {
     await journey.terminateCodexDetachedCompanion(sessionId);
     await journey.until(
-      `The automatic Codex session ${sessionId} remained live after all companions stopped`,
+      `The automatic Codex session ${sessionId} was still registered after its detached companion was terminated`,
       () => journey.sessionGone(sessionId),
       15_000,
     );

--- a/scripts/qa/live-journey.mjs
+++ b/scripts/qa/live-journey.mjs
@@ -948,6 +948,18 @@ export function assertCompanionRunning(companion, label) {
 }
 
 /**
+ * The SessionStart hook is only a launcher: it exits after publishing a
+ * detached companion. Discoverable live cards are the proof that the detached
+ * process is running; the launcher itself should merely have exited cleanly.
+ */
+export function assertSessionStartLauncherSucceeded(companion, label) {
+  if (companion.signalCode !== null || (companion.exitCode !== null && companion.exitCode !== 0)) {
+    throw new Error(`${label} failed before its detached companion registered.`);
+  }
+  return companion;
+}
+
+/**
  * Wait for one live host session to leave the router directory.
  *
  * This is the decision that keeps a shutdown from creating an orphan, so it is
@@ -1375,6 +1387,28 @@ fs.appendFileSync(process.env.MEMESH_FAKE_CODEX_QUEUE_LOG, JSON.stringify(record
   async stopCodexCompanion(companion) {
     await stopChild(companion);
     this.companions = this.companions.filter((candidate) => candidate !== companion);
+  }
+
+  async terminateCodexDetachedCompanion(threadId) {
+    const statePath = path.join(this.memeshDir, 'runtime', 'codex-session', `${threadId}.json`);
+    const state = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+    await new Promise((resolve, reject) => {
+      const socket = net.createConnection(state.control_socket);
+      let response = '';
+      const timer = setTimeout(() => {
+        socket.destroy();
+        reject(new Error(`Detached Codex companion ${threadId} did not acknowledge termination.`));
+      }, 2_000);
+      socket.setEncoding('utf8');
+      socket.on('data', (chunk) => { response += chunk; });
+      socket.once('error', (error) => { clearTimeout(timer); reject(error); });
+      socket.once('close', () => {
+        clearTimeout(timer);
+        if (response.trim() !== 'terminated') reject(new Error(`Detached Codex companion ${threadId} rejected termination.`));
+        else resolve();
+      });
+      socket.once('connect', () => socket.end(`${JSON.stringify({ action: 'terminate', token: state.token })}\n`));
+    });
   }
 
   trackCodexProcess(child) {
@@ -1990,8 +2024,8 @@ async function runCodexSessionAutoRegistration(journey) {
       },
       15_000,
     );
-    assertCompanionRunning(firstCompanion, 'First packaged Codex SessionStart companion');
-    assertCompanionRunning(secondCompanion, 'Second packaged Codex SessionStart companion');
+    assertSessionStartLauncherSucceeded(firstCompanion, 'First packaged Codex SessionStart launcher');
+    assertSessionStartLauncherSucceeded(secondCompanion, 'Second packaged Codex SessionStart launcher');
     if (fs.existsSync(configPath)) {
       throw new Error('Automatic Codex SessionStart registration unexpectedly created hosts/codex-session.json.');
     }
@@ -2029,10 +2063,6 @@ async function runCodexSessionAutoRegistration(journey) {
   });
 
   const cliSentinel = `codex-auto-first-${randomUUID().slice(0, 8)}`;
-  const cliPayload = {
-    qa_sentinel: cliSentinel,
-    instruction: 'No action required. MeMesh owner-run live journey check; run no commands.',
-  };
   const sent = [
     mcpRun.result.sent,
     {
@@ -2041,7 +2071,7 @@ async function runCodexSessionAutoRegistration(journey) {
       project: journey.project,
       sender: 'memesh-live-journey-harness',
       contentType: 'application/json',
-      payload: cliPayload,
+      payload: buildLiveJourneyPayload(cliSentinel),
       ...journey.sendAccepted(threadId, cliSentinel, cliSentinel, 'codex-cli-queue'),
     },
   ];
@@ -2068,9 +2098,7 @@ async function runCodexSessionAutoRegistration(journey) {
   }
   await journey.assertLegacyRouterUntouched();
 
-  if (firstCompanion.exitCode !== null) {
-    throw new Error('The original first Codex companion exited before the resume registration was attempted.');
-  }
+  assertSessionStartLauncherSucceeded(firstCompanion, 'Original first Codex SessionStart launcher');
   const resumedCompanion = journey.startCodexCompanion(threadId, workspace, 'codex-session-auto-resume.log', 'resume');
   const resumedCard = await journey.until(
     'The resumed first Codex thread never superseded its original generation',
@@ -2095,6 +2123,7 @@ async function runCodexSessionAutoRegistration(journey) {
   for (const companion of journey.companions) await stopChild(companion);
   journey.companions = [];
   for (const sessionId of [threadId, secondThreadId]) {
+    await journey.terminateCodexDetachedCompanion(sessionId);
     await journey.until(
       `The automatic Codex session ${sessionId} remained live after all companions stopped`,
       () => journey.sessionGone(sessionId),

--- a/scripts/upgrade-plugin.sh
+++ b/scripts/upgrade-plugin.sh
@@ -91,6 +91,11 @@ MARKETPLACE_DIR="$CLAUDE_CONFIG_ROOT/plugins/marketplaces/pcircle-memesh"
 INSTALL_REGISTRY="$CLAUDE_CONFIG_ROOT/plugins/installed_plugins.json"
 CACHE_ROOT="$CLAUDE_CONFIG_ROOT/plugins/cache/pcircle-memesh/memesh"
 LOCK_DIR="$CACHE_ROOT.lock"
+# Use the checker shipped beside this upgrade script, not a file newly staged
+# from the target commit. This keeps upgrades from legacy marketplace commits
+# testable and prevents a target archive from disabling its own validation.
+UPGRADE_SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ARTIFACT_CHECKER="$UPGRADE_SCRIPT_DIR/check-plugin-hook-artifact.mjs"
 
 # ─── Pre-flight ────────────────────────────────────────────────────────────
 if [ ! -d "$MARKETPLACE_DIR" ]; then
@@ -514,14 +519,23 @@ echo "==> Installing runtime deps (this may take a minute)..."
   exit 1
 }
 
-# Validate the exact staged plugin before moving it into the live cache. The
+# Validate a real staged plugin before moving it into the live cache. The
 # host registry may load hooks immediately after the swap; a manifest that
 # names a missing script would otherwise surface as a frightening `127` in the
-# user's next session. This check is source/artifact integrity only and never
-# mutates the live cache or registry.
-if ! node "$STAGE_PATH/scripts/check-plugin-hook-artifact.mjs" --root "$STAGE_PATH" --skip-pack; then
-  echo "ERROR: staged plugin hook integrity check failed — the live cache at $NEW_INSTALL_PATH was not touched" >&2
-  exit 1
+# user's next session. Tiny legacy marketplace fixtures (and genuinely old
+# plugin archives) have no plugin wiring to validate, so preserve their
+# historical cache-refresh behavior; once wiring is present, the checker is
+# mandatory and fail-closed. The checker itself comes from this script's
+# installed release, never from the target archive being validated.
+if [ -f "$STAGE_PATH/hooks/hooks.json" ] || [ -f "$STAGE_PATH/.claude-plugin/plugin.json" ] || [ -f "$STAGE_PATH/.codex-plugin/plugin.json" ]; then
+  if [ ! -f "$PLUGIN_ARTIFACT_CHECKER" ]; then
+    echo "ERROR: plugin artifact checker is missing beside the upgrade script — the live cache at $NEW_INSTALL_PATH was not touched" >&2
+    exit 1
+  fi
+  if ! node "$PLUGIN_ARTIFACT_CHECKER" --root "$STAGE_PATH" --skip-pack; then
+    echo "ERROR: staged plugin artifact integrity check failed — the live cache at $NEW_INSTALL_PATH was not touched" >&2
+    exit 1
+  fi
 fi
 
 # ─── 5. Swap the staged copy in ───────────────────────────────────────────

--- a/scripts/upgrade-plugin.sh
+++ b/scripts/upgrade-plugin.sh
@@ -514,6 +514,16 @@ echo "==> Installing runtime deps (this may take a minute)..."
   exit 1
 }
 
+# Validate the exact staged plugin before moving it into the live cache. The
+# host registry may load hooks immediately after the swap; a manifest that
+# names a missing script would otherwise surface as a frightening `127` in the
+# user's next session. This check is source/artifact integrity only and never
+# mutates the live cache or registry.
+if ! node "$STAGE_PATH/scripts/check-plugin-hook-artifact.mjs" --root "$STAGE_PATH" --skip-pack; then
+  echo "ERROR: staged plugin hook integrity check failed — the live cache at $NEW_INSTALL_PATH was not touched" >&2
+  exit 1
+fi
+
 # ─── 5. Swap the staged copy in ───────────────────────────────────────────
 if [ -e "$NEW_INSTALL_PATH" ] || [ -L "$NEW_INSTALL_PATH" ]; then
   HAD_LIVE_CACHE=1

--- a/tests/cli/upgrade-plugin-same-version.test.ts
+++ b/tests/cli/upgrade-plugin-same-version.test.ts
@@ -228,6 +228,26 @@ function writeRegistry(entry: Record<string, unknown>): void {
   fs.writeFileSync(registry, JSON.stringify({ plugins: { 'memesh@pcircle-memesh': [entry] } }, null, 4));
 }
 
+function commitWiredMarketplace({ missingHook = false, missingServer = false } = {}): void {
+  fs.mkdirSync(path.join(marketplace, 'hooks'), { recursive: true });
+  fs.mkdirSync(path.join(marketplace, 'scripts', 'hooks'), { recursive: true });
+  fs.mkdirSync(path.join(marketplace, '.claude-plugin'), { recursive: true });
+  fs.mkdirSync(path.join(marketplace, '.codex-plugin'), { recursive: true });
+  fs.mkdirSync(path.join(marketplace, 'dist', 'mcp'), { recursive: true });
+  fs.writeFileSync(path.join(marketplace, 'hooks', 'hooks.json'), JSON.stringify({ hooks: {
+    PreCompact: [{ hooks: [{ type: 'command', command: '${CLAUDE_PLUGIN_ROOT}/scripts/hooks/pre-compact.js' }] }],
+  } }));
+  if (!missingHook) fs.writeFileSync(path.join(marketplace, 'scripts', 'hooks', 'pre-compact.js'), '');
+  if (!missingServer) fs.writeFileSync(path.join(marketplace, 'dist', 'mcp', 'server.js'), '');
+  fs.writeFileSync(path.join(marketplace, '.claude-plugin', 'plugin.json'), JSON.stringify({ name: 'memesh', version: '4.8.2', mcpServers: './.claude-plugin/mcp.json' }));
+  fs.writeFileSync(path.join(marketplace, '.codex-plugin', 'plugin.json'), JSON.stringify({ name: 'memesh', version: '4.8.2', mcpServers: './.codex-plugin/mcp.json' }));
+  fs.writeFileSync(path.join(marketplace, '.claude-plugin', 'mcp.json'), JSON.stringify({ mcpServers: { memesh: { command: 'node', args: ['${CLAUDE_PLUGIN_ROOT}/dist/mcp/server.js'] } } }));
+  fs.writeFileSync(path.join(marketplace, '.codex-plugin', 'mcp.json'), JSON.stringify({ mcpServers: { memesh: { command: 'node', args: ['./dist/mcp/server.js'] } } }));
+  git(marketplace, 'add', '-A');
+  git(marketplace, 'commit', '-q', '-m', 'test: wired plugin fixture');
+  git(marketplace, 'push', '-q', 'origin', 'main');
+}
+
 beforeEach(() => {
   home = fs.mkdtempSync(path.join(os.tmpdir(), 'memesh-upgrade-sha-'));
   const origin = path.join(home, 'origin.git');
@@ -260,6 +280,50 @@ describe('upgrade-plugin.sh: config-root preflight', () => {
 });
 
 describe('upgrade-plugin.sh: same version, different commit', () => {
+  posixOnly('valid wired plugin stage invokes the current checker before swap', () => {
+    commitWiredMarketplace();
+    const live = path.join(home, '.claude/plugins/cache/pcircle-memesh/memesh/4.8.2');
+    fs.writeFileSync(path.join(live, 'LIVE-MARKER.txt'), 'old cache remains replaceable\n');
+    const headSha = git(marketplace, 'rev-parse', 'HEAD');
+    writeRegistry({ installPath: live, version: '4.8.2', gitCommitSha: headSha.slice(0, -1) + (headSha.endsWith('0') ? '1' : '0') });
+
+    const r = runScript();
+    expect(r.exitCode, r.stderr).toBe(0);
+    expect(fs.existsSync(path.join(live, 'scripts/hooks/pre-compact.js'))).toBe(true);
+    expect(fs.existsSync(path.join(live, 'dist/mcp/server.js'))).toBe(true);
+    expect(JSON.parse(fs.readFileSync(registry, 'utf8')).plugins['memesh@pcircle-memesh'][0].gitCommitSha).toBe(headSha);
+  });
+
+  posixOnly('wired plugin with a missing hook fails before touching cache or registry', () => {
+    commitWiredMarketplace({ missingHook: true });
+    const live = path.join(home, '.claude/plugins/cache/pcircle-memesh/memesh/4.8.2');
+    fs.writeFileSync(path.join(live, 'LIVE-MARKER.txt'), 'must survive integrity failure\n');
+    const headSha = git(marketplace, 'rev-parse', 'HEAD');
+    writeRegistry({ installPath: live, version: '4.8.2', gitCommitSha: headSha.slice(0, -1) + (headSha.endsWith('0') ? '1' : '0') });
+    const registryBefore = fs.readFileSync(registry, 'utf8');
+
+    const r = runScript();
+    expect(r.exitCode).not.toBe(0);
+    expect(r.stderr).toContain('staged plugin artifact integrity check failed');
+    expect(fs.readFileSync(path.join(live, 'LIVE-MARKER.txt'), 'utf8')).toContain('must survive');
+    expect(fs.readFileSync(registry, 'utf8')).toBe(registryBefore);
+  });
+
+  posixOnly('wired plugin with a missing MCP entrypoint fails before swap', () => {
+    commitWiredMarketplace({ missingServer: true });
+    const live = path.join(home, '.claude/plugins/cache/pcircle-memesh/memesh/4.8.2');
+    fs.writeFileSync(path.join(live, 'LIVE-MARKER.txt'), 'must survive MCP integrity failure\n');
+    const headSha = git(marketplace, 'rev-parse', 'HEAD');
+    writeRegistry({ installPath: live, version: '4.8.2', gitCommitSha: headSha.slice(0, -1) + (headSha.endsWith('0') ? '1' : '0') });
+    const registryBefore = fs.readFileSync(registry, 'utf8');
+
+    const r = runScript();
+    expect(r.exitCode).not.toBe(0);
+    expect(r.stderr).toContain('staged plugin artifact integrity check failed');
+    expect(fs.readFileSync(path.join(live, 'LIVE-MARKER.txt'), 'utf8')).toContain('must survive');
+    expect(fs.readFileSync(registry, 'utf8')).toBe(registryBefore);
+  });
+
   posixOnly('refreshes the cache in place and records the marketplace commit', () => {
     const bumpSha = git(marketplace, 'rev-parse', 'HEAD');
     writeRegistry({ installPath: path.join(home, '.claude/plugins/cache/pcircle-memesh/memesh/4.8.2'), version: '4.8.2', gitCommitSha: bumpSha });

--- a/tests/cli/upgrade-plugin-same-version.test.ts
+++ b/tests/cli/upgrade-plugin-same-version.test.ts
@@ -29,12 +29,16 @@ function git(cwd: string, ...args: string[]): string {
   }).trim();
 }
 
-function runScript(envOverride: Record<string, string> = {}): { stdout: string; stderr: string; exitCode: number } {
-  const result = spawnSync('bash', [SCRIPT], {
+function runScriptAt(scriptPath: string, envOverride: Record<string, string> = {}): { stdout: string; stderr: string; exitCode: number } {
+  const result = spawnSync('bash', [scriptPath], {
     encoding: 'utf8',
     env: { ...process.env, HOME: home, ...envOverride },
   });
   return { stdout: result.stdout ?? '', stderr: result.stderr ?? '', exitCode: result.status ?? 1 };
+}
+
+function runScript(envOverride: Record<string, string> = {}): { stdout: string; stderr: string; exitCode: number } {
+  return runScriptAt(SCRIPT, envOverride);
 }
 
 function runScriptWithoutHome(): { stdout: string; stderr: string; exitCode: number } {
@@ -320,6 +324,25 @@ describe('upgrade-plugin.sh: same version, different commit', () => {
     const r = runScript();
     expect(r.exitCode).not.toBe(0);
     expect(r.stderr).toContain('staged plugin artifact integrity check failed');
+    expect(fs.readFileSync(path.join(live, 'LIVE-MARKER.txt'), 'utf8')).toContain('must survive');
+    expect(fs.readFileSync(registry, 'utf8')).toBe(registryBefore);
+  });
+
+  posixOnly('wired plugin refuses to swap when the updater-side checker is absent', () => {
+    commitWiredMarketplace();
+    const live = path.join(home, '.claude/plugins/cache/pcircle-memesh/memesh/4.8.2');
+    fs.writeFileSync(path.join(live, 'LIVE-MARKER.txt'), 'must survive missing checker\n');
+    const headSha = git(marketplace, 'rev-parse', 'HEAD');
+    writeRegistry({ installPath: live, version: '4.8.2', gitCommitSha: headSha.slice(0, -1) + (headSha.endsWith('0') ? '1' : '0') });
+    const registryBefore = fs.readFileSync(registry, 'utf8');
+    const copiedScriptDir = fs.mkdtempSync(path.join(home, 'copied-updater-'));
+    const copiedScript = path.join(copiedScriptDir, 'upgrade-plugin.sh');
+    fs.copyFileSync(SCRIPT, copiedScript);
+    fs.chmodSync(copiedScript, 0o755);
+
+    const r = runScriptAt(copiedScript);
+    expect(r.exitCode).not.toBe(0);
+    expect(r.stderr).toContain('plugin artifact checker is missing beside the upgrade script');
     expect(fs.readFileSync(path.join(live, 'LIVE-MARKER.txt'), 'utf8')).toContain('must survive');
     expect(fs.readFileSync(registry, 'utf8')).toBe(registryBefore);
   });

--- a/tests/consumer-audit-gate.test.ts
+++ b/tests/consumer-audit-gate.test.ts
@@ -125,6 +125,26 @@ describe('Feature: the consumer audit cannot pass on an empty tree', () => {
     expect(res.status).not.toBe(0); // fake install is still intentionally rejected
     expect(fs.readFileSync(marker, 'utf8')).toMatch(/memesh-consumer-npm-cache-/);
   });
+
+  it('terminates a hung npm command and reports a bounded failure', () => {
+    fs.writeFileSync(
+      path.join(binDir, 'npm'),
+      ['#!/bin/sh', 'if [ "$1" = "pack" ]; then sleep 2; fi', 'exit 0', ''].join('\n'),
+    );
+    fs.chmodSync(path.join(binDir, 'npm'), 0o755);
+    const res = spawnSync('node', ['scripts/check-consumer-audit.mjs'], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        PATH: `${binDir}${path.delimiter}${process.env.PATH}`,
+        MEMESH_CONSUMER_AUDIT_TIMEOUT_MS: '50',
+      },
+      encoding: 'utf8',
+      timeout: 120000,
+    });
+    expect(res.status).not.toBe(0);
+    expect(`${res.stdout}${res.stderr}`).toMatch(/timed out|ETIMEDOUT/i);
+  });
 });
 
 describe('Feature: the only non-literal argument is checked, not trusted', () => {

--- a/tests/consumer-audit-gate.test.ts
+++ b/tests/consumer-audit-gate.test.ts
@@ -116,6 +116,21 @@ describe('Feature: the consumer audit cannot pass on an empty tree', () => {
       ].join('\n'),
     );
     fs.chmodSync(path.join(binDir, 'npm'), 0o755);
+    fs.writeFileSync(
+      path.join(binDir, 'npm.cmd'),
+      [
+        '@echo off',
+        '> "%MEMESH_TEST_CACHE_MARKER%" echo %npm_config_cache%',
+        'if "%~1"=="pack" (',
+        '  type nul > fake-package-0.0.0.tgz',
+        '  echo fake-package-0.0.0.tgz',
+        '  exit /b 0',
+        ')',
+        'if "%~1"=="audit" echo found 0 vulnerabilities',
+        'exit /b 0',
+        '',
+      ].join('\r\n'),
+    );
     const res = spawnSync('node', ['scripts/check-consumer-audit.mjs'], {
       cwd: repoRoot,
       env: { ...process.env, PATH: `${binDir}${path.delimiter}${process.env.PATH}`, MEMESH_TEST_CACHE_MARKER: marker },
@@ -132,6 +147,15 @@ describe('Feature: the consumer audit cannot pass on an empty tree', () => {
       ['#!/bin/sh', 'if [ "$1" = "pack" ]; then sleep 2; fi', 'exit 0', ''].join('\n'),
     );
     fs.chmodSync(path.join(binDir, 'npm'), 0o755);
+    fs.writeFileSync(
+      path.join(binDir, 'npm.cmd'),
+      [
+        '@echo off',
+        'if "%~1"=="pack" powershell -NoProfile -NonInteractive -Command "Start-Sleep -Milliseconds 2000"',
+        'exit /b 0',
+        '',
+      ].join('\r\n'),
+    );
     const res = spawnSync('node', ['scripts/check-consumer-audit.mjs'], {
       cwd: repoRoot,
       env: {

--- a/tests/consumer-audit-gate.test.ts
+++ b/tests/consumer-audit-gate.test.ts
@@ -98,6 +98,33 @@ describe('Feature: the consumer audit cannot pass on an empty tree', () => {
     expect(res.status).not.toBe(0);
     expect(`${res.stdout}${res.stderr}`).toMatch(/did not install|nothing was audited/i);
   });
+
+  it('uses a private npm cache instead of inheriting the caller cache', () => {
+    const marker = path.join(binDir, 'npm-cache-seen');
+    fs.writeFileSync(
+      path.join(binDir, 'npm'),
+      [
+        '#!/bin/sh',
+        'printf "%s" "$npm_config_cache" > "$MEMESH_TEST_CACHE_MARKER"',
+        'case "$1" in',
+        '  pack) : > "fake-package-0.0.0.tgz"; echo "fake-package-0.0.0.tgz"; exit 0;;',
+        '  install) exit 0;;',
+        '  audit) echo "found 0 vulnerabilities"; exit 0;;',
+        '  *) exit 0;;',
+        'esac',
+        '',
+      ].join('\n'),
+    );
+    fs.chmodSync(path.join(binDir, 'npm'), 0o755);
+    const res = spawnSync('node', ['scripts/check-consumer-audit.mjs'], {
+      cwd: repoRoot,
+      env: { ...process.env, PATH: `${binDir}${path.delimiter}${process.env.PATH}`, MEMESH_TEST_CACHE_MARKER: marker },
+      encoding: 'utf8',
+      timeout: 120000,
+    });
+    expect(res.status).not.toBe(0); // fake install is still intentionally rejected
+    expect(fs.readFileSync(marker, 'utf8')).toMatch(/memesh-consumer-npm-cache-/);
+  });
 });
 
 describe('Feature: the only non-literal argument is checked, not trusted', () => {

--- a/tests/mcp-work-package-runtime.test.ts
+++ b/tests/mcp-work-package-runtime.test.ts
@@ -11,6 +11,7 @@ import { ListRootsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { MemeshDatabase } from '../src/storage/sqlite.js';
 import { getProjectName } from '../src/core/paths.js';
 import { projectTranscriptSlug } from '../src/core/transcript-source.js';
+import { removeTempDir } from './helpers/temp-dir.js';
 
 it('stages digest and visible transcript work through the actual MCP stdio process with read-only deferral', async () => {
   const repo = fileURLToPath(new URL('../', import.meta.url));
@@ -250,7 +251,7 @@ it('stages digest and visible transcript work through the actual MCP stdio proce
     try { await client.close(); }
     finally {
       await transport.close();
-      fs.rmSync(runtime, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+      removeTempDir(runtime);
     }
   }
 }, 30000);

--- a/tests/plugin-hook-artifact.test.ts
+++ b/tests/plugin-hook-artifact.test.ts
@@ -93,6 +93,19 @@ describe('plugin hook artifact integrity', () => {
       ], { encoding: 'utf8', timeout: 60000 });
       expect(run.status, `${run.stdout}${run.stderr}`).toBe(0);
       expect(run.stdout).toMatch(/plugin artifact integrity: PASS/);
+
+      // Through a symlink, explicitly. The guard that decides whether main()
+      // runs compares import.meta.url (symlinks resolved by Node) with argv[1]
+      // (not resolved); on macOS os.tmpdir() is itself a symlink so the run
+      // above already crosses one, on Linux CI it is not, and the regression
+      // would pass there. A named symlink makes the pin hold on every OS.
+      const linkDir = path.join(packDir, 'linkdir');
+      fs.mkdirSync(linkDir);
+      const linked = path.join(linkDir, 'checker.mjs');
+      fs.symlinkSync(path.join(packageRoot, 'scripts', 'check-plugin-hook-artifact.mjs'), linked);
+      const viaLink = spawnSync(process.execPath, [linked, '--root', packageRoot, '--skip-pack'], { encoding: 'utf8', timeout: 60000 });
+      expect(viaLink.status, `${viaLink.stdout}${viaLink.stderr}`).toBe(0);
+      expect(viaLink.stdout).toMatch(/plugin artifact integrity: PASS/);
     } finally {
       fs.rmSync(packDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
     }

--- a/tests/plugin-hook-artifact.test.ts
+++ b/tests/plugin-hook-artifact.test.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { spawnSync } from 'node:child_process';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { hookTargetsFromManifest, validateArtifactPaths, validateHookTargets, validatePluginEntrypoints } from '../scripts/check-plugin-hook-artifact.mjs';
 
@@ -51,6 +52,51 @@ describe('plugin hook artifact integrity', () => {
       fs.rmSync(outside, { force: true });
     }
   });
+
+  it('rejects a symlinked directory above a hook target', () => {
+    // The lstat-only check saw a regular file at the leaf and passed; the
+    // directory it sat in pointed outside the staged plugin.
+    const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memesh-hook-outside-dir-'));
+    try {
+      fs.writeFileSync(path.join(outsideDir, 'session-start.js'), '');
+      fs.writeFileSync(path.join(outsideDir, 'pre-compact.js'), '');
+      fs.rmSync(path.join(root, 'scripts', 'hooks'), { recursive: true, force: true });
+      fs.symlinkSync(outsideDir, path.join(root, 'scripts', 'hooks'), 'dir');
+      const result = validateHookTargets(root);
+      expect(result.ok).toBe(false);
+      expect(result.missing).toHaveLength(2);
+    } finally {
+      fs.rmSync(outsideDir, { recursive: true, force: true });
+    }
+  });
+
+  it('loads and passes from the npm tarball, not only from the repository', () => {
+    // `memesh upgrade-plugin` prefers the npm-installed copy of the updater,
+    // and the updater runs THIS checker fail-closed. v4.9.4's first candidate
+    // packed the checker without `scripts/lib/npm-bin.mjs`, so from an npm
+    // install it died on import and every upgrade was refused — while
+    // `pkg.files` contained the checker and the gate reported PASS. Only
+    // executing the unpacked artifact pins the dependency.
+    const repoRoot = path.resolve(__dirname, '..');
+    const packDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memesh-pack-run-'));
+    try {
+      const pack = spawnSync('npm', ['pack', '--json', '--ignore-scripts', '--pack-destination', packDir], {
+        cwd: repoRoot, encoding: 'utf8', shell: process.platform === 'win32', timeout: 120000,
+      });
+      expect(pack.status, pack.stderr).toBe(0);
+      const tarball = path.join(packDir, JSON.parse(pack.stdout)[0].filename);
+      const untar = spawnSync('tar', ['-xzf', tarball, '-C', packDir], { encoding: 'utf8', timeout: 60000 });
+      expect(untar.status, untar.stderr).toBe(0);
+      const packageRoot = path.join(packDir, 'package');
+      const run = spawnSync(process.execPath, [
+        path.join(packageRoot, 'scripts', 'check-plugin-hook-artifact.mjs'), '--root', packageRoot, '--skip-pack',
+      ], { encoding: 'utf8', timeout: 60000 });
+      expect(run.status, `${run.stdout}${run.stderr}`).toBe(0);
+      expect(run.stdout).toMatch(/plugin artifact integrity: PASS/);
+    } finally {
+      fs.rmSync(packDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+    }
+  }, 240000);
 
   it('requires both host MCP manifests and their bundled entrypoint', () => {
     fs.writeFileSync(path.join(root, 'scripts', 'hooks', 'session-start.js'), '');

--- a/tests/plugin-hook-artifact.test.ts
+++ b/tests/plugin-hook-artifact.test.ts
@@ -1,0 +1,78 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { hookTargetsFromManifest, validateArtifactPaths, validateHookTargets, validatePluginEntrypoints } from '../scripts/check-plugin-hook-artifact.mjs';
+
+describe('plugin hook artifact integrity', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'memesh-plugin-hook-integrity-'));
+    fs.mkdirSync(path.join(root, 'hooks'), { recursive: true });
+    fs.mkdirSync(path.join(root, 'scripts', 'hooks'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'hooks', 'hooks.json'), JSON.stringify({ hooks: {
+      SessionStart: [{ hooks: [{ type: 'command', command: '${CLAUDE_PLUGIN_ROOT}/scripts/hooks/session-start.js' }] }],
+      PreCompact: [{ hooks: [{ type: 'command', command: '${CLAUDE_PLUGIN_ROOT}/scripts/hooks/pre-compact.js' }] }],
+    } }));
+  });
+
+  afterEach(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  it('fails closed when a declared hook file is missing', () => {
+    fs.writeFileSync(path.join(root, 'scripts', 'hooks', 'session-start.js'), '');
+    const result = validateHookTargets(root);
+    expect(result.ok).toBe(false);
+    expect(result.missing).toEqual([expect.objectContaining({ event: 'PreCompact', relative: 'scripts/hooks/pre-compact.js' })]);
+  });
+
+  it('accepts a complete manifest and rejects an omitted packed target', () => {
+    fs.writeFileSync(path.join(root, 'scripts', 'hooks', 'session-start.js'), '');
+    fs.writeFileSync(path.join(root, 'scripts', 'hooks', 'pre-compact.js'), '');
+    const source = validateHookTargets(root);
+    expect(source.ok).toBe(true);
+    expect(validateArtifactPaths(source.targets, ['hooks/hooks.json', 'scripts/hooks/session-start.js']).ok).toBe(false);
+    expect(validateArtifactPaths(source.targets, ['hooks/hooks.json', 'scripts/hooks/session-start.js', 'scripts/hooks/pre-compact.js']).ok).toBe(true);
+  });
+
+  it('rejects traversal and shell fragments', () => {
+    expect(() => hookTargetsFromManifest({ hooks: { Stop: [{ hooks: [{ type: 'command', command: '${CLAUDE_PLUGIN_ROOT}/../escape.js' }] }] } })).toThrow();
+    expect(() => hookTargetsFromManifest({ hooks: { Stop: [{ hooks: [{ type: 'command', command: '${CLAUDE_PLUGIN_ROOT}/scripts/x.js --flag' }] }] } })).toThrow();
+  });
+
+  it('rejects a hook symlink that escapes the staged plugin', () => {
+    const outside = path.join(root, '..', `memesh-hook-outside-${process.pid}.js`);
+    fs.writeFileSync(outside, '');
+    try {
+      fs.writeFileSync(path.join(root, 'scripts', 'hooks', 'session-start.js'), '');
+      fs.symlinkSync(outside, path.join(root, 'scripts', 'hooks', 'pre-compact.js'));
+      expect(validateHookTargets(root).ok).toBe(false);
+    } finally {
+      fs.rmSync(outside, { force: true });
+    }
+  });
+
+  it('requires both host MCP manifests and their bundled entrypoint', () => {
+    fs.writeFileSync(path.join(root, 'scripts', 'hooks', 'session-start.js'), '');
+    fs.writeFileSync(path.join(root, 'scripts', 'hooks', 'pre-compact.js'), '');
+    fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({ version: '1.2.3' }));
+    fs.mkdirSync(path.join(root, '.claude-plugin'), { recursive: true });
+    fs.mkdirSync(path.join(root, '.codex-plugin'), { recursive: true });
+    fs.mkdirSync(path.join(root, 'dist', 'mcp'), { recursive: true });
+    fs.writeFileSync(path.join(root, '.claude-plugin', 'plugin.json'), JSON.stringify({ name: 'memesh', version: '1.2.3', mcpServers: './.claude-plugin/mcp.json' }));
+    fs.writeFileSync(path.join(root, '.codex-plugin', 'plugin.json'), JSON.stringify({ name: 'memesh', version: '1.2.3', mcpServers: './.codex-plugin/mcp.json' }));
+    fs.writeFileSync(path.join(root, '.claude-plugin', 'mcp.json'), JSON.stringify({ mcpServers: { memesh: { command: 'node', args: ['${CLAUDE_PLUGIN_ROOT}/dist/mcp/server.js'] } } }));
+    fs.writeFileSync(path.join(root, '.codex-plugin', 'mcp.json'), JSON.stringify({ mcpServers: { memesh: { command: 'node', args: ['./dist/mcp/server.js'] } } }));
+    expect(() => validatePluginEntrypoints(root)).toThrow(/entrypoint/);
+    fs.writeFileSync(path.join(root, 'dist', 'mcp', 'server.js'), '');
+    expect(validatePluginEntrypoints(root).targets.map(({ relative }) => relative)).toContain('dist/mcp/server.js');
+  });
+
+  it('runs before the upgrade script swaps the staged cache', () => {
+    const upgrade = fs.readFileSync(path.resolve('scripts/upgrade-plugin.sh'), 'utf8');
+    const check = upgrade.indexOf('check-plugin-hook-artifact.mjs');
+    const swap = upgrade.indexOf('# ─── 5. Swap the staged copy');
+    expect(check).toBeGreaterThan(-1);
+    expect(swap).toBeGreaterThan(check);
+  });
+});

--- a/tests/qa-pre-release.test.ts
+++ b/tests/qa-pre-release.test.ts
@@ -77,6 +77,20 @@ describe('the plan', () => {
     expect(scripts['check:entry-points-start']).toContain('check-entry-points-start.mjs');
   });
 
+  it('reaches the plugin hook cache/artifact integrity gate transitively', () => {
+    const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8'));
+    expect(pkg.files).toContain('scripts/check-plugin-hook-artifact.mjs');
+    expect(pkg.scripts['verify:release']).toContain('check:plugin-hook-artifact');
+    expect(pkg.scripts['check:plugin-hook-artifact']).toContain('check-plugin-hook-artifact.mjs');
+  });
+
+  it('covers the detached auto-update runner in the shipped integrity manifest', () => {
+    const manifest = JSON.parse(fs.readFileSync(path.join(repoRoot, 'dist', 'skills-manifest.json'), 'utf8'));
+    expect(manifest.entries.map((entry: { path: string }) => entry.path)).toContain(
+      'scripts/hooks/auto-update-runner.mjs',
+    );
+  });
+
   it('says what it cannot check, including the one gate that still lives elsewhere', () => {
     // The entry-point start gate used to be named here too — it is not
     // anymore, because it is wired into `verify:release` (and therefore into

--- a/tests/qa/live-journey.test.ts
+++ b/tests/qa/live-journey.test.ts
@@ -50,6 +50,7 @@ import {
   assertOutsideOwnerMemesh,
   assertTaskOwnedCodexHome,
   assertRecipientUnavailable,
+  assertSessionStartLauncherSucceeded,
   assertSocketPathFits,
   awaitSessionDisconnect,
   buildJourneyEnv,
@@ -932,6 +933,15 @@ describe('ordinary MCP registration boundary', () => {
       .toThrow(/exited before its live registration was verified/);
     expect(() => assertCompanionRunning({ exitCode: null, signalCode: 'SIGTERM' }, 'companion'))
       .toThrow(/exited before its live registration was verified/);
+  });
+
+  it('accepts a cleanly exited SessionStart launcher after discover proves the detached companion', () => {
+    expect(() => assertSessionStartLauncherSucceeded({ exitCode: 0, signalCode: null }, 'launcher')).not.toThrow();
+    expect(() => assertSessionStartLauncherSucceeded({ exitCode: null, signalCode: null }, 'launcher')).not.toThrow();
+    expect(() => assertSessionStartLauncherSucceeded({ exitCode: 1, signalCode: null }, 'launcher'))
+      .toThrow(/failed before its detached companion registered/);
+    expect(() => assertSessionStartLauncherSucceeded({ exitCode: null, signalCode: 'SIGTERM' }, 'launcher'))
+      .toThrow(/failed before its detached companion registered/);
   });
 });
 


### PR DESCRIPTION
## Summary
- harden plugin hook and MCP artifact integrity checks, including .mjs runtimes and symlink rejection (file and directory)
- fail closed before plugin-cache swaps when staged wiring is incomplete
- ship the checker's one dependency (`scripts/lib/npm-bin.mjs`) in the npm package; pin it by unpacking the real tarball and executing the checker
- bound consumer-audit npm usage; strip every case variant of `npm_config_cache` before setting the private cache (Windows: vitest upper-cases worker env keys, Node keeps the first of two case-variant keys)
- prepare all release metadata for v4.9.4

## Verification (candidate df6bada6)
- CI: 13/13 checks pass (run 34386449653; the Packaged Dashboard E2E Smoke needed one re-run after Google's Chrome apt index returned Hash Sum mismatch — infrastructure, not this diff)
- npm run verify:release: PASS; lint, typecheck, check-doc-claims, check-version-coherence: exit 0
- independent whole-diff reviews (different model from the implementer, with Bash): a030f477 FAIL → 9a1c3d5a PASS_WITH_CONCERNS → 090aae58 PASS_WITH_CONCERNS; every blocking finding fixed in the following commit, three mutation checks KILLED
- qa:live-journey --host codex: PASS 13/13 on df6bada6 (real Codex thread quoted message_id and delivery_id back; no commands ran on the proof turn)
- qa:live-journey --host claude: PASS 11/11 on df6bada6 (interactive session's own model called `intake`; receipt actor == registered session id; `/mcp` and `/hooks` inspected before attestation)

## Release exception
Withdrawn. Both real host journeys have been run on this SHA. Post-merge, both journeys will be re-run on the merge commit because `release:finish` requires receipts for the exact HEAD, and a fresh-consumer npm readback remains required after publish.
